### PR TITLE
Fixes setup config error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ dev =
     pytest==5.0.1
     pytest-cov>=2.10.1
     nbsphinx>=0.8.2
-    sphinx-fortran=1.1.1
+    sphinx-fortran==1.1.1
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Current `setup.cfg` results in an error when I run `pip install -e .`. The error ends with:
 
`[...] 
pkg_resources.extern.packaging.requirements.InvalidRequirement: Parse error at "'=1.1.1'": Expected stringEnd`

I think there is a missing `=`, as per `pip`'s convention. 

If other users are encountering this problem, this PR should fix it.