### PR TITLE
Fix to documentation

### DIFF
--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -41,7 +41,7 @@ class Model(SmartSimEntity):
         :param path: path to output, error, and configuration files
         :type path: str
         :param run_settings: launcher settings specified in the experiment
-        :type run_settings: dict
+        :type run_settings: RunSettings
         """
         super().__init__(name, path, run_settings)
         self.params = params

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -294,7 +294,7 @@ class Experiment:
         :param name: name of the model
         :type name: str
         :param run_settings: defines how ``Model`` should be run,
-        :type run_settings: dict
+        :type run_settings: RunSettings
         :param params: model parameters for writing into configuration files
         :type params: dict, optional
         :param path: path to where the model should be executed at runtime


### PR DESCRIPTION
## Description
There were two locations where the `run_settings` parameter for `Experiment.create_model` and  `Model.__init__` was documented as being of type dictionary when it should have been documented as having the type RunSettings. This was due to the documentation not being entirely updated when the concept of RunSettings was introduced in the 0.3.0 release.