### PR TITLE
Remove usage of redis-py-cluster

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 coloredlogs==10.0
-redis>=3.0.1
-redis-py-cluster==2.0.0
+smartredis==0.1.1
 sphinx==3.1.1
 numpy>=1.18.2
 toml>=0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 psutil>=5.7.2
 coloredlogs==10.0
 pandas>=1.1.3
-redis==3.0.1
-redis-py-cluster==2.0.0
+smartredis==0.1.1
 numpy>=1.18.2
 tqdm>=4.50.2
 toml>=0.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,7 @@ install_requires =
     psutil>=5.7.2
     coloredlogs==10.0
     pandas>=1.1.3
-    redis==3.0.1
-    redis-py-cluster==2.0.0
+    smartredis==0.1.1
     numpy>=1.18.2
     tqdm>=4.50.2
     toml>=0.10.1

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -139,8 +139,12 @@ class Orchestrator(EntityList):
         :raises SmartSimError: If cluster status cannot be verified
         """
         # pick a single host and port
-        host = self.hosts[0]
-        port = self.ports[0]
+        try:
+            host = self.hosts[0]
+            port = self.ports[0]
+        except:
+            raise SmartSimError("Hosts and ports are not populated")
+
         address = ":".join((host, str(port)))
         client = Client(address=address, cluster=True)
 
@@ -151,6 +155,7 @@ class Orchestrator(EntityList):
             time.sleep(2)
             try:
                 client.put_tensor("cluster_test", np.array([1, 2, 3, 4]))
+                receive_tensor = client.get_tensor("cluster_test")
                 logger.debug("Cluster status verified")
                 return
             except RedisReplyError:

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -31,8 +31,9 @@ import sys
 import time
 from os import getcwd
 
-from rediscluster import RedisCluster
-from rediscluster.exceptions import ClusterDownError
+import numpy as np
+from smartredis import Client
+from smartredis.error import RedisReplyError
 
 from ..config import CONFIG
 from ..entity import DBNode, EntityList
@@ -132,19 +133,16 @@ class Orchestrator(EntityList):
         self.check_cluster_status()
         logger.info(f"Database cluster created with {str(len(self.hosts))} shards")
 
-    def check_cluster_status(self):  # cov-wlm
+    def check_cluster_status(self):
         """Check that a cluster is up and running
 
         :raises SmartSimError: If cluster status cannot be verified
         """
-        # TODO use smartredis for this, then we don't have to create host dictionary
-        host_list = []
-        for host in self.hosts:
-            for port in self.ports:
-                host_dict = dict()
-                host_dict["host"] = host
-                host_dict["port"] = port
-                host_list.append(host_dict)
+        # pick a single host and port
+        host = self.hosts[0]
+        port = self.ports[0]
+        address = ":".join((host, str(port)))
+        client = Client(address=address, cluster=True)
 
         trials = 10
         logger.debug("Beginning database cluster status check...")
@@ -152,12 +150,10 @@ class Orchestrator(EntityList):
             # wait for cluster to spin up
             time.sleep(2)
             try:
-                redis_tester = RedisCluster(startup_nodes=host_list)
-                redis_tester.set("__test__", "__test__")
-                redis_tester.delete("__test__")
+                client.put_tensor("cluster_test", np.array([1, 2, 3, 4]))
                 logger.debug("Cluster status verified")
                 return
-            except ClusterDownError:
+            except RedisReplyError:
                 logger.debug("Cluster still spinning up...")
                 time.sleep(5)
                 trials -= 1

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -133,7 +133,7 @@ class Orchestrator(EntityList):
         self.check_cluster_status()
         logger.info(f"Database cluster created with {str(len(self.hosts))} shards")
 
-    def check_cluster_status(self):
+    def check_cluster_status(self):  # cov-wlm
         """Check that a cluster is up and running
 
         :raises SmartSimError: If cluster status cannot be verified

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -138,12 +138,12 @@ class Orchestrator(EntityList):
 
         :raises SmartSimError: If cluster status cannot be verified
         """
-        # pick a single host and port
         try:
+            # SmartRedis needs only one cluster host/port to connect
             host = self.hosts[0]
             port = self.ports[0]
-        except:
-            raise SmartSimError("Hosts and ports are not populated")
+        except SmartSimError as e:
+            raise SmartSimError("Database is not active") from e
 
         address = ":".join((host, str(port)))
         client = Client(address=address, cluster=True)


### PR DESCRIPTION
Remove usage of redis-py-cluster

The orchestrator utilized a third-party library called redis-py-cluster to check the cluster status after initialization

this has been replaced with SmartRedis such that the check_cluster_status function now utilizes the SmartRedis client