### PR TITLE
Edit Makefile and test fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,15 +98,23 @@ docs:
 # help: test                           - Build and run all tests
 .PHONY: test
 test:
-	@cd ./tests/; python -m pytest
+	@cd ./tests/; python -m pytest --ignore=full_wlm/
 
 # help: test-verbose                   - Build and run all tests [verbosely]
 .PHONY: test-verbose
 test-verbose:
-	@cd ./tests/; python -m pytest -vv
+	@cd ./tests/; python -m pytest -vv --ignore=full_wlm/
 
 # help: test-cov                       - run python tests with coverage
 .PHONY: test-cov
 test-cov:
+	@cd ./tests/; python -m pytest --cov=../smartsim -vv --cov-config=${COV_FILE} --ignore=full_wlm/
+
+
+# help: test-full                      - run all WLM tests with Python coverage (full test suite)
+# help:                                  WARNING: do not run test-full on shared systems.
+.PHONY: test-full
+test-full:
 	@cd ./tests/; python -m pytest --cov=../smartsim -vv --cov-config=${COV_FILE}
+
 

--- a/tests/test_dbnode.py
+++ b/tests/test_dbnode.py
@@ -18,9 +18,8 @@ def test_hosts(fileutils):
     exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir(exp_name)
 
-    orc = Orchestrator()
+    orc = Orchestrator(port=6888)
     orc.set_path(test_dir)
-    exp.generate(orc)
     exp.start(orc)
 
     thrown = False


### PR DESCRIPTION
Small edits to tests introduced in PR #53 that left some testing files around.

Also introduces a new testing flag in the makefile for users who want to run the test suite on interactive allocations without the ``full_wlm`` tests which assume full control over the host machine.

