### PR TITLE
get_address() function in Orchestrator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,15 +98,23 @@ docs:
 # help: test                           - Build and run all tests
 .PHONY: test
 test:
-	@cd ./tests/; python -m pytest
+	@cd ./tests/; python -m pytest --ignore=full_wlm/
 
 # help: test-verbose                   - Build and run all tests [verbosely]
 .PHONY: test-verbose
 test-verbose:
-	@cd ./tests/; python -m pytest -vv
+	@cd ./tests/; python -m pytest -vv --ignore=full_wlm/
 
 # help: test-cov                       - run python tests with coverage
 .PHONY: test-cov
 test-cov:
+	@cd ./tests/; python -m pytest --cov=../smartsim -vv --cov-config=${COV_FILE} --ignore=full_wlm/
+
+
+# help: test-full                      - run all WLM tests with Python coverage (full test suite)
+# help:                                  WARNING: do not run test-full on shared systems.
+.PHONY: test-full
+test-full:
 	@cd ./tests/; python -m pytest --cov=../smartsim -vv --cov-config=${COV_FILE}
+
 

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -165,6 +165,19 @@ class Orchestrator(EntityList):
         if trials == 0:
             raise SmartSimError("Cluster setup could not be verified")
 
+    def get_address(self):
+        """Return database addresses
+
+        :return: addresses
+        :rtype: list[str]
+        """
+        if not self._hosts:
+            raise SmartSimError()
+        addresses = []
+        for host, port in itertools.product(self._hosts, self.ports):
+            addresses.append(":".join((host, port)))
+        return addresses
+
     def _get_AI_module(self):
         """Get the RedisAI module from third-party installations
 

--- a/tests/test_dbnode.py
+++ b/tests/test_dbnode.py
@@ -18,9 +18,8 @@ def test_hosts(fileutils):
     exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir(exp_name)
 
-    orc = Orchestrator()
+    orc = Orchestrator(port=6888)
     orc.set_path(test_dir)
-    exp.generate(orc)
     exp.start(orc)
 
     thrown = False


### PR DESCRIPTION
Added a function to the Orchestrator related to PR #54.

Previously, the Orchestrator's address was a hidden property.

Now `get_address()` in `orchestrator.py` returns the hosts and 
ports in a formatted manner--a list of strings (`"host:port"`)--that 
is accessible to the user.