### PR TITLE
Fix orchestrator bugs introduced in 98341ca

### DIFF
--- a/.github/workflows/run_local_tests.yml
+++ b/.github/workflows/run_local_tests.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Run Pytest
         run: |
           echo "SMARTSIM_LOG_LEVEL=debug" >> $GITHUB_ENV
-          py.test --import-mode=importlib -o log_cli=true
+          py.test -s --import-mode=importlib -o log_cli=true

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,11 @@ check-lint:
 docs:
 	@cd doc; make html
 
+# help: cov                            - generate html coverage report for Python client
+.PHONY: cov
+cov:
+		@cd ./tests/ && coverage html
+		@echo if data was present, coverage report is in ./tests/htmlcov/index.html
 
 # help:
 # help: Test

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -24,12 +24,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import time
-import socket
 import itertools
-import numpy as np
+import socket
+import time
 from os import getcwd
 
+import numpy as np
 from smartredis import Client
 from smartredis.error import RedisConnectionError, RedisReplyError
 

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -191,8 +191,8 @@ class Orchestrator(EntityList):
         host = self._hosts[0]
         port = self.ports[0]
         address = ":".join((host, str(port)))
-        client = Client(address=address, cluster=False)
         try:
+            client = Client(address=address, cluster=False)
             client.put_tensor("db_test", np.array([1, 2, 3, 4]))
             receive_tensor = client.get_tensor("db_test")
             return True

--- a/tests/test_configs/smartredis/consumer.py
+++ b/tests/test_configs/smartredis/consumer.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 import torch
 import torch.nn as nn
-
 from smartredis import Client
 
 if __name__ == "__main__":

--- a/tests/test_configs/smartredis/producer.py
+++ b/tests/test_configs/smartredis/producer.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 import torch
 import torch.nn as nn
-
 from smartredis import Client
 
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -82,11 +82,11 @@ def test_random():
         params,
         run_settings=rs,
         perm_strat="random",
-        n_models=len(random_ints)-1,
+        n_models=len(random_ints) - 1,
     )
-    assert len(ensemble) == len(random_ints)-1
+    assert len(ensemble) == len(random_ints) - 1
     assigned_params = [m.params["h"] for m in ensemble.entities]
-    assert all([x in random_ints for x in assigned_params])    
+    assert all([x in random_ints for x in assigned_params])
 
 
 def test_user_strategy():

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,16 +1,20 @@
 import pytest
+
 from smartsim import Experiment
 from smartsim.database import Orchestrator
 from smartsim.error import SmartSimError
+
 
 def test_orc_parameters():
     threads_per_queue = 2
     inter_op_threads = 2
     intra_op_threads = 2
-    db = Orchestrator(db_nodes=1,
-                      threads_per_queue=threads_per_queue,
-                      inter_op_threads=inter_op_threads,
-                      intra_op_threads=intra_op_threads)
+    db = Orchestrator(
+        db_nodes=1,
+        threads_per_queue=threads_per_queue,
+        inter_op_threads=inter_op_threads,
+        intra_op_threads=intra_op_threads,
+    )
     assert db.queue_threads == threads_per_queue
     assert db.inter_threads == inter_op_threads
     assert db.intra_threads == intra_op_threads
@@ -30,6 +34,7 @@ def test_inactive_orc_get_address():
     db = Orchestrator()
     with pytest.raises(SmartSimError):
         db.get_address()
+
 
 def test_orc_active_functions(fileutils):
     exp_name = "test_orc_active_functions"
@@ -65,8 +70,3 @@ def test_catch_local_db_errors():
     # MPMD local orchestrator not allowed
     with pytest.raises(SmartSimError):
         db = Orchestrator(dpn=2)
-
-
-
-
-

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,72 @@
+import pytest
+from smartsim import Experiment
+from smartsim.database import Orchestrator
+from smartsim.error import SmartSimError
+
+def test_orc_parameters():
+    threads_per_queue = 2
+    inter_op_threads = 2
+    intra_op_threads = 2
+    db = Orchestrator(db_nodes=1,
+                      threads_per_queue=threads_per_queue,
+                      inter_op_threads=inter_op_threads,
+                      intra_op_threads=intra_op_threads)
+    assert db.queue_threads == threads_per_queue
+    assert db.inter_threads == inter_op_threads
+    assert db.intra_threads == intra_op_threads
+
+    module_str = db._get_AI_module()
+    assert "THREADS_PER_QUEUE" in module_str
+    assert "INTRA_OP_THREADS" in module_str
+    assert "INTER_OP_THREADS" in module_str
+
+
+def test_is_not_active():
+    db = Orchestrator(db_nodes=1)
+    assert not db.is_active()
+
+
+def test_inactive_orc_get_address():
+    db = Orchestrator()
+    with pytest.raises(SmartSimError):
+        db.get_address()
+
+def test_orc_active_functions(fileutils):
+    exp_name = "test_orc_active_functions"
+    exp = Experiment(exp_name, launcher="local")
+    test_dir = fileutils.make_test_dir(exp_name)
+
+    db = Orchestrator(port=6780)
+    db.set_path(test_dir)
+
+    exp.start(db)
+
+    # check if the orchestrator is active
+    assert db.is_active()
+
+    # check if the orchestrator can get the address
+    assert db.get_address() == ["127.0.0.1:6780"]
+
+    exp.stop(db)
+
+    assert not db.is_active()
+
+    # check if orchestrator.get_addree() raises an exception
+    with pytest.raises(SmartSimError):
+        db.get_address()
+
+
+def test_catch_local_db_errors():
+
+    # local database with more than one node not allowed
+    with pytest.raises(SmartSimError):
+        db = Orchestrator(db_nodes=2)
+
+    # MPMD local orchestrator not allowed
+    with pytest.raises(SmartSimError):
+        db = Orchestrator(dpn=2)
+
+
+
+
+

--- a/tests/with_smartredis/test_smartredis.py
+++ b/tests/with_smartredis/test_smartredis.py
@@ -22,9 +22,8 @@ REDIS_PORT = 6780
 
 
 try:
-    import torch
-
     import smartredis
+    import torch
 except ImportError:
     pass
 


### PR DESCRIPTION
There were two problems with the ``get_address`` and ``is_active`` implmentations

1. itertools was not imported
2. ports are integers and hence cause the string formation to fail.

New tests were added that increase ``Orchestrator`` coverage to 99%. 

This was my fault for not catching this in review. 