### PR TITLE
Add condition to redis IP sleep

### DIFF
--- a/smartsim/entity/dbnode.py
+++ b/smartsim/entity/dbnode.py
@@ -160,7 +160,8 @@ class DBNode(SmartSimEntity):
                 time.sleep(5)
             logger.debug("Waiting for RedisIP files to populate...")
             trials -= 1
-            time.sleep(5)
+            if not host:
+                time.sleep(5)
 
         if not host and not ip:
             logger.error("RedisIP address lookup strategy failed.")
@@ -220,7 +221,8 @@ class DBNode(SmartSimEntity):
                     time.sleep(5)
                 logger.debug("Waiting for RedisIP files to populate...")
                 trials -= 1
-                time.sleep(5)
+                if not host:
+                    time.sleep(5)
 
             if not host and not ip:
                 logger.error("RedisIP address lookup strategy failed.")


### PR DESCRIPTION
When we parse RedisIP info, we always sleep 5 seconds, even if we found the host. This means that if we have N nodes, we wait for N*5 seconds, but most likely, all nodes will have written their info when we parse it for one. This quick fix removes the sleep operation when we find host (but leaves it otherwise).