### PR TITLE
Add new FindTensorFlow.cmake

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -149,7 +149,7 @@ class WLMUtils:
         elif test_launcher == "cobalt":
             db = CobaltOrchestrator(db_nodes=nodes, port=port, batch=batch, interface=test_nic)
         elif test_launcher == "lsf":
-            db = LSFOrchestrator(db_nodes=nodes, port=port, batch=batch, project=get_account(), interface=test_nic)
+            db = LSFOrchestrator(db_nodes=nodes, port=port, batch=batch, gpus_per_shard=1 if test_device=="GPU" else 0, project=get_account(), interface=test_nic)
         else:
             db = Orchestrator(port=port, interface="lo")
         return db

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -446,8 +446,10 @@ to get a working SmartSim build with PyTorch for GPU on Summit.
   pushd smartsim
   pip install .
 
+  export Torch_DIR=/ccs/home/<USERNAME>/.conda/envs/smartsim/lib/python3.8/site-packages/torch/share/cmake/Torch/
+  export CFLAGS="$CFLAGS -I/ccs/home/<USERNAME>/.conda/envs/smarter/lib/python3.8/site-packages/tensorflow/include"
   # install PyTorch backend for the Orchestrator database.
-  smart --device=gpu --torch_dir /ccs/home/arigazzi/.conda/envs/smartsim/lib/python3.8/site-packages/torch/share/cmake/Torch/ -v
+  smart --device=gpu --torch_dir $Torch_DIR -v
 
 
 

--- a/doc/orchestrator.rst
+++ b/doc/orchestrator.rst
@@ -26,7 +26,7 @@ SmartSim supports.
  - :ref:`SlurmOrchestrator <slurm_orc_api>` for Slurm managed systems
  - :ref:`CobaltOrchestrator <cobalt_orc_api>` for Cobalt managed systems
  - :ref:`PBSOrchestrator <pbs_orc_api>` for PBSPro managed systems.
- - :ref:`LSFOrchestrator <_lsf_orc_api>` for LSF managed systems.
+ - :ref:`LSFOrchestrator <lsf_orc_api>` for LSF managed systems.
 
 The base ``Orchestrator`` class can be used for launching Redis
 locally on single node workstations or laptops.

--- a/modules/FindTensorFlow.cmake
+++ b/modules/FindTensorFlow.cmake
@@ -1,0 +1,359 @@
+# Patrick Wieschollek, <mail@patwie.com>
+# FindTensorFlow.cmake
+# https://github.com/PatWie/tensorflow-cmake/blob/master/cmake/modules/FindTensorFlow.cmake
+# -------------
+#
+# Find TensorFlow library and includes
+#
+# Automatically set variables have prefix "TensorFlow_",
+# while environmental variables you can specify have prefix "TENSORFLOW_"
+# This module will set the following variables in your project:
+#
+# ``TensorFlow_VERSION``
+#   exact TensorFlow version obtained from runtime
+# ``TensorFlow_ABI``
+#   ABI specification of TensorFlow library obtained from runtime
+# ``TensorFlow_INCLUDE_DIR``
+#   where to find tensorflow header files obtained from runtime
+# ``TensorFlow_LIBRARY``
+#   the libraries to link against to use TENSORFLOW obtained from runtime
+# ``TensorFlow_FOUND TRUE``
+#   If false, do not try to use TENSORFLOW.
+# ``TensorFlow_C_LIBRARY``
+#   Path to tensorflow_cc library (libtensorflow[.so,.dylib,.dll], or similar)
+#
+#  for some examples, you will need to specify on of the following cmake variables:
+# ``TensorFlow_BUILD_DIR`` Is the directory containing the tensorflow_cc library, which can be initialized
+#  with env-var 'TENSORFLOW_BUILD_DIR' environmental variable
+# ``TensorFlow_SOURCE_DIR`` Is the path to source of TensorFlow, which can be initialized
+#  with env-var 'TENSORFLOW_SOURCE_DIR' environmental variable
+#
+#
+# USAGE
+# ------
+# add "list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}../../path/to/this/file)" to your project
+#
+# "add_tensorflow_gpu_operation" is a macro to compile a custom operation
+#
+# add_tensorflow_gpu_operation("<op-name>") expects the following files to exists:
+#   - kernels/<op-name>_kernel.cc
+#   - kernels/<op-name>_kernel_gpu.cu.cc (kernels/<op-name>_kernel.cu is supported as well)
+#   - kernels/<op-name>_op.cc
+#   - kernels/<op-name>_op.h
+#   - ops/<op-name>.cc
+
+if(APPLE)
+  message(WARNING "This FindTensorflow.cmake is not tested on APPLE\n"
+                  "Please report if this works\n"
+                  "https://github.com/PatWie/tensorflow-cmake")
+endif()
+
+if(WIN32)
+  message(WARNING "This FindTensorflow.cmake is not tested on WIN32\n"
+                  "Please report if this works\n"
+                  "https://github.com/PatWie/tensorflow-cmake")
+endif()
+
+set(PYTHON_EXECUTABLE "python3" CACHE STRING "specify the python version TensorFlow is installed on.")
+
+if(TensorFlow_FOUND AND EXISTS "${TensorFlow_LIBRARY}" AND IS_DIRECTORY "${TensorFlow_INCLUDE_DIR}")
+  # reuse cached variables
+  message(STATUS "Reuse cached information from TensorFlow ${TensorFlow_VERSION} ")
+else()
+  message(STATUS "Detecting TensorFlow using ${PYTHON_EXECUTABLE}"
+          " (use -DPYTHON_EXECUTABLE=... otherwise)")
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} -c "import tensorflow as tf; print(tf.__version__); print(tf.__cxx11_abi_flag__); print(tf.sysconfig.get_include()); print(tf.sysconfig.get_lib());"
+    OUTPUT_VARIABLE TF_INFORMATION_STRING
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE retcode)
+
+  if(NOT "${retcode}" STREQUAL "0")
+    message(FATAL_ERROR "Detecting TensorFlow info - failed  \n Did you installed TensorFlow?")
+  else()
+    message(STATUS "Detecting TensorFlow info - done")
+  endif()
+
+  string(REPLACE "\n" ";" TF_INFORMATION_LIST ${TF_INFORMATION_STRING})
+  list(GET TF_INFORMATION_LIST 0 TF_DETECTED_VERSION)
+  list(GET TF_INFORMATION_LIST 1 TF_DETECTED_ABI)
+  list(GET TF_INFORMATION_LIST 2 TF_DETECTED_INCLUDE_DIR)
+  list(GET TF_INFORMATION_LIST 3 TF_DETECTED_LIBRARY_PATH)
+
+  # set(TF_DETECTED_VERSION 1.8)
+
+  set(_packageName "TF")
+  if (DEFINED TF_DETECTED_VERSION)
+      string (REGEX MATCHALL "[0-9]+" _versionComponents "${TF_DETECTED_VERSION}")
+      list (LENGTH _versionComponents _len)
+      if (${_len} GREATER 0)
+          list(GET _versionComponents 0 TF_DETECTED_VERSION_MAJOR)
+      endif()
+      if (${_len} GREATER 1)
+          list(GET _versionComponents 1 TF_DETECTED_VERSION_MINOR)
+      endif()
+      if (${_len} GREATER 2)
+          list(GET _versionComponents 2 TF_DETECTED_VERSION_PATCH)
+      endif()
+      if (${_len} GREATER 3)
+          list(GET _versionComponents 3 TF_DETECTED_VERSION_TWEAK)
+      endif()
+      set (TF_DETECTED_VERSION_COUNT ${_len})
+  else()
+      set (TF_DETECTED_VERSION_COUNT 0)
+  endif()
+
+
+  # -- prevent pre 1.9 versions
+  # Note: TensorFlow 1.7 supported custom ops and all header files.
+  # TensorFlow 1.8 broke that promise and 1.9, 1.10 are fine again.
+  # This cmake-file is only tested against 1.9+.
+  if("${TF_DETECTED_VERSION}" VERSION_LESS "1.9")
+    message(FATAL_ERROR "Your installed TensorFlow version ${TF_DETECTED_VERSION} is too old.")
+  endif()
+
+  if(TF_FIND_VERSION_EXACT)
+    # User requested exact match of TensorFlow.
+    # TensorFlow release cycles are currently just depending on (major, minor)
+    # But we test against both.
+    set(_TensorFlow_TEST_VERSIONS
+        "${TF_FIND_VERSION_MAJOR}.${TF_FIND_VERSION_MINOR}.${TF_FIND_VERSION_PATCH}"
+        "${TF_FIND_VERSION_MAJOR}.${TF_FIND_VERSION_MINOR}")
+  else() # TF_FIND_VERSION_EXACT
+    # User requested not an exact TensorFlow version.
+    # However, only TensorFlow versions 1.9, 1.10 support all header files
+    # for custom ops.
+    set(_TensorFlow_KNOWN_VERSIONS ${TensorFlow_ADDITIONAL_VERSIONS}
+        "1.9" "1.9.0" "1.10" "1.10.0" "1.11" "1.11.0" "1.12" "1.12.0" "1.13" "1.13.1" "1.14" "2.4" )
+    set(_TensorFlow_TEST_VERSIONS)
+
+    if(TF_FIND_VERSION)
+        set(_TF_FIND_VERSION_SHORT "${TF_FIND_VERSION_MAJOR}.${TF_FIND_VERSION_MINOR}")
+        # Select acceptable versions.
+        foreach(version ${_TensorFlow_KNOWN_VERSIONS})
+          if(NOT "${version}" VERSION_LESS "${TF_FIND_VERSION}")
+            # This version is high enough.
+            list(APPEND _TensorFlow_TEST_VERSIONS "${version}")
+          endif()
+        endforeach()
+      else() # TF_FIND_VERSION
+        # Any version is acceptable.
+        set(_TensorFlow_TEST_VERSIONS "${_TensorFlow_KNOWN_VERSIONS}")
+      endif()
+  endif()
+
+  #### ---- Configure TensorFlow_SOURCE_DIR
+  # Order of precidence is 1) CMake variable value, 2) Environmental Variable value
+  if(IS_DIRECTORY "${TensorFlow_SOURCE_DIR}")
+    set(TensorFlow_SOURCE_DIR "${TensorFlow_SOURCE_DIR}" CACHE PATH "directory containing the file 'libtensorflow_cc${CMAKE_SHARED_LIBRARY_SUFFIX}'")
+  else()
+    if(IS_DIRECTORY "$ENV{TENSORFLOW_SOURCE_DIR}")
+      set(TensorFlow_SOURCE_DIR "$ENV{TENSORFLOW_SOURCE_DIR}" CACHE PATH "source code for tensorflow (i.e. the git checkout directory of the source code)")
+    else()
+      set(TensorFlow_SOURCE_DIR "TensorFlow_SOURCE_DIR-NOTFOUND" CACHE PATH "source code for tensorflow (i.e. the git checkout directory of the source code)")
+    endif()
+  endif()
+
+  # Report on status of cmake cache variable for TensorFlow_SOURCE_DIR
+  if(IS_DIRECTORY ${TensorFlow_SOURCE_DIR})
+    message(STATUS "TensorFlow_SOURCE_DIR is ${TensorFlow_SOURCE_DIR}")
+  else()
+    # NOTE This is not a fatal error for backward compatibility ("custom_op test")
+    message(STATUS "No directory at 'TensorFlow_SOURCE_DIR:PATH=${TensorFlow_SOURCE_DIR}' detected,\n"
+      "please specify the path in ENV 'export TENSORFLOW_SOURCE_DIR=...'\n or cmake -DTensorFlow_SOURCE_DIR:PATH=...\n"
+      "to the directory containing the source code for tensorflow\n (i.e. the git checkout directory of the source code)"
+      )
+  endif()
+
+  #### ---- Configure TensorFlow_BUILD_DIR
+  # Order of precidence is 1) CMake variable value, 2) Environmental Variable value
+  if(IS_DIRECTORY "${TensorFlow_BUILD_DIR}")
+    set(TensorFlow_BUILD_DIR "${TensorFlow_BUILD_DIR}" CACHE PATH "directory containing the file 'libtensorflow_cc${CMAKE_SHARED_LIBRARY_SUFFIX}'")
+  else()
+    if(IS_DIRECTORY "$ENV{TENSORFLOW_BUILD_DIR}")
+      set(TensorFlow_BUILD_DIR "$ENV{TENSORFLOW_BUILD_DIR}" CACHE PATH "directory containing the file 'libtensorflow_cc${CMAKE_SHARED_LIBRARY_SUFFIX}'")
+    else()
+      set(TensorFlow_BUILD_DIR "TensorFlow_BUILD_DIR-NOTFOUND" CACHE PATH "directory containing the file 'libtensorflow_cc${CMAKE_SHARED_LIBRARY_SUFFIX}'")
+    endif()
+  endif()
+
+  # Report on status of cmake cache variable for TensorFlow_BUILD_DIR
+  if(IS_DIRECTORY ${TensorFlow_BUILD_DIR})
+    message(STATUS "TensorFlow_BUILD_DIR is ${TensorFlow_BUILD_DIR}")
+  else()
+    # NOTE This is not a fatal error for backward compatibility ("custom_op test")
+    message(STATUS "No directory at 'TensorFlow_BUILD_DIR:PATH=${TensorFlow_BUILD_DIR}' detected,\n"
+      "please specify the path in ENV 'export TENSORFLOW_BUILD_DIR=...'\n or cmake -DTensorFlow_BUILD_DIR:PATH=...\n"
+      "to the directory containing the file 'libtensorflow_cc${CMAKE_SHARED_LIBRARY_SUFFIX}'"
+      )
+  endif()
+
+  if(IS_DIRECTORY ${TensorFlow_BUILD_DIR})
+    file(GLOB_RECURSE TF_LIBRARY_SEARCH_PATHS
+      LIST_DIRECTORIES FALSE
+      "${TensorFlow_BUILD_DIR}/*libtensorflow_cc${CMAKE_SHARED_LIBRARY_SUFFIX}"
+      )
+    list(LENGTH TF_LIBRARY_SEARCH_PATHS TF_LIBRARY_SEARCH_PATHS_LENGTH)
+    if( NOT ${TF_LIBRARY_SEARCH_PATHS_LENGTH} EQUAL 1 )
+      message(FATAL_ERROR "Incorrect number of items matching 'libtensorflow_cc${CMAKE_SHARED_LIBRARY_SUFFIX}' in '${TF_LIBRARY_SEARCH_PATHS}'\n"
+        "( ${TF_LIBRARY_SEARCH_PATHS_LENGTH} != 1 ).\n"
+        "Change 'TensorFlow_BUILD_DIR' to have more specific path."
+      )
+    endif()
+    list(GET TF_LIBRARY_SEARCH_PATHS 0 TF_LIBRARY_SEARCH_ONEPATH)
+    get_filename_component(TensorFlow_C_LIBRARY_DIR "${TF_LIBRARY_SEARCH_ONEPATH}" DIRECTORY )
+
+    if( IS_DIRECTORY "${TensorFlow_C_LIBRARY_DIR}")
+      find_library(TensorFlow_C_LIBRARY
+        NAMES tensorflow_cc
+        PATHS "${TensorFlow_C_LIBRARY_DIR}"
+        DOC "TensorFlow CC library." )
+    endif()
+    if( TensorFlow_C_LIBRARY )
+      message(STATUS "TensorFlow-CC-LIBRARY is ${TensorFlow_C_LIBRARY}")
+    else()
+      # NOTE This is not a fatal error for backward compatibility ("custom_op test")
+      message(STATUS "No TensorFlow-CC-LIBRARY detected")
+    endif()
+  endif()
+
+  find_library( TF_DETECTED_LIBRARY
+      NAMES tensorflow
+      PATHS "${TensorFlow_C_LIBRARY_DIR}" # Prefer the library from the build tree, if TensorFlow_C_LIBRARY is detected.
+            "${TF_DETECTED_LIBRARY_PATH}" # use copy of file from the python install tree (This often has a .so.1 extension only for installed version)
+      DOC "The tensorflow_framework library path."
+  )
+  if( TF_DETECTED_LIBRARY )
+    message(STATUS "Found: ${TF_DETECTED_LIBRARY}")
+  else()
+    message(FATAL_ERROR "Required library for tensorflow_framework not found in ${TF_DETECTED_LIBRARY_PATH}!")
+  endif()
+
+  # test all given versions
+  set(TensorFlow_FOUND FALSE)
+  foreach(_TensorFlow_VER ${_TensorFlow_TEST_VERSIONS})
+    if("${TF_DETECTED_VERSION_MAJOR}.${TF_DETECTED_VERSION_MINOR}" STREQUAL "${_TensorFlow_VER}")
+      # found appropriate version
+      set(TensorFlow_VERSION ${TF_DETECTED_VERSION})
+      set(TensorFlow_ABI ${TF_DETECTED_ABI})
+      set(TensorFlow_INCLUDE_DIR ${TF_DETECTED_INCLUDE_DIR})
+      set(TensorFlow_LIBRARY ${TF_DETECTED_LIBRARY})
+      set(TensorFlow_FOUND TRUE)
+      message(STATUS "Found TensorFlow: (found appropriate version \"${TensorFlow_VERSION}\")")
+      message(STATUS "TensorFlow-ABI is ${TensorFlow_ABI}")
+      message(STATUS "TensorFlow-INCLUDE_DIR is ${TensorFlow_INCLUDE_DIR}")
+      message(STATUS "TensorFlow-LIBRARY is ${TensorFlow_LIBRARY}")
+
+      add_definitions("-DTENSORFLOW_ABI=${TensorFlow_ABI}")
+      add_definitions("-DTENSORFLOW_VERSION=${TensorFlow_VERSION}")
+      break()
+    endif()
+  endforeach()
+
+  if(NOT TensorFlow_FOUND)
+  message(FATAL_ERROR "Your installed TensorFlow version ${TF_DETECTED_VERSION_MAJOR}.${TF_DETECTED_VERSION_MINOR} is not supported\n"
+                      "We tested against ${_TensorFlow_TEST_VERSIONS}")
+  endif()
+
+  # test 1.11 version
+  if("${TF_DETECTED_VERSION}" VERSION_EQUAL "1.11")
+    set(TF_DISABLE_ASSERTS "TRUE")
+  endif()
+
+  if("${TF_DETECTED_VERSION}" VERSION_EQUAL "1.12")
+    set(TF_DISABLE_ASSERTS "TRUE")
+  endif()
+
+  if("${TF_DETECTED_VERSION}" VERSION_EQUAL "1.12.0")
+    set(TF_DISABLE_ASSERTS "TRUE")
+  endif()
+
+  if("${TF_DETECTED_VERSION}" VERSION_EQUAL "1.13")
+    set(TF_DISABLE_ASSERTS "TRUE")
+  endif()
+
+  if("${TF_DETECTED_VERSION}" VERSION_EQUAL "1.13.1")
+    set(TF_DISABLE_ASSERTS "TRUE")
+  endif()
+
+endif() #-- End detection 
+
+if(${TF_DISABLE_ASSERTS})
+  message(STATUS "[WARNING] The TensorFlow version ${TF_DETECTED_VERSION} has a bug (see \#22766). We disable asserts using -DNDEBUG=True ")
+  add_definitions("-DNDEBUG=True")
+endif()
+macro(TensorFlow_REQUIRE_C_LIBRARY)
+  if(NOT EXISTS "${TensorFlow_C_LIBRARY}")
+    message(FATAL_ERROR "Project requires libtensorflow_cc${CMAKE_SHARED_LIBRARY_SUFFIX}, please specify the path in ENV 'export TENSORFLOW_BUILD_DIR=...' or cmake -DTensorFlow_BUILD_DIR:PATH=...")
+  endif()
+endmacro()
+
+macro(TensorFlow_REQUIRE_SOURCE)
+  if(NOT IS_DIRECTORY "${TensorFlow_SOURCE_DIR}")
+    message(FATAL_ERROR "Project requires TensorFlow source directory, please specify the path in ENV 'export TENSORFLOW_SOURCE_DIR=...' or cmake -DTensorFlow_SOURCE_DIR:PATH=...")
+  endif()
+endmacro()
+
+macro(add_tensorflow_cpu_operation op_name)
+  # Compiles a CPU-only operation without invoking NVCC
+  message(STATUS "will build custom TensorFlow operation \"${op_name}\" (CPU only)")
+
+  add_library(${op_name}_op SHARED kernels/${op_name}_op.cc kernels/${op_name}_kernel.cc ops/${op_name}.cc )
+
+  set_target_properties(${op_name}_op PROPERTIES PREFIX "")
+  target_link_libraries(${op_name}_op LINK_PUBLIC ${TensorFlow_LIBRARY})
+endmacro()
+
+
+macro(add_tensorflow_gpu_operation op_name)
+# Compiles a CPU + GPU operation with invoking NVCC
+  message(STATUS "will build custom TensorFlow operation \"${op_name}\" (CPU+GPU)")
+
+  set(kernel_file "")
+  if(EXISTS "kernels/${op_name}_kernel.cu")
+     message(WARNING "you should rename your file ${op_name}_kernel.cu to ${op_name}_kernel_gpu.cu.cc")
+     set(kernel_file kernels/${op_name}_kernel.cu)
+  else()
+    set_source_files_properties(kernels/${op_name}_kernel_gpu.cu.cc PROPERTIES CUDA_SOURCE_PROPERTY_FORMAT OBJ)
+     set(kernel_file kernels/${op_name}_kernel_gpu.cu.cc)
+  endif()
+
+  cuda_add_library(${op_name}_op_cu SHARED ${kernel_file})
+  set_target_properties(${op_name}_op_cu PROPERTIES PREFIX "")
+
+  add_library(${op_name}_op SHARED kernels/${op_name}_op.cc kernels/${op_name}_kernel.cc ops/${op_name}.cc )
+
+  set_target_properties(${op_name}_op PROPERTIES PREFIX "")
+  set_target_properties(${op_name}_op PROPERTIES COMPILE_FLAGS "-DGOOGLE_CUDA")
+  target_link_libraries(${op_name}_op LINK_PUBLIC ${op_name}_op_cu ${TensorFlow_LIBRARY})
+endmacro()
+
+# simplify TensorFlow dependencies
+add_library(TensorFlow_DEP INTERFACE)
+target_include_directories(TensorFlow_DEP SYSTEM INTERFACE ${TensorFlow_SOURCE_DIR})
+target_include_directories(TensorFlow_DEP SYSTEM INTERFACE ${TensorFlow_INCLUDE_DIR})
+target_link_libraries(TensorFlow_DEP INTERFACE -Wl,--allow-multiple-definition -Wl,--whole-archive ${TensorFlow_C_LIBRARY} -Wl,--no-whole-archive)
+target_link_libraries(TensorFlow_DEP INTERFACE -Wl,--allow-multiple-definition -Wl,--whole-archive ${TensorFlow_LIBRARY} -Wl,--no-whole-archive)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  TENSORFLOW
+  FOUND_VAR TENSORFLOW_FOUND
+  REQUIRED_VARS
+    TensorFlow_LIBRARY
+    TensorFlow_INCLUDE_DIR
+  VERSION_VAR
+    TensorFlow_VERSION
+  )
+
+mark_as_advanced(TF_INFORMATION_STRING TF_DETECTED_VERSION TF_DETECTED_VERSION_MAJOR TF_DETECTED_VERSION_MINOR TF_DETECTED_VERSION TF_DETECTED_ABI
+                 TF_DETECTED_INCLUDE_DIR TF_DETECTED_LIBRARY TF_DISABLE_ASSERTS
+                 TensorFlow_C_LIBRARY TensorFlow_LIBRARY TensorFlow_SOURCE_DIR TensorFlow_INCLUDE_DIR TensorFlow_ABI)
+
+set(TensorFlow_INCLUDE_DIR "${TensorFlow_INCLUDE_DIR}" CACHE PATH "The path to tensorflow header files")
+set(TensorFlow_VERSION "${TensorFlow_VERSION}" CACHE INTERNAL "The Tensorflow version")
+set(TensorFlow_ABI "${TensorFlow_ABI}" CACHE STRING "The ABI version used by TensorFlow")
+set(TensorFlow_LIBRARY "${TensorFlow_LIBRARY}" CACHE FILEPATH "The C++ library of TensorFlow")
+set(TensorFlow_C_LIBRARY "${TensorFlow_C_LIBRARY}" CACHE STRING "The C library of TensorFlow")
+set(TensorFlow_FOUND "${TensorFlow_FOUND}" CACHE BOOL "A flag stating if TensorFlow has been found")
+set(TF_DISABLE_ASSERTS "${TF_DISABLE_ASSERTS}" CACHE BOOL "A flag to enable workarounds")

--- a/smartsim/bin/scripts/build-redisai-cpu.sh
+++ b/smartsim/bin/scripts/build-redisai-cpu.sh
@@ -20,6 +20,7 @@ if [[ -f "$DIR/../../lib/redisai.so" ]]; then
 else
     if [[ ! -d "$DIR/../../.third-party/RedisAI" ]]; then
         GIT_LFS_SKIP_SMUDGE=1 git clone --recursive https://github.com/RedisAI/RedisAI.git --branch v1.2.3 --depth=1 $DIR/../../.third-party/RedisAI
+	    cp $DIR/../../../modules/FindTensorFlow.cmake $DIR/../../.third-party/RedisAI/opt/cmake/modules/ 
         echo "RedisAI downloaded"
     fi
     echo "Downloading RedisAI CPU ML Runtimes"

--- a/smartsim/bin/scripts/build-redisai-gpu.sh
+++ b/smartsim/bin/scripts/build-redisai-gpu.sh
@@ -30,7 +30,8 @@ else
     fi
 
     if [[ ! -d "$DIR/../../.third-party/RedisAI" ]]; then
-         GIT_LFS_SKIP_SMUDGE=1 git clone --recursive https://github.com/RedisAI/RedisAI.git --branch v1.2.3 --depth=1 $DIR/../../.third-party/RedisAI
+        GIT_LFS_SKIP_SMUDGE=1 git clone --recursive https://github.com/RedisAI/RedisAI.git --branch v1.2.3 --depth=1 $DIR/../../.third-party/RedisAI
+	    cp $DIR/../../../modules/FindTensorFlow.cmake $DIR/../../.third-party/RedisAI/opt/cmake/modules/ 
         echo "RedisAI downloaded"
     fi
     echo "Downloading RedisAI GPU ML Runtimes"

--- a/smartsim/database/redis6.conf
+++ b/smartsim/database/redis6.conf
@@ -830,7 +830,7 @@ acllog-max-len 128
 # connections, one incoming and another outgoing. It is important to size the
 # limit accordingly in case of very large clusters.
 #
-maxclients 25000
+maxclients 50000
 
 ############################## MEMORY MANAGEMENT ################################
 

--- a/smartsim/launcher/lsf/lsfLauncher.py
+++ b/smartsim/launcher/lsf/lsfLauncher.py
@@ -107,7 +107,7 @@ class LSFLauncher(WLMLauncher):
             if out:
                 step_id = parse_bsub(out)
                 logger.debug(f"Gleaned batch job id: {step_id} for {step.name}")
-        elif isinstance(step, MpirunSettings):
+        elif isinstance(step, MpirunStep):
             out, err = step.get_output_files()
             # mpirun doesn't direct output for us
             output = open(out, "w+")

--- a/tutorials/cheyenne/launch_database_cluster.py
+++ b/tutorials/cheyenne/launch_database_cluster.py
@@ -9,7 +9,7 @@ from smartredis import Client
 
 """
 Launch a distributed, in memory database cluster and use the
-SmartRedis python client to send and recieve some numpy arrays.
+SmartRedis python client to send and receive some numpy arrays.
 
 This example runs in an interactive allocation with at least three
 nodes and 1 processor per node.

--- a/tutorials/summit/README.md
+++ b/tutorials/summit/README.md
@@ -1,0 +1,116 @@
+
+# Summit Tutorials
+
+Summit is the supercomputer at Oak Ridge. The
+following tutorials are meant to aide users on Summit with getting used to the
+different types of workflows that are possible with SmartSim.
+
+
+## Prerequisites
+
+Summit users can use both LSF (`jsrun`) or OpenMPI (`mpirun`) as launchers. In the
+tutorials, we'll show examples for both.
+
+The following modules were loaded to build the LSF examples
+
+```bash
+ 1) hsi/5.0.2.p5   2) xalt/1.2.1   3) lsf-tools/2.0
+ 4) darshan-runtime/3.1.7   5) DefApps   6) gcc/8.1.1
+ 7) cuda/11.2.0   8) spectrum-mpi/10.3.1.2-20200121
+```
+
+The following modules were loaded to build the OpenMPI examples
+
+```bash
+ 1) hsi/5.0.2.p5   2) xalt/1.2.1   3) lsf-tools/2.0 
+ 4) darshan-runtime/3.1.7   5) DefApps   6) gcc/8.1.1
+ 7) cuda/11.2.0   8) openmpi/4.0.3
+```
+
+Please refer to the documentation for how to build SmartSim and SmartRedis on
+Summit [here](https://www.craylabs.org/docs/installation.html)
+
+## Examples
+
+Three of the examples utilize interactive allocations, which is the preferred method of
+launching SmartSim.
+
+
+----------
+
+### 1. launch_distributed_model_lsf.py and launch_distributed_model_ompi.py
+
+Launch a distributed model with OpenMPI through SmartSim. This could represent
+a simulation or other workload that contains the SmartRedis clients and commuicates
+with the Orchestrator.
+
+This example runs in an interactive allocation with at least 40 processors, i.e. one node
+is sufficient.
+
+After obtaining the allocation, make sure to module load your conda or python environment
+with SmartSim and SmartRedis installed, as well as the correct environment as shown above.
+
+Compile the simple hello world MPI program with the correct environment loaded.
+
+```bash
+mpicc hello.c -o hello
+```
+
+Run the model through SmartSim in the interactive allocation. To use IBM Spectrum MPI
+and `jsrun`
+
+```bash
+python launch_distributed_model_lsf.py
+```
+
+to use OpenMPI and `mpirun`
+
+```bash
+python launch_distributed_model_ompi.py
+```
+
+Instead of using an interactive allocation, SmartSim jobs can also be
+launched through batch files. This is helpful when waiting a long time
+for queued jobs.
+
+The following gives an example of how you could launch the MPI
+model above through a batch script instead of an interactive allocation.
+
+```bash
+#!/bin/bash
+
+#PBS -l select=3:ncpus=20:mpiprocs=20
+#PBS -l walltime=00:10:00
+#PBS -A NCGD0048
+#PBS -q economy
+#PBS -N SmartSim
+
+# activate conda env if needed
+python launch_distributed_model.py
+```
+---------
+
+### 2. launch_database_cluster.py
+
+This file shows how to launch a distributed ``Orchestrator`` (database cluster) and
+utilize the SmartRedis Python client to communicate with it. This example is meant
+to provide an example of how users can interact with the database in an interactive
+fashion, possibly in a medium like a jupyter notebook.
+
+This example runs in an interactive allocation with at least three
+nodes. 
+
+```bash
+# fill in account and queue parameters
+bsub -Is -W 01:00 -J SmartSim-int -nnodes 1 -P <project> -alloc_flags smt1 $SHELL
+```
+After obtaining the allocation, make sure to module load your conda or python environment
+with SmartSim and SmartRedis installed.
+
+Run the workflow with
+
+```bash
+python launch_database_cluster.py
+```
+
+

--- a/tutorials/summit/hello.c
+++ b/tutorials/summit/hello.c
@@ -1,0 +1,27 @@
+#include <mpi.h>
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  // Initialize the MPI environment
+  MPI_Init(NULL, NULL);
+
+  // Get the number of processes
+  int world_size;
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+  // Get the rank of the process
+  int world_rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+
+  // Get the name of the processor
+  char processor_name[MPI_MAX_PROCESSOR_NAME];
+  int name_len;
+  MPI_Get_processor_name(processor_name, &name_len);
+
+  // Print off a hello world message
+  printf("Hello world from processor %s, rank %d out of %d processors\n",
+	 processor_name, world_rank, world_size);
+
+  // Finalize the MPI environment.
+  MPI_Finalize();
+}

--- a/tutorials/summit/launch_database_cluster.py
+++ b/tutorials/summit/launch_database_cluster.py
@@ -1,0 +1,78 @@
+import os
+import numpy as np
+
+from smartsim import Experiment
+from smartsim.database import LSFOrchestrator
+
+from smartredis import Client
+
+PROJECT="GEN150_SMARTSIM"
+
+"""
+Launch a distributed, in memory database cluster and use the
+SmartRedis python client to send and receive some numpy arrays.
+
+This example runs in an interactive allocation with at least three
+nodes and 1 processor per node.
+
+i.e. bsub -Is -W 01:00 -J SmartSim-int -nnodes 3 -P <project> -alloc_flags smt1 $SHELL
+"""
+
+def launch_cluster_orc(experiment, port):
+    """Just spin up a database cluster, check the status
+       and tear it down"""
+
+    # batch = False to launch on existing allocation
+
+    db = LSFOrchestrator(port=port,
+                        db_per_host=2,
+                        db_nodes=6,
+                        batch=False,
+                        cpus_per_shard=21,
+                        gpus_per_shard=3,
+                        project=PROJECT,
+                        interface="ib0")
+
+
+    # generate directories for output files
+    # pass in objects to make dirs for
+    experiment.generate(db, overwrite=True)
+
+    # start the database on interactive allocation
+    experiment.start(db, block=True)
+
+    # get the status of the database
+    statuses = experiment.get_status(db)
+    print(f"Status of all database nodes: {statuses}")
+
+    return db
+
+# create the experiment and specify LSF because Summit is a LSF system
+exp = Experiment("launch_cluster_db", launcher="lsf")
+
+db_port = 6780
+# start the database
+db = launch_cluster_orc(exp, db_port)
+
+
+# test sending some arrays to the database cluster
+# the following functions are largely the same across all the
+# client languages: C++, C, Fortran, Python
+
+# only need one address of one shard of DB to connect client
+db_address = ":".join((db._hosts[0], str(db_port)))
+client = Client(address=db_address, cluster=True)
+
+# put into database
+test_array = np.array([1,2,3,4])
+print(f"Array put in database: {test_array}")
+client.put_tensor("test", test_array)
+
+# get from database
+returned_array = client.get_tensor("test")
+print(f"Array retrieved from database: {returned_array}")
+
+# shutdown the database because we don't need it anymore
+exp.stop(db)
+
+

--- a/tutorials/summit/launch_database_cluster.py
+++ b/tutorials/summit/launch_database_cluster.py
@@ -6,7 +6,6 @@ from smartsim.database import LSFOrchestrator
 
 from smartredis import Client
 
-PROJECT="GEN150_SMARTSIM"
 
 """
 Launch a distributed, in memory database cluster and use the
@@ -30,7 +29,6 @@ def launch_cluster_orc(experiment, port):
                         batch=False,
                         cpus_per_shard=21,
                         gpus_per_shard=3,
-                        project=PROJECT,
                         interface="ib0")
 
 

--- a/tutorials/summit/launch_distributed_model_lsf.py
+++ b/tutorials/summit/launch_distributed_model_lsf.py
@@ -1,0 +1,32 @@
+from smartsim import Experiment
+from smartsim.settings import JsrunSettings
+
+"""
+Create a simple model that runs a hello_world.c program
+
+Make sure to have openmpi loaded (module load openmpi)
+
+this example runs in an interactive allocation. 
+
+e.g. bsub -Is -W 01:00 -J SmartSim-int -nnodes 1 -P <project> -alloc_flags smt1 $SHELL
+"""
+
+exp = Experiment("simple", launcher="lsf")
+
+# see https://www.craylabs.org/docs/api/smartsim_api.html#mpirunsettings
+jsrun = JsrunSettings("hello") # hello is name of executable
+jsrun.set_tasks(40)
+
+# create a model with the settings we have defined
+# this is like pythonic reference to a running job
+hello_world = exp.create_model("hello_world", jsrun)
+
+# create directory for output files of this model
+exp.generate(hello_world, overwrite=True)
+
+# start the model and block until completion
+exp.start(hello_world, block=True, summary=True)
+
+# get the status (should be Completed because we set block=True)
+print(f"Model status: {exp.get_status(hello_world)}")
+

--- a/tutorials/summit/launch_distributed_model_ompi.py
+++ b/tutorials/summit/launch_distributed_model_ompi.py
@@ -1,0 +1,32 @@
+from smartsim import Experiment
+from smartsim.settings import MpirunSettings
+
+"""
+Create a simple model that runs a hello_world.c program
+
+Make sure to have openmpi loaded (module load openmpi)
+
+this example runs in an interactive allocation. 
+
+e.g. bsub -Is -W 01:00 -J SmartSim-int -nnodes 1 -P <project> -alloc_flags smt1 $SHELL
+"""
+
+exp = Experiment("simple", launcher="lsf")
+
+# see https://www.craylabs.org/docs/api/smartsim_api.html#mpirunsettings
+mpirun = MpirunSettings("hello") # hello is name of executable
+mpirun.set_tasks(40)
+
+# create a model with the settings we have defined
+# this is like pythonic reference to a running job
+hello_world = exp.create_model("hello_world", mpirun)
+
+# create directory for output files of this model
+exp.generate(hello_world, overwrite=True)
+
+# start the model and block until completion
+exp.start(hello_world, block=True, summary=True)
+
+# get the status (should be Completed because we set block=True)
+print(f"Model status: {exp.get_status(hello_world)}")
+

--- a/tutorials/summit/run.sh
+++ b/tutorials/summit/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+#BSUB -W 00:10
+#BSUB -P GEN150_SMARTSIM
+#BSUB -J SmartSim
+#BSUB -nnodes 1
+
+# activate conda env if needed
+
+# This is lsf
+python launch_distributed_model_lsf.py


### PR DESCRIPTION
This PR patches a problem RedisAI has to find pre-installed TF. 

We store a modified version of RAI's `FindTensorFlow.cmake` file, where we add TF 2.4 (which covers all patch releases) to the accepted TF versions. Moreover, we change the library name (the shared object file has changed). 

Notice this was solely tested on Summit (and it's our current solution on that system).