### PR TITLE
Summit update fixes

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -429,6 +429,7 @@ Note that SmartSim and SmartRedis will be downloaded to the working directory
 from which these instructions are executed.
 
 .. code-block:: bash
+
   # setup Python and build environment
   module load open-ce
   conda create -p /ccs/home/$USER/.conda/envs/smartsim --clone open-ce-1.2.0-py38-0
@@ -471,6 +472,7 @@ When executing SmartSim, if you want to use the PyTorch backend in the orchestra
 you will need to add the PyTorch library path to the environment with:
 
 .. code-block:: bash
+  
   export LD_LIBRARY_PATH=/ccs/home/$USER/.conda/envs/smartsim/lib/python3.8/site-packages/torch/lib/:$LD_LIBRARY_PATH
 
 

--- a/smartsim/database/lsfOrchestrator.py
+++ b/smartsim/database/lsfOrchestrator.py
@@ -227,7 +227,7 @@ class LSFOrchestrator(Orchestrator):
             old_host = host
 
             erf_sets = {
-                "rank_count": "1",
+                "rank": str(shard_id),
                 "host": str(1 + host),
                 "cpu": "{" + f"{assigned_smts}:{self.cpus_per_shard}" + "}",
             }

--- a/smartsim/launcher/lsf/lsfCommands.py
+++ b/smartsim/launcher/lsf/lsfCommands.py
@@ -46,9 +46,37 @@ def bkill(args):
 
     :param args: list of command arguments
     :type args: list of str
-    :return: output and error
-    :rtype: str
+    :return: returncode, output and error
+    :rtype: (int, str, str)
     """
     cmd = ["bkill"] + args
     returncode, out, error = execute_cmd(cmd)
     return returncode, out, error
+
+
+def jskill(args):
+    """Calls LSF jskill with args.
+
+    returncode is also supplied in this function.
+
+    :param args: list of command arguments
+    :type args: list of str
+    :return: returncode, output and error
+    :rtype: (int, str, str)
+    """
+
+    cmd = ["jskill"] + args
+    returncode, out, error = execute_cmd(cmd)
+    return returncode, out, error
+
+def jslist(args):
+    """Calls LSF jslist with args
+
+    :param args: List of command arguments
+    :type args: List of str
+    :returns: Output and error of jslist
+    :rtype: (str, str)
+    """
+    cmd = ["jslist"] + args
+    _, out, err = execute_cmd(cmd)
+    return out, err

--- a/smartsim/launcher/lsf/lsfLauncher.py
+++ b/smartsim/launcher/lsf/lsfLauncher.py
@@ -151,7 +151,7 @@ class LSFLauncher(WLMLauncher):
         step_info.status = STATUS_CANCELLED  # set status to cancelled instead of failed
         return step_info
 
-    def _get_lsf_step_id(self, step, interval=2, trials=5):  # pragma: no cover
+    def _get_lsf_step_id(self, step, interval=2, trials=5): 
         """Get the step_id of last launched step from jslist
 
         """
@@ -169,7 +169,6 @@ class LSFLauncher(WLMLauncher):
             raise LauncherError("Could not find id of launched job step")
         return f"{step.alloc}.{step_id}"
 
-    # TODO: use jslist here if it is a JsrunStep
     def _get_managed_step_update(self, step_ids):
         """Get step updates for WLM managed jobs
 

--- a/smartsim/launcher/lsf/lsfLauncher.py
+++ b/smartsim/launcher/lsf/lsfLauncher.py
@@ -26,17 +26,15 @@
 
 import time
 
-import psutil
-
 from ...constants import STATUS_CANCELLED, STATUS_COMPLETED
 from ...error import LauncherError, SSConfigError
 from ...settings import BsubBatchSettings, JsrunSettings, MpirunSettings
 from ...utils import get_logger
 from ..launcher import WLMLauncher
 from ..step import BsubBatchStep, JsrunStep, MpirunStep
-from ..stepInfo import LSFStepInfo
-from .lsfCommands import bjobs, bkill
-from .lsfParser import parse_bjobs_jobid, parse_bsub, parse_step_id_from_bjobs
+from ..stepInfo import LSFBatchStepInfo, LSFJsrunStepInfo
+from .lsfCommands import bjobs, bkill, jslist, jskill
+from .lsfParser import parse_jslist_stepid, parse_bjobs_jobid, parse_bsub, parse_max_step_id_from_jslist
 
 logger = get_logger(__name__)
 
@@ -115,15 +113,12 @@ class LSFLauncher(WLMLauncher):
             task_id = self.task_manager.start_task(
                 cmd_list, step.cwd, out=output, err=error
             )
-        else:
+        else:  # JsrunStep
             task_id = self.task_manager.start_task(cmd_list, step.cwd)
+            time.sleep(5)
+            step_id = f"{step.alloc}.{self._get_lsf_step_id()}"
 
-        # if batch submission did not successfully retrieve job ID
-        if not step_id and step.managed:  # pragma: no cover
-            step_id = self._get_lsf_step_id(step)
         self.step_mapping.add(step.name, step_id, task_id, step.managed)
-
-        time.sleep(5)
 
         return step_id
 
@@ -137,8 +132,11 @@ class LSFLauncher(WLMLauncher):
         """
         stepmap = self.step_mapping[step_name]
         if stepmap.managed:
-            qdel_rc, _, err = bkill([str(stepmap.step_id)])
-            if qdel_rc != 0:
+            if "." in stepmap.step_id:
+                rc, _, err = jskill([stepmap.step_id.rpartition(".")[-1]])
+            else:
+                rc, _, err = bkill([str(stepmap.step_id)])
+            if rc != 0:
                 logger.warning(f"Unable to cancel job step {step_name}\n {err}")
             if stepmap.task_id:
                 self.task_manager.remove_task(stepmap.task_id)
@@ -149,21 +147,15 @@ class LSFLauncher(WLMLauncher):
         step_info.status = STATUS_CANCELLED  # set status to cancelled instead of failed
         return step_info
 
-    # TODO: use jslist here if it is a JsrunStep
-    # otherwise, this is only reached in a very rare case where a batch
-    # job is submitted but no message is receieved
-    # We exclude this from coverage
-    def _get_lsf_step_id(self, step, interval=2, trials=5):  # pragma: no cover
-        """Get the step_id of a step from bjobs (rarely used)
+    def _get_lsf_step_id(self, interval=2, trials=5):  # pragma: no cover
+        """Get the step_id of last launched step from jslist
 
-        Parses bjobs output by looking for the step name
         """
         time.sleep(interval)
         step_id = "unassigned"
-        username = psutil.Process.username()
         while trials > 0:
-            output, _ = bjobs(["-w", "-u", username])
-            step_id = parse_step_id_from_bjobs(output, step.name)
+            output, _ = jslist([])
+            step_id = parse_max_step_id_from_jslist(output)
             if step_id:
                 break
             else:
@@ -171,6 +163,7 @@ class LSFLauncher(WLMLauncher):
                 trials -= 1
         if not step_id:
             raise LauncherError("Could not find id of launched job step")
+        logger.debug(f"Step id retrieved by jslist: {step_id}")
         return step_id
 
     # TODO: use jslist here if it is a JsrunStep
@@ -183,17 +176,26 @@ class LSFLauncher(WLMLauncher):
         :rtype: list[StepInfo]
         """
         updates = []
-        # Include recently finished jobs
-        bjobs_args = ["-a"] + step_ids
-        bjobs_out, _ = bjobs(bjobs_args)
-        stats = [parse_bjobs_jobid(bjobs_out, str(step_id)) for step_id in step_ids]
-        # create LSFStepInfo objects to return
 
-        for stat, _ in zip(stats, step_ids):
-            info = LSFStepInfo(stat, None)
-            # account for case where job history is not logged by LSF
-            if info.status == STATUS_COMPLETED:
-                info.returncode = 0
+        for step_id in step_ids:
+
+            # Batch jobs have integer step id,
+            # Jsrun processes have {alloc}.{task_id}
+            # Include recently finished jobs
+            if "." in str(step_id):
+                jsrun_step_id = step_id.rpartition(".")[-1]
+                jslist_out, _ = jslist([])
+                stat, return_code = parse_jslist_stepid(jslist_out, jsrun_step_id)
+                info = LSFJsrunStepInfo(stat, return_code)
+            else:
+                bjobs_args = ["-a"] + step_ids
+                bjobs_out, _ = bjobs(bjobs_args)
+                stat = parse_bjobs_jobid(bjobs_out, str(step_id))
+                # create LSFBatchStepInfo objects to return
+                info = LSFBatchStepInfo(stat, None)
+                # account for case where job history is not logged by LSF
+                if info.status == STATUS_COMPLETED:
+                    info.returncode = 0
 
             updates.append(info)
         return updates

--- a/smartsim/launcher/step/lsfStep.py
+++ b/smartsim/launcher/step/lsfStep.py
@@ -119,7 +119,7 @@ class JsrunStep(Step):
         super().__init__(name, cwd)
         self.run_settings = run_settings
         self.alloc = None
-        self.managed = False
+        self.managed = True
         if not self.run_settings.in_batch:
             self._set_alloc()
 
@@ -168,8 +168,8 @@ class JsrunStep(Step):
         ]
 
         if self.run_settings.env_vars:
-            env_var_str = self.run_settings.format_env_vars()
-            jsrun_cmd += [env_var_str]
+            env_var_str_list = self.run_settings.format_env_vars()
+            jsrun_cmd += env_var_str_list
 
         jsrun_cmd += self.run_settings.format_run_args()
         jsrun_cmd += self._build_exe()
@@ -233,9 +233,9 @@ class JsrunStep(Step):
             distr_line = "launch_distribution : packed"
 
         with open(erf_file, "w+") as f:
-            f.write(distr_line)
+            f.write(distr_line + "\n")
             for line in preamble_lines:
-                f.write(line)
+                f.write(line + "\n")
             f.write("\n")
 
             # First we list the apps

--- a/smartsim/launcher/stepInfo.py
+++ b/smartsim/launcher/stepInfo.py
@@ -208,7 +208,7 @@ class CobaltStepInfo(StepInfo):  # cov-cobalt
         return STATUS_FAILED
 
 
-class LSFStepInfo(StepInfo):  # cov-lsf
+class LSFBatchStepInfo(StepInfo):  # cov-lsf
 
     # see https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=execution-about-job-states
     mapping = {
@@ -228,14 +228,47 @@ class LSFStepInfo(StepInfo):  # cov-lsf
                 smartsim_status = "Completed"
                 returncode = 0
         else:
-            smartsim_status = self._get_smartsim_status(status)
+            smartsim_status = self._get_smartsim_status(status, returncode)
         super().__init__(
             smartsim_status, status, returncode, output=output, error=error
         )
 
-    def _get_smartsim_status(self, status):
+    def _get_smartsim_status(self, status, returncode):
         if status in SMARTSIM_STATUS:
             return SMARTSIM_STATUS[status]
         elif status in self.mapping:
             return self.mapping[status]
+        return STATUS_FAILED
+
+class LSFJsrunStepInfo(StepInfo):  # cov-lsf
+
+    # see https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=execution-about-job-states
+    mapping = {
+        "Killed": STATUS_COMPLETED,
+        "Running": STATUS_RUNNING,
+        "Queued": STATUS_PAUSED,
+        "Complete": STATUS_COMPLETED,
+    }
+
+    def __init__(self, status="", returncode=None, output=None, error=None):
+        if status == "NOTFOUND":
+            if returncode is not None:
+                smartsim_status = "Completed" if returncode == 0 else "Failed"
+            else:
+                smartsim_status = "Completed"
+                returncode = 0
+        else:
+            smartsim_status = self._get_smartsim_status(status, returncode)
+        super().__init__(
+            smartsim_status, status, returncode, output=output, error=error
+        )
+
+    def _get_smartsim_status(self, status, returncode):
+        if status in SMARTSIM_STATUS:
+            return SMARTSIM_STATUS[status]
+        elif status in self.mapping:
+            if returncode is not None and int(returncode) != 0:
+                return STATUS_FAILED
+            else:
+                return self.mapping[status]
         return STATUS_FAILED

--- a/smartsim/settings/lsfSettings.py
+++ b/smartsim/settings/lsfSettings.py
@@ -187,16 +187,16 @@ class JsrunSettings(RunSettings):
         to be passed with ``--env``. If a variable is set to ``None``,
         its value is propagated from the current environment.
 
-        :returns: formatted string to export variables
-        :rtype: str
+        :returns: formatted list of strings to export variables
+        :rtype: list[str]
         """
-        format_str = ""
+        format_str = []
         for k, v in self.env_vars.items():
             if v:
-                format_str += f"-E {k}={v} "
+                format_str += ["-E", f"{k}={v}"]
             else:
-                format_str += f"-E {k} "
-        return format_str.rstrip(" ")
+                format_str += ["-E", f"{k}"]
+        return format_str
 
     def set_individual_output(self, suffix=None):
         """Set individual std output.

--- a/tests/test_lsf_parser.py
+++ b/tests/test_lsf_parser.py
@@ -51,11 +51,21 @@ def test_parse_bsub_nodes(fileutils):
     assert nodes == parsed_nodes
 
 
-def test_parse_bjobs_jobid():
-    """Parse jobid from bjobs called with -w"""
+def test_parse_max_step_id():
+    """Get max step id from jslist"""
     output = (
-        "JOBID   USER       STAT   SLOTS    QUEUE       START_TIME    FINISH_TIME   JOB_NAME                      \n"
-        "1234567 smartsim   RUN    85       debug       -             -             SmartSim   \n"
+    "         parent                cpus      gpus      exit               \n"
+   "ID   ID       nrs    per RS    per RS    status         status\n"
+"===============================================================================\n"
+"    3    0         1         1         0         1       Complete\n"
+"    6    0         1         1         0         0       Complete\n"
+"    7    0         1         1         0         0       Complete\n"
+"    8    0         1         1         0         0       Complete\n"
+"    9    0         1         1         0         0       Complete\n"
+"    2    0         3   various   various       137         Killed\n"
+"    4    0         1   various   various       137         Killed\n"
+"    5    0         3   various   various       137         Killed\n"
+
     )
-    parsed_id = lsfParser.parse_step_id_from_bjobs(output, step_name="SmartSim")
-    assert parsed_id == "1234567"
+    parsed_id = lsfParser.parse_max_step_id_from_jslist(output)
+    assert parsed_id == "9"

--- a/tests/test_lsf_settings.py
+++ b/tests/test_lsf_settings.py
@@ -79,7 +79,7 @@ def test_jsrun_format_env():
     env_vars = {"OMP_NUM_THREADS": None, "LOGGING": "verbose"}
     settings = JsrunSettings("python", env_vars=env_vars)
     formatted = settings.format_env_vars()
-    assert formatted == "-E OMP_NUM_THREADS -E LOGGING=verbose"
+    assert formatted == ["-E", "OMP_NUM_THREADS", "-E", "LOGGING=verbose"]
 
 
 def test_jsrun_mpmd():


### PR DESCRIPTION
This PR includes changes to LSFLauncher and LSFOrchestrator needed to run SmartSim on Summit after the last update.

Mainly:
- `LSFOrchestrator` specifies rank number for each process
- `JsrunStep` is now managed and uses `jslist`
- env vars are split differently in `JsrunStep`