### PR TITLE
Improve parameter handling with and without generation

### DIFF
--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -32,7 +32,7 @@ from smartsim.error.errors import SmartSimError
 from ..error import EntityExistsError, SSUnsupportedError, UserStrategyError
 from ..settings.settings import BatchSettings, RunSettings
 from ..utils import get_logger
-from ..utils.helpers import init_default, cat_arg_and_value
+from ..utils.helpers import cat_arg_and_value, init_default
 from .entityList import EntityList
 from .model import Model
 from .strategies import create_all_permutations, random_permutations, step_values
@@ -100,14 +100,16 @@ class Ensemble(EntityList):
         """
         strategy = self._set_strategy(kwargs.pop("perm_strat"))
         replicas = kwargs.pop("replicas", None)
-        
+
         # If param dictionaries are empty, empty lists will be returned
         param_names, params, arg_names, arg_params = self._read_model_parameters()
 
         # Pre-compute parameterized command line arguments and model
         # parameters, as we need them in different branches, if they are given
         if self.params or self.arg_params:
-            all_params = strategy(param_names+arg_names, params+arg_params, **kwargs)
+            all_params = strategy(
+                param_names + arg_names, params + arg_params, **kwargs
+            )
             if not isinstance(all_params, list):
                 raise UserStrategyError(strategy)
 
@@ -119,7 +121,7 @@ class Ensemble(EntityList):
                     raise UserStrategyError(strategy)
                 model_param_dict = {}
                 arg_param_dict = {}
-                for k,v in all_param_list.items():
+                for k, v in all_param_list.items():
                     if k in param_names:
                         model_param_dict[k] = v
                     elif k in arg_names:
@@ -139,7 +141,9 @@ class Ensemble(EntityList):
                         raise UserStrategyError(strategy)
                     run_settings = deepcopy(self.run_settings)
                     for arg_param_name, arg_param_value in arg_param_set.items():
-                        run_settings.add_exe_args(cat_arg_and_value(arg_param_name, arg_param_value))
+                        run_settings.add_exe_args(
+                            cat_arg_and_value(arg_param_name, arg_param_value)
+                        )
                     model_run_settings.append(run_settings)
 
         # if a ensemble has parameters and run settings, create
@@ -152,7 +156,7 @@ class Ensemble(EntityList):
                         run_settings = model_run_settings[i]
                     else:
                         run_settings = deepcopy(self.run_settings)
-                        
+
                     model_name = "_".join((self.name, str(i)))
                     model = Model(
                         model_name,
@@ -336,7 +340,7 @@ class Ensemble(EntityList):
             raise TypeError(
                 "Ensemble initialization argument 'params' must be of type dict"
             )
-        
+
         def list_params(params):
             param_names = []
             parameters = []
@@ -356,4 +360,9 @@ class Ensemble(EntityList):
 
         packed_params = list_params(self.params)
         packed_arg_params = list_params(self.arg_params)
-        return packed_params[0], packed_params[1], packed_arg_params[0], packed_arg_params[1]
+        return (
+            packed_params[0],
+            packed_params[1],
+            packed_arg_params[0],
+            packed_arg_params[1],
+        )

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -32,7 +32,7 @@ from smartsim.error.errors import SmartSimError
 from ..error import EntityExistsError, SSUnsupportedError, UserStrategyError
 from ..settings.settings import BatchSettings, RunSettings
 from ..utils import get_logger
-from ..utils.helpers import cat_arg_and_value, init_default
+from ..utils.helpers import init_default
 from .entityList import EntityList
 from .model import Model
 from .strategies import create_all_permutations, random_permutations, step_values
@@ -49,7 +49,7 @@ class Ensemble(EntityList):
         self,
         name,
         params,
-        arg_params=None,
+        params_as_args=None,
         batch_settings=None,
         run_settings=None,
         perm_strat="all_perm",
@@ -64,8 +64,10 @@ class Ensemble(EntityList):
         :type name: str
         :param params: parameters to expand into ``Model`` members
         :type params: dict[str, Any]
-        :param arg_params: command line parameters to expand into ``Model`` members
-        :type arg_params: dict[str, Any]
+        :param params_as_args: list of params which should be used as command line arguments
+                               to the ``Model`` member executables and not written to generator
+                               files
+        :type arg_params: list[str]
         :param batch_settings: describes settings for ``Ensemble`` as batch workload
         :type batch_settings: BatchSettings, optional
         :param run_settings: describes how each ``Model`` should be executed
@@ -81,7 +83,7 @@ class Ensemble(EntityList):
         :rtype: ``Ensemble``
         """
         self.params = init_default({}, params, dict)
-        self.arg_params = init_default({}, arg_params, dict)
+        self.params_as_args = init_default({}, params_as_args, (list,str))
         self._key_prefixing_enabled = True
         self.batch_settings = init_default({}, batch_settings, BatchSettings)
         self.run_settings = init_default({}, run_settings, RunSettings)
@@ -101,77 +103,33 @@ class Ensemble(EntityList):
         strategy = self._set_strategy(kwargs.pop("perm_strat"))
         replicas = kwargs.pop("replicas", None)
 
-        # If param dictionaries are empty, empty lists will be returned
-        param_names, params, arg_names, arg_params = self._read_model_parameters()
-
-        # Pre-compute parameterized command line arguments and model
-        # parameters, as we need them in different branches, if they are given
-        if self.params or self.arg_params:
-            # Compute all combinations of model parameters and arguments
-            all_params = strategy(
-                param_names + arg_names, params + arg_params, **kwargs
-            )
-            if not isinstance(all_params, list):
-                raise UserStrategyError(strategy)
-
-            all_model_params = []
-            all_arg_params = []
-
-            # Separate model parameters and model arguments
-            # into two lists
-            for all_param_list in all_params:
-                if not isinstance(all_param_list, dict):
-                    raise UserStrategyError(strategy)
-                model_param_dict = {}
-                arg_param_dict = {}
-                for k, v in all_param_list.items():
-                    if k in param_names:
-                        model_param_dict[k] = v
-                    elif k in arg_names:
-                        arg_param_dict[k] = v
-                    else:
-                        raise UserStrategyError(strategy)
-                if model_param_dict:
-                    all_model_params.append(model_param_dict)
-                if arg_param_dict:
-                    all_arg_params.append(arg_param_dict)
-
-            if self.arg_params:
-                # run settings with exe_args modified according to params
-                model_run_settings = []
-                for arg_param_set in all_arg_params:
-                    if not isinstance(arg_param_set, dict):
-                        raise UserStrategyError(strategy)
-                    run_settings = deepcopy(self.run_settings)
-                    for arg_param_name, arg_param_value in arg_param_set.items():
-                        run_settings.add_exe_args(
-                            cat_arg_and_value(arg_param_name, arg_param_value)
-                        )
-                    model_run_settings.append(run_settings)
-
         # if a ensemble has parameters and run settings, create
         # the ensemble and assign run_settings to each member
         if self.params:
             if self.run_settings:
-                for i, param_set in enumerate(all_model_params):
-                    
-                    # if there are parameterized arguments,
-                    # pick the model_run_settings corresponding 
-                    # to this combination of model parameters
-                    # otherwise just copy run_settings
-                    if self.arg_params:
-                        run_settings = model_run_settings[i]
-                    else:
-                        run_settings = deepcopy(self.run_settings)
+                param_names, params = self._read_model_parameters()
 
+                # Compute all combinations of model parameters and arguments
+                all_model_params = strategy(
+                    param_names, params, **kwargs
+                )
+                if not isinstance(all_model_params, list):
+                    raise UserStrategyError(strategy)
+
+                for i, param_set in enumerate(all_model_params):
+                    if not isinstance(param_set, dict):
+                        raise UserStrategyError(strategy)
+                    run_settings = deepcopy(self.run_settings)
                     model_name = "_".join((self.name, str(i)))
                     model = Model(
                         model_name,
                         param_set,
                         self.path,
                         run_settings=run_settings,
+                        params_as_args=self.params_as_args,
                     )
                     model.enable_key_prefixing()
+                    model.params_to_args()
                     logger.debug(
                         f"Created ensemble member: {model_name} in {self.name}"
                     )
@@ -179,28 +137,7 @@ class Ensemble(EntityList):
             # cannot generate models without run settings
             else:
                 raise SmartSimError(
-                    "Ensembles without 'params', 'arg_params', or 'replicas' argument to expand into members cannot be given run settings"
-                )
-        # if there are only parameterized arguments and no model parameter
-        # just iterate over all model_run_settings
-        elif self.arg_params:
-            if self.run_settings:
-                for i, run_settings in enumerate(model_run_settings):
-                    model_name = "_".join((self.name, str(i)))
-                    model = Model(
-                        model_name,
-                        {},
-                        self.path,
-                        run_settings=run_settings,
-                    )
-                    model.enable_key_prefixing()
-                    logger.debug(
-                        f"Created ensemble member: {model_name} in {self.name}"
-                    )
-                    self.add_model(model)
-            else:
-                raise SmartSimError(
-                    "Ensembles without 'params', 'arg_params', or 'replicas' argument to expand into members cannot be given run settings"
+                    "Ensembles without 'params' or 'replicas' argument to expand into members cannot be given run settings"
                 )
         else:
             if self.run_settings:
@@ -220,7 +157,7 @@ class Ensemble(EntityList):
                         self.add_model(model)
                 else:
                     raise SmartSimError(
-                        "Ensembles without 'params', 'arg_params', or 'replicas' argument to expand into members cannot be given run settings"
+                        "Ensembles without 'params' or 'replicas' argument to expand into members cannot be given run settings"
                     )
             # if no params, no run settings and no batch settings, error because we
             # don't know how to run the ensemble
@@ -230,6 +167,7 @@ class Ensemble(EntityList):
                 )
             else:
                 logger.info("Empty ensemble created for batch launch")
+
 
     def add_model(self, model):
         """Add a model to this ensemble
@@ -345,33 +283,18 @@ class Ensemble(EntityList):
                 "Ensemble initialization argument 'params' must be of type dict"
             )
 
-        if not isinstance(self.arg_params, dict):
-            raise TypeError(
-                "Ensemble initialization argument 'params' must be of type dict"
-            )
+        param_names = []
+        parameters = []
+        for name, val in self.params.items():
+            param_names.append(name)
 
-        def list_params(params):
-            param_names = []
-            parameters = []
-            for name, val in params.items():
-                param_names.append(name)
-
-                if isinstance(val, list):
-                    parameters.append(val)
-                elif isinstance(val, (int, str)):
-                    parameters.append([val])
-                else:
-                    raise TypeError(
-                        "Incorrect type for ensemble parameters\n"
-                        + "Must be list, int, or string."
-                    )
-            return param_names, parameters
-
-        packed_params = list_params(self.params)
-        packed_arg_params = list_params(self.arg_params)
-        return (
-            packed_params[0],
-            packed_params[1],
-            packed_arg_params[0],
-            packed_arg_params[1],
-        )
+            if isinstance(val, list):
+                parameters.append(val)
+            elif isinstance(val, (int, str)):
+                parameters.append([val])
+            else:
+                raise TypeError(
+                    "Incorrect type for ensemble parameters\n"
+                    + "Must be list, int, or string."
+                )
+        return param_names, parameters

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -107,6 +107,7 @@ class Ensemble(EntityList):
         # Pre-compute parameterized command line arguments and model
         # parameters, as we need them in different branches, if they are given
         if self.params or self.arg_params:
+            # Compute all combinations of model parameters and arguments
             all_params = strategy(
                 param_names + arg_names, params + arg_params, **kwargs
             )
@@ -116,6 +117,8 @@ class Ensemble(EntityList):
             all_model_params = []
             all_arg_params = []
 
+            # Separate model parameters and model arguments
+            # into two lists
             for all_param_list in all_params:
                 if not isinstance(all_param_list, dict):
                     raise UserStrategyError(strategy)
@@ -147,11 +150,15 @@ class Ensemble(EntityList):
                     model_run_settings.append(run_settings)
 
         # if a ensemble has parameters and run settings, create
-        # the ensemble and copy run_settings to each member
+        # the ensemble and assign run_settings to each member
         if self.params:
             if self.run_settings:
                 for i, param_set in enumerate(all_model_params):
-
+                    
+                    # if there are parameterized arguments,
+                    # pick the model_run_settings corresponding 
+                    # to this combination of model parameters
+                    # otherwise just copy run_settings
                     if self.arg_params:
                         run_settings = model_run_settings[i]
                     else:
@@ -174,6 +181,8 @@ class Ensemble(EntityList):
                 raise SmartSimError(
                     "Ensembles without 'params', 'arg_params', or 'replicas' argument to expand into members cannot be given run settings"
                 )
+        # if there are only parameterized arguments and no model parameter
+        # just iterate over all model_run_settings
         elif self.arg_params:
             if self.run_settings:
                 for i, run_settings in enumerate(model_run_settings):

--- a/smartsim/utils/helpers.py
+++ b/smartsim/utils/helpers.py
@@ -146,31 +146,31 @@ def delete_elements(dictionary, key_list):
 def cat_arg_and_value(arg_name, value):
     """Concatenate a command line argument and its value
 
-        This function returns ``arg_name`` and ``value
-        concatenated in the best possible way for a command
-        line execution, namely:
-        - if arg_name starts with `--` (e.g. `--arg`):
-          `arg_name=value` is returned (i.e. `--arg=val`)
-        - if arg_name starts with `-` (e.g. `-a`):
-          `arg_name value` is returned (i.e. `-a val`)
-        - if arg_name does not start with `-` and it is a
-          long option (e.g. `arg`):
-          `--arg_name=value` (i.e., `--arg=val`)
-        - if arg_name does not start with `-` and it is a
-          short option (e.g. `a`):
-          `-arg_name=value` (i.e., `-a val`) 
+    This function returns ``arg_name`` and ``value
+    concatenated in the best possible way for a command
+    line execution, namely:
+    - if arg_name starts with `--` (e.g. `--arg`):
+      `arg_name=value` is returned (i.e. `--arg=val`)
+    - if arg_name starts with `-` (e.g. `-a`):
+      `arg_name value` is returned (i.e. `-a val`)
+    - if arg_name does not start with `-` and it is a
+      long option (e.g. `arg`):
+      `--arg_name=value` (i.e., `--arg=val`)
+    - if arg_name does not start with `-` and it is a
+      short option (e.g. `a`):
+      `-arg_name=value` (i.e., `-a val`)
 
-        :param arg_name: the command line argument name
-        :type arg_name: str
-        :param value: the command line argument value
-        :type value: str
+    :param arg_name: the command line argument name
+    :type arg_name: str
+    :param value: the command line argument value
+    :type value: str
     """
-    
+
     if arg_name.startswith("--"):
         return "=".join((arg_name, str(value)))
     elif arg_name.startswith("-"):
         return " ".join((arg_name, str(value)))
     elif len(arg_name) == 1:
-        return " ".join(("-"+arg_name, str(value)))
+        return " ".join(("-" + arg_name, str(value)))
     else:
-        return "=".join(("--"+arg_name, str(value)))
+        return "=".join(("--" + arg_name, str(value)))

--- a/smartsim/utils/helpers.py
+++ b/smartsim/utils/helpers.py
@@ -141,3 +141,36 @@ def delete_elements(dictionary, key_list):
     for key in key_list:
         if key in dictionary:
             del dictionary[key]
+
+
+def cat_arg_and_value(arg_name, value):
+    """Concatenate a command line argument and its value
+
+        This function returns ``arg_name`` and ``value
+        concatenated in the best possible way for a command
+        line execution, namely:
+        - if arg_name starts with `--` (e.g. `--arg`):
+          `arg_name=value` is returned (i.e. `--arg=val`)
+        - if arg_name starts with `-` (e.g. `-a`):
+          `arg_name value` is returned (i.e. `-a val`)
+        - if arg_name does not start with `-` and it is a
+          long option (e.g. `arg`):
+          `--arg_name=value` (i.e., `--arg=val`)
+        - if arg_name does not start with `-` and it is a
+          short option (e.g. `a`):
+          `-arg_name=value` (i.e., `-a val`) 
+
+        :param arg_name: the command line argument name
+        :type arg_name: str
+        :param value: the command line argument value
+        :type value: str
+    """
+    
+    if arg_name.startswith("--"):
+        return "=".join((arg_name, str(value)))
+    elif arg_name.startswith("-"):
+        return " ".join((arg_name, str(value)))
+    elif len(arg_name) == 1:
+        return " ".join(("-"+arg_name, str(value)))
+    else:
+        return "=".join(("--"+arg_name, str(value)))

--- a/tests/backends/run_sklearn_onnx.py
+++ b/tests/backends/run_sklearn_onnx.py
@@ -5,6 +5,7 @@ from sklearn.datasets import load_iris
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import train_test_split
+
 from smartredis import Client
 
 

--- a/tests/backends/run_tf.py
+++ b/tests/backends/run_tf.py
@@ -1,9 +1,9 @@
 import os
 
 import numpy as np
-from smartredis import Client
 from tensorflow import keras
 
+from smartredis import Client
 from smartsim.tf import freeze_model
 
 

--- a/tests/backends/run_torch.py
+++ b/tests/backends/run_torch.py
@@ -4,6 +4,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
 from smartredis import Client
 
 

--- a/tests/test_configs/multi_tags_template.sh
+++ b/tests/test_configs/multi_tags_template.sh
@@ -1,0 +1,1 @@
+echo "My two parameters are ;port; and ;password;, OK?"

--- a/tests/test_configs/smartredis/consumer.py
+++ b/tests/test_configs/smartredis/consumer.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import torch
 import torch.nn as nn
+
 from smartredis import Client
 
 if __name__ == "__main__":

--- a/tests/test_configs/smartredis/producer.py
+++ b/tests/test_configs/smartredis/producer.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import torch
 import torch.nn as nn
+
 from smartredis import Client
 
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,5 +1,6 @@
 import pytest
 
+from copy import deepcopy
 from smartsim import Experiment
 from smartsim.entity import Ensemble, Model
 from smartsim.error import EntityExistsError, SSUnsupportedError, UserStrategyError
@@ -101,6 +102,81 @@ def test_user_strategy():
     model_2_params = {"h": 6, "g": 8}
     assert ensemble.entities[1].params == model_2_params
 
+
+# ----- Model arguments -------------------------------------
+
+def test_arg_params():
+    """Test parameterized exe arguments
+    """
+    arg_params = {"H": [5, 6], "g_param": ["a", "b"]}
+    
+    # Copy rs to avoid modifying referenced object
+    rs_copy = deepcopy(rs)
+    rs_orig_args = rs_copy.exe_args
+    ensemble = Ensemble("step", params=None, arg_params=arg_params, run_settings=rs_copy, perm_strat="step")
+    assert len(ensemble) == 2
+
+    exe_args_0 = rs_orig_args + ["-H", "5", "--g_param=a"]
+    assert ensemble.entities[0].run_settings.exe_args == exe_args_0
+
+    exe_args_1 = rs_orig_args + ["-H", "6", "--g_param=b"]
+    assert ensemble.entities[1].run_settings.exe_args == exe_args_1
+
+
+def test_arg_and_model_params_step():
+    """Test parameterized exe arguments combined with 
+       model parameters and step strategy
+    """
+    arg_params = {"H": [5, 6], "g_param": ["a", "b"]}
+    params = {"h": [5, 6], "g": [7, 8]}
+
+    # Copy rs to avoid modifying referenced object
+    rs_copy = deepcopy(rs)
+    rs_orig_args = rs_copy.exe_args
+    ensemble = Ensemble("step", params, arg_params=arg_params, run_settings=rs_copy, perm_strat="step")
+    assert len(ensemble) == 2
+
+    exe_args_0 = rs_orig_args + ["-H", "5", "--g_param=a"]
+    assert ensemble.entities[0].run_settings.exe_args == exe_args_0
+
+    exe_args_1 = rs_orig_args + ["-H", "6", "--g_param=b"]
+    assert ensemble.entities[1].run_settings.exe_args == exe_args_1
+
+    model_1_params = {"h": 5, "g": 7}
+    assert ensemble.entities[0].params == model_1_params
+
+    model_2_params = {"h": 6, "g": 8}
+    assert ensemble.entities[1].params == model_2_params
+
+
+def test_arg_and_model_params_all_perms():
+    """Test parameterized exe arguments combined with 
+       model parameters and all_perm strategy
+    """
+    params = {"h": [5, 6]}
+    arg_params = {"g_param": ["a", "b"]}
+
+    # Copy rs to avoid modifying referenced object
+    rs_copy = deepcopy(rs)
+    rs_orig_args = rs_copy.exe_args
+    ensemble = Ensemble("step", params, arg_params=arg_params, run_settings=rs_copy, perm_strat="all_perm")
+    assert len(ensemble) == 4
+
+    exe_args_0 = rs_orig_args + ["--g_param=a"]
+    assert ensemble.entities[0].run_settings.exe_args == exe_args_0
+    assert ensemble.entities[2].run_settings.exe_args == exe_args_0
+
+    exe_args_1 = rs_orig_args + ["--g_param=b"]
+    assert ensemble.entities[1].run_settings.exe_args == exe_args_1
+    assert ensemble.entities[3].run_settings.exe_args == exe_args_1
+
+    model_0_params = {"h": 5}
+    assert ensemble.entities[0].params == model_0_params
+    assert ensemble.entities[1].params == model_0_params
+
+    model_2_params = {"h": 6}
+    assert ensemble.entities[2].params == model_2_params
+    assert ensemble.entities[3].params == model_2_params
 
 # ----- Error Handling --------------------------------------
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,6 +1,7 @@
+from copy import deepcopy
+
 import pytest
 
-from copy import deepcopy
 from smartsim import Experiment
 from smartsim.entity import Ensemble, Model
 from smartsim.error import EntityExistsError, SSUnsupportedError, UserStrategyError
@@ -105,15 +106,21 @@ def test_user_strategy():
 
 # ----- Model arguments -------------------------------------
 
+
 def test_arg_params():
-    """Test parameterized exe arguments
-    """
+    """Test parameterized exe arguments"""
     arg_params = {"H": [5, 6], "g_param": ["a", "b"]}
-    
+
     # Copy rs to avoid modifying referenced object
     rs_copy = deepcopy(rs)
     rs_orig_args = rs_copy.exe_args
-    ensemble = Ensemble("step", params=None, arg_params=arg_params, run_settings=rs_copy, perm_strat="step")
+    ensemble = Ensemble(
+        "step",
+        params=None,
+        arg_params=arg_params,
+        run_settings=rs_copy,
+        perm_strat="step",
+    )
     assert len(ensemble) == 2
 
     exe_args_0 = rs_orig_args + ["-H", "5", "--g_param=a"]
@@ -124,8 +131,8 @@ def test_arg_params():
 
 
 def test_arg_and_model_params_step():
-    """Test parameterized exe arguments combined with 
-       model parameters and step strategy
+    """Test parameterized exe arguments combined with
+    model parameters and step strategy
     """
     arg_params = {"H": [5, 6], "g_param": ["a", "b"]}
     params = {"h": [5, 6], "g": [7, 8]}
@@ -133,7 +140,9 @@ def test_arg_and_model_params_step():
     # Copy rs to avoid modifying referenced object
     rs_copy = deepcopy(rs)
     rs_orig_args = rs_copy.exe_args
-    ensemble = Ensemble("step", params, arg_params=arg_params, run_settings=rs_copy, perm_strat="step")
+    ensemble = Ensemble(
+        "step", params, arg_params=arg_params, run_settings=rs_copy, perm_strat="step"
+    )
     assert len(ensemble) == 2
 
     exe_args_0 = rs_orig_args + ["-H", "5", "--g_param=a"]
@@ -150,8 +159,8 @@ def test_arg_and_model_params_step():
 
 
 def test_arg_and_model_params_all_perms():
-    """Test parameterized exe arguments combined with 
-       model parameters and all_perm strategy
+    """Test parameterized exe arguments combined with
+    model parameters and all_perm strategy
     """
     params = {"h": [5, 6]}
     arg_params = {"g_param": ["a", "b"]}
@@ -159,7 +168,13 @@ def test_arg_and_model_params_all_perms():
     # Copy rs to avoid modifying referenced object
     rs_copy = deepcopy(rs)
     rs_orig_args = rs_copy.exe_args
-    ensemble = Ensemble("step", params, arg_params=arg_params, run_settings=rs_copy, perm_strat="all_perm")
+    ensemble = Ensemble(
+        "step",
+        params,
+        arg_params=arg_params,
+        run_settings=rs_copy,
+        perm_strat="all_perm",
+    )
     assert len(ensemble) == 4
 
     exe_args_0 = rs_orig_args + ["--g_param=a"]
@@ -177,6 +192,7 @@ def test_arg_and_model_params_all_perms():
     model_2_params = {"h": 6}
     assert ensemble.entities[2].params == model_2_params
     assert ensemble.entities[3].params == model_2_params
+
 
 # ----- Error Handling --------------------------------------
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -109,15 +109,15 @@ def test_user_strategy():
 
 def test_arg_params():
     """Test parameterized exe arguments"""
-    arg_params = {"H": [5, 6], "g_param": ["a", "b"]}
+    params = {"H": [5, 6], "g_param": ["a", "b"]}
 
     # Copy rs to avoid modifying referenced object
     rs_copy = deepcopy(rs)
     rs_orig_args = rs_copy.exe_args
     ensemble = Ensemble(
         "step",
-        params=None,
-        arg_params=arg_params,
+        params=params,
+        params_as_args=list(params.keys()),
         run_settings=rs_copy,
         perm_strat="step",
     )
@@ -134,14 +134,13 @@ def test_arg_and_model_params_step():
     """Test parameterized exe arguments combined with
     model parameters and step strategy
     """
-    arg_params = {"H": [5, 6], "g_param": ["a", "b"]}
-    params = {"h": [5, 6], "g": [7, 8]}
+    params = {"H": [5, 6], "g_param": ["a", "b"], "h": [5, 6], "g": [7, 8]}
 
     # Copy rs to avoid modifying referenced object
     rs_copy = deepcopy(rs)
     rs_orig_args = rs_copy.exe_args
     ensemble = Ensemble(
-        "step", params, arg_params=arg_params, run_settings=rs_copy, perm_strat="step"
+        "step", params, params_as_args=["H", "g_param"], run_settings=rs_copy, perm_strat="step"
     )
     assert len(ensemble) == 2
 
@@ -151,10 +150,10 @@ def test_arg_and_model_params_step():
     exe_args_1 = rs_orig_args + ["-H", "6", "--g_param=b"]
     assert ensemble.entities[1].run_settings.exe_args == exe_args_1
 
-    model_1_params = {"h": 5, "g": 7}
+    model_1_params = {"H": 5, "g_param": "a", "h": 5, "g": 7}
     assert ensemble.entities[0].params == model_1_params
 
-    model_2_params = {"h": 6, "g": 8}
+    model_2_params = {"H": 6, "g_param": "b", "h": 6, "g": 8}
     assert ensemble.entities[1].params == model_2_params
 
 
@@ -162,8 +161,7 @@ def test_arg_and_model_params_all_perms():
     """Test parameterized exe arguments combined with
     model parameters and all_perm strategy
     """
-    params = {"h": [5, 6]}
-    arg_params = {"g_param": ["a", "b"]}
+    params = {"h": [5, 6], "g_param": ["a", "b"]}
 
     # Copy rs to avoid modifying referenced object
     rs_copy = deepcopy(rs)
@@ -171,7 +169,7 @@ def test_arg_and_model_params_all_perms():
     ensemble = Ensemble(
         "step",
         params,
-        arg_params=arg_params,
+        params_as_args=["g_param"],
         run_settings=rs_copy,
         perm_strat="all_perm",
     )
@@ -185,13 +183,14 @@ def test_arg_and_model_params_all_perms():
     assert ensemble.entities[1].run_settings.exe_args == exe_args_1
     assert ensemble.entities[3].run_settings.exe_args == exe_args_1
 
-    model_0_params = {"h": 5}
+    model_0_params = {"g_param": "a", "h": 5}
     assert ensemble.entities[0].params == model_0_params
-    assert ensemble.entities[1].params == model_0_params
-
-    model_2_params = {"h": 6}
+    model_1_params = {"g_param": "b", "h": 5}
+    assert ensemble.entities[1].params == model_1_params
+    model_2_params = {"g_param": "a", "h": 6}
     assert ensemble.entities[2].params == model_2_params
-    assert ensemble.entities[3].params == model_2_params
+    model_3_params = {"g_param": "b", "h": 6}
+    assert ensemble.entities[3].params == model_3_params
 
 
 # ----- Error Handling --------------------------------------

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -133,3 +133,23 @@ def test_dir_files(fileutils):
         assert osp.isdir(model_path)
         assert osp.isdir(osp.join(model_path, "test_dir_1"))
         assert osp.isfile(osp.join(model_path, "test.py"))
+
+
+def test_multiple_tags(fileutils):
+    """Test substitution of multiple tagged parameters on same line
+    """
+    test_dir = fileutils.make_test_dir("multiple_tags")
+
+    exp = Experiment("test-multiple-tags", test_dir)
+    model_params = {"port": 6379, "password": "unbreakable_password"}
+    model_settings = RunSettings("bash", "multi_tags_template.sh")
+    parameterized_model = exp.create_model("multi-tags", 
+                                    run_settings=model_settings, params=model_params)
+    config = fileutils.get_test_conf_path("multi_tags_template.sh")
+    parameterized_model.attach_generator_files(to_configure=[config])
+    exp.generate(parameterized_model, overwrite=True)
+    exp.start(parameterized_model, block=True)
+
+    with open(osp.join(parameterized_model.path, "multi-tags.out")) as f:
+        line = f.readline()
+        assert line.strip() == "My two parameters are 6379 and unbreakable_password, OK?"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -136,15 +136,15 @@ def test_dir_files(fileutils):
 
 
 def test_multiple_tags(fileutils):
-    """Test substitution of multiple tagged parameters on same line
-    """
+    """Test substitution of multiple tagged parameters on same line"""
     test_dir = fileutils.make_test_dir("multiple_tags")
 
     exp = Experiment("test-multiple-tags", test_dir)
     model_params = {"port": 6379, "password": "unbreakable_password"}
     model_settings = RunSettings("bash", "multi_tags_template.sh")
-    parameterized_model = exp.create_model("multi-tags", 
-                                    run_settings=model_settings, params=model_params)
+    parameterized_model = exp.create_model(
+        "multi-tags", run_settings=model_settings, params=model_params
+    )
     config = fileutils.get_test_conf_path("multi_tags_template.sh")
     parameterized_model.attach_generator_files(to_configure=[config])
     exp.generate(parameterized_model, overwrite=True)
@@ -152,4 +152,6 @@ def test_multiple_tags(fileutils):
 
     with open(osp.join(parameterized_model.path, "multi-tags.out")) as f:
         line = f.readline()
-        assert line.strip() == "My two parameters are 6379 and unbreakable_password, OK?"
+        assert (
+            line.strip() == "My two parameters are 6379 and unbreakable_password, OK?"
+        )

--- a/tests/test_smartredis.py
+++ b/tests/test_smartredis.py
@@ -22,8 +22,9 @@ REDIS_PORT = 6780
 
 shouldrun = True
 try:
-    import smartredis
     import torch
+
+    import smartredis
 except ImportError:
     shouldrun = False
 


### PR DESCRIPTION
This PR enhances the current way parameters and models are generated in two ways:

- add the possibility of specifying `arg_params` in `Ensemble`s: `arg_params` are treated like `params` but set as `exe_args` in the created `Model`s -- thus they are set even without the generation step.
- allow multiple tagged parameters on same line

This PR resolves #16 #40 