### PR TITLE
Add base run settings to tests for LSF

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -133,7 +133,10 @@ class WLMUtils:
             settings = RunSettings(exe, args, run_command="aprun", run_args=run_args)
             return settings
         if test_launcher == "lsf":
-            raise SSUnsupportedError("SmartSim LSF launcher does not support custom run settings at this time.")
+            run_args = {"--np": ntasks, "--nrs": nodes}
+            run_args.update(kwargs)
+            settings = RunSettings(exe, args, run_command="jsrun", run_args=run_args)
+            return settings
         # TODO allow user to pick aprun vs MPIrun
         return RunSettings(exe, args)
         

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ from smartsim.settings import (
     JsrunSettings, RunSettings
 )
 from smartsim.config import CONFIG
+from smartsim.error import SSConfigError
 
 
 # Globals, yes, but its a testing file
@@ -137,6 +138,8 @@ class WLMUtils:
             run_args.update(kwargs)
             settings = RunSettings(exe, args, run_command="jsrun", run_args=run_args)
             return settings
+        elif test_launcher != "local":
+            raise SSConfigError(f"Base run settings are available for Slurm, PBS, Cobalt, and LSF, but launcher was {test_launcher}")
         # TODO allow user to pick aprun vs MPIrun
         return RunSettings(exe, args)
         

--- a/tests/on_wlm/test_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_base_settings_on_wlm.py
@@ -3,7 +3,6 @@ import time
 import pytest
 
 from smartsim import Experiment, constants
-from smartsim.settings.settings import RunSettings
 
 """
 Test the launch and stop of models and ensembles using base
@@ -17,8 +16,8 @@ if pytest.test_launcher not in pytest.wlm_options:
 
 def test_model_on_wlm(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
-    if launcher not in ["pbs", "slurm", "cobalt"]:
-        pytest.skip("Test only runs on systems with PBSPro, Slurm, or Cobalt as WLM")
+    if launcher not in ["pbs", "slurm", "cobalt", "lsf"]:
+        pytest.skip("Test only runs on systems with PBSPro, Slurm, LSF, or Cobalt as WLM")
 
     exp_name = "test-base-settings-model-launch"
     exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
@@ -39,8 +38,8 @@ def test_model_on_wlm(fileutils, wlmutils):
 
 def test_model_stop_on_wlm(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
-    if launcher not in ["pbs", "slurm", "cobalt"]:
-        pytest.skip("Test only runs on systems with PBSPro, Slurm, or Cobalt as WLM")
+    if launcher not in ["pbs", "slurm", "cobalt", "lsf"]:
+        pytest.skip("Test only runs on systems with PBSPro, Slurm, LSF, or Cobalt as WLM")
 
     exp_name = "test-base-settings-model-stop"
     exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
@@ -64,8 +63,8 @@ def test_model_stop_on_wlm(fileutils, wlmutils):
 
 def test_ensemble_on_wlm(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
-    if launcher not in ["pbs", "slurm", "cobalt"]:
-        pytest.skip("Test only runs on systems with PBSPro, Slurm, or Cobalt as WLM")
+    if launcher not in ["pbs", "slurm", "cobalt", "lsf"]:
+        pytest.skip("Test only runs on systems with PBSPro, Slurm, LSF, or Cobalt as WLM")
 
     exp_name = "test-base-settings-ensemble-launch"
     exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
@@ -85,8 +84,8 @@ def test_ensemble_on_wlm(fileutils, wlmutils):
 
 def test_ensemble_stop_on_wlm(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
-    if launcher not in ["pbs", "slurm", "cobalt"]:
-        pytest.skip("Test only runs on systems with PBSPro, Slurm, or Cobalt as WLM")
+    if launcher not in ["pbs", "slurm", "cobalt", "lsf"]:
+        pytest.skip("Test only runs on systems with PBSPro, Slurm, LSF, or Cobalt as WLM")
 
     exp_name = "test-base-settings-ensemble-launch"
     exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())


### PR DESCRIPTION
This PR actually just adds the tests for LSF base settings, as they were already supported in the LSF launcher. Therefore, the status is now:
- in the LSF launcher, `RunSettings` objects are supported
- in `conftest.py`, `get_base_run_settings` can generate `RunSettings` for LSF.

Let me know if there was something else to be added! 