### PR TITLE
Add missing functions to LSFSettings API

### DIFF
--- a/smartsim/launcher/pbs/pbsParser.py
+++ b/smartsim/launcher/pbs/pbsParser.py
@@ -73,6 +73,9 @@ def parse_qstat_jobid(output, job_id):
     """
     result = "NOTFOUND"
     for line in output.split("\n"):
+        fields = line.split()
+        if len(fields) < 5:
+            continue
         if line.split()[0] == job_id:
             line = line.split()
             stat = line[4]

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -201,10 +201,15 @@ class RunSettings:
 
 
 class BatchSettings:
-    def __init__(self, batch_cmd, batch_args=None):
+    def __init__(self, batch_cmd, batch_args=None, **kwargs):
         self._batch_cmd = batch_cmd
         self.batch_args = init_default({}, batch_args, dict)
         self._preamble = []
+        print("BatchSettings", kwargs)
+        self.set_nodes(kwargs.get("nodes", None))
+        self.set_walltime(kwargs.get("time", None))
+        self.set_queue(kwargs.get("queue", None))
+        self.set_account(kwargs.get("account", None))
 
     @property
     def batch_cmd(self):

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -205,7 +205,6 @@ class BatchSettings:
         self._batch_cmd = batch_cmd
         self.batch_args = init_default({}, batch_args, dict)
         self._preamble = []
-        print("BatchSettings", kwargs)
         self.set_nodes(kwargs.get("nodes", None))
         self.set_walltime(kwargs.get("time", None))
         self.set_queue(kwargs.get("queue", None))

--- a/smartsim/settings/cobaltSettings.py
+++ b/smartsim/settings/cobaltSettings.py
@@ -50,15 +50,14 @@ class CobaltBatchSettings(BatchSettings):
         :param batch_args: extra batch arguments, defaults to None
         :type batch_args: dict[str, str], optional
         """
-        super().__init__("qsub", batch_args=batch_args)
-        if nodes:
-            self.set_nodes(nodes)
-        if time:
-            self.set_walltime(time)
-        if account:
-            self.set_account(account)
-        if queue:
-            self.set_queue(queue)
+        super().__init__("qsub",
+                         batch_args=batch_args,
+                         nodes=nodes, 
+                         account=account, 
+                         queue=queue, 
+                         time=time,  
+                         **kwargs)
+                         
 
     def set_walltime(self, walltime):
         """Set the walltime of the job
@@ -73,7 +72,8 @@ class CobaltBatchSettings(BatchSettings):
         """
         # TODO check for formatting errors here
         # TODO catch existing "t" in batch_args
-        self.batch_args["time"] = walltime
+        if walltime:
+            self.batch_args["time"] = walltime
 
     def set_nodes(self, num_nodes):
         """Set the number of nodes for this batch job
@@ -82,7 +82,8 @@ class CobaltBatchSettings(BatchSettings):
         :type num_nodes: int
         """
         # TODO catch existing "n" in batch_args
-        self.batch_args["nodecount"] = int(num_nodes)
+        if num_nodes:
+            self.batch_args["nodecount"] = int(num_nodes)
 
     def set_hostlist(self, host_list):
         """Specify the hostlist for this job
@@ -115,16 +116,18 @@ class CobaltBatchSettings(BatchSettings):
         :type queue: str
         """
         # TODO catch existing "q" in batch args
-        self.batch_args["queue"] = str(queue)
+        if queue:
+            self.batch_args["queue"] = str(queue)
 
-    def set_account(self, acct):
+    def set_account(self, account):
         """Set the account for this batch job
 
         :param acct: account id
         :type acct: str
         """
         # TODO catch existing "A" in batch_args
-        self.batch_args["project"] = acct
+        if account:
+            self.batch_args["project"] = account
 
     def format_batch_args(self):
         """Get the formatted batch arguments for a preview

--- a/smartsim/settings/lsfSettings.py
+++ b/smartsim/settings/lsfSettings.py
@@ -30,10 +30,10 @@ from .base import BatchSettings, RunSettings
 
 
 class JsrunSettings(RunSettings):
-    def __init__(self, exe, exe_args=None, run_args=None, env_vars=None):
+    def __init__(self, exe, exe_args=None, run_args=None, env_vars=None, **kwargs):
         """Settings to run job with ``jsrun`` command
 
-        ``JsrunSettings`` can be used for both the `lsf` launcher.
+        ``JsrunSettings`` should only be used on LSF-based systems.
 
         :param exe: executable
         :type exe: str
@@ -348,20 +348,14 @@ class BsubBatchSettings(BatchSettings):
 
         This sets ``-W``.
 
-        :param walltime: Time in hh:mm format, e.g. "10:00" for 10 hours
+        :param walltime: Time in hh:mm format, e.g. "10:00" for 10 hours,
+                         if time is supplied in hh:mm:ss format, seconds
+                         will be ignored and walltime will be set as ``hh:mm``
         :type walltime: str
         """
+        if walltime and len(walltime.split(":")) > 2:
+            walltime = ":".join(walltime.split(":")[:2])
         self.walltime = walltime
-
-    def set_queue(self, queue):
-        """Set the queue
-
-        This sets ``-q``.
-
-        :param queue: queue name
-        :type queue: str
-        """
-        self.batch_args["q"] = queue
 
     def set_smts(self, smts):
         """Set SMTs
@@ -386,7 +380,14 @@ class BsubBatchSettings(BatchSettings):
         self.project = project
 
     def set_account(self, account):
-        self.project = account
+        """Set the project
+
+        this function is an alias for `set_project`.
+
+        :param account: project name
+        :type account: str
+        """
+        self.set_project(account)
 
     def set_nodes(self, nodes):
         """Set the number of nodes for this batch job
@@ -435,6 +436,14 @@ class BsubBatchSettings(BatchSettings):
         """
         self.batch_args["n"] = int(tasks)
 
+    def set_queue(self, queue):
+        """Set the queue for this job
+
+        :param queue: The queue to submit the job on
+        :type queue: str
+        """
+        self.batch_args["q"] = queue
+
     def _format_alloc_flags(self):
         """Format ``alloc_flags`` checking if user already
         set it. Currently only adds SMT flag if missing
@@ -460,7 +469,7 @@ class BsubBatchSettings(BatchSettings):
     def format_batch_args(self):
         """Get the formatted batch arguments for a preview
 
-        :return: list of batch arguments for bsub
+        :return: list of batch arguments for Qsub
         :rtype: list[str]
         """
         opts = []

--- a/smartsim/settings/lsfSettings.py
+++ b/smartsim/settings/lsfSettings.py
@@ -333,6 +333,9 @@ class BsubBatchSettings(BatchSettings):
         """
         if project:
             kwargs.pop("account", None)
+        else:
+            project = kwargs.pop("account", None)
+            
         super().__init__("bsub",
                          batch_args=batch_args,
                          nodes=nodes,

--- a/smartsim/settings/lsfSettings.py
+++ b/smartsim/settings/lsfSettings.py
@@ -67,61 +67,90 @@ class JsrunSettings(RunSettings):
         else:
             self.run_args["nrs"] = int(num_rs)
 
-    def set_cpus_per_rs(self, num_cpus):
+    def set_cpus_per_rs(self, cpus_per_rs):
         """Set the number of cpus to use per resource set
 
         This sets ``--cpu_per_rs``
 
-        :param num_cpus: number of cpus to use per resource set or ALL_CPUS
-        :type num_cpus: int or str
+        :param cpus_per_rs: number of cpus to use per resource set or ALL_CPUS
+        :type cpus_per_rs: int or str
         """
-        if isinstance(num_cpus, str):
-            self.run_args["cpu_per_rs"] = num_cpus
+        if isinstance(cpus_per_rs, str):
+            self.run_args["cpu_per_rs"] = cpus_per_rs
         else:
-            self.run_args["cpu_per_rs"] = int(num_cpus)
+            self.run_args["cpu_per_rs"] = int(cpus_per_rs)
 
-    def set_gpus_per_rs(self, num_gpus):
+    def set_gpus_per_rs(self, gpus_per_rs):
         """Set the number of gpus to use per resource set
 
         This sets ``--gpu_per_rs``
 
-        :param num_cpus: number of gpus to use per resource set or ALL_GPUS
-        :type num_gpus: int or str
+        :param gpus_per_rs: number of gpus to use per resource set or ALL_GPUS
+        :type gpus_per_rs: int or str
         """
-        if isinstance(num_gpus, str):
-            self.run_args["gpu_per_rs"] = num_gpus
+        if isinstance(gpus_per_rs, str):
+            self.run_args["gpu_per_rs"] = gpus_per_rs
         else:
-            self.run_args["gpu_per_rs"] = int(num_gpus)
+            self.run_args["gpu_per_rs"] = int(gpus_per_rs)
 
-    def set_rs_per_host(self, num_rs):
+    def set_rs_per_host(self, rs_per_host):
         """Set the number of resource sets to use per host
 
         This sets ``--rs_per_host``
 
-        :param num_rs: number of resource sets to use per host
-        :type num_rs: int
+        :param rs_per_host: number of resource sets to use per host
+        :type rs_per_host: int
         """
-        self.run_args["rs_per_host"] = int(num_rs)
+        self.run_args["rs_per_host"] = int(rs_per_host)
 
-    def set_tasks(self, num_tasks):
+    def set_tasks(self, tasks):
         """Set the number of tasks for this job
 
         This sets ``--np``
 
-        :param num_tasks: number of tasks
-        :type num_tasks: int
+        :param tasks: number of tasks
+        :type tasks: int
         """
-        self.run_args["np"] = int(num_tasks)
+        self.run_args["np"] = int(tasks)
 
-    def set_tasks_per_rs(self, num_tprs):
+    def set_tasks_per_rs(self, tasks_per_rs):
         """Set the number of tasks per resource set
 
         This sets ``--tasks_per_rs``
 
-        :param num_tpn: number of tasks per resource set
-        :type num_tpn: int
+        :param tasks_per_rs: number of tasks per resource set
+        :type tasks_per_rs: int
         """
-        self.run_args["tasks_per_rs"] = int(num_tprs)
+        self.run_args["tasks_per_rs"] = int(tasks_per_rs)
+
+    def set_tasks_per_node(self, tasks_per_node):
+        """Set the number of tasks per resource set.
+         
+        This function is an alias for `set_tasks_per_rs`.
+
+        :param tasks_per_node: number of tasks per resource set
+        :type tasks_per_node: int
+        """
+        self.set_tasks_per_rs(tasks_per_node)
+
+    def set_hostlist(self, host_list):
+        """This function has no effect.
+
+        This function is only available to unify LSFSettings
+        to other WLM settings classes.
+        
+        """
+        pass
+
+    def set_cpus_per_task(self, cpus_per_task):
+        """Set the number of cpus per tasks.
+         
+        This function is an alias for `set_cpus_per_rs`.
+
+        :param cpus_per_task: number of cpus per resource set
+        :type cpus_per_task: int
+        """
+        self.set_cpus_per_rs(cpus_per_task)
 
     def set_binding(self, binding):
         """Set binding
@@ -314,15 +343,15 @@ class BsubBatchSettings(BatchSettings):
         self.expert_mode = False
         self.easy_settings = ["ln_slots", "ln_mem", "cn_cu", "nnodes"]
 
-    def set_walltime(self, time):
+    def set_walltime(self, walltime):
         """Set the walltime
 
         This sets ``-W``.
 
-        :param time: Time in hh:mm format, e.g. "10:00" for 10 hours
-        :type time: str
+        :param walltime: Time in hh:mm format, e.g. "10:00" for 10 hours
+        :type walltime: str
         """
-        self.walltime = time
+        self.walltime = walltime
 
     def set_smts(self, smts):
         """Set SMTs
@@ -346,15 +375,15 @@ class BsubBatchSettings(BatchSettings):
         """
         self.project = project
 
-    def set_nodes(self, num_nodes):
+    def set_nodes(self, nodes):
         """Set the number of nodes for this batch job
 
         This sets ``-nnodes``.
 
-        :param num_nodes: number of nodes
-        :type num_nodes: int
+        :param nodes: number of nodes
+        :type nodes: int
         """
-        self.batch_args["nnodes"] = int(num_nodes)
+        self.batch_args["nnodes"] = int(nodes)
 
     def set_expert_mode_req(self, res_req, slots):
         """Set allocation for expert mode. This
@@ -383,15 +412,15 @@ class BsubBatchSettings(BatchSettings):
             raise TypeError("host_list argument must be list of strings")
         self.batch_args["m"] = '"' + " ".join(host_list) + '"'
 
-    def set_tasks(self, num_tasks):
+    def set_tasks(self, tasks):
         """Set the number of tasks for this job
 
         This sets ``-n``
 
-        :param num_tasks: number of tasks
-        :type num_tasks: int
+        :param tasks: number of tasks
+        :type tasks: int
         """
-        self.batch_args["n"] = int(num_tasks)
+        self.batch_args["n"] = int(tasks)
 
     def _format_alloc_flags(self):
         """Format ``alloc_flags`` checking if user already

--- a/smartsim/settings/lsfSettings.py
+++ b/smartsim/settings/lsfSettings.py
@@ -388,7 +388,7 @@ class BsubBatchSettings(BatchSettings):
     def set_account(self, account):
         self.project = account
 
-    def set_nodes(self, num_nodes):
+    def set_nodes(self, nodes):
         """Set the number of nodes for this batch job
 
         This sets ``-nnodes``.

--- a/smartsim/settings/lsfSettings.py
+++ b/smartsim/settings/lsfSettings.py
@@ -331,11 +331,12 @@ class BsubBatchSettings(BatchSettings):
         :param smts: SMTs, defaults to None
         :type smts: int, optional
         """
-        super().__init__("bsub", batch_args=batch_args)
-        if nodes:
-            self.set_nodes(nodes)
-        self.set_walltime(time)
-        self.set_project(project)
+        super().__init__("bsub",
+         batch_args=batch_args,
+                         nodes=nodes,
+                         time=time, 
+                         **kwargs)
+
         if smts:
             self.set_smts(smts)
         else:
@@ -353,9 +354,11 @@ class BsubBatchSettings(BatchSettings):
                          will be ignored and walltime will be set as ``hh:mm``
         :type walltime: str
         """
-        if walltime and len(walltime.split(":")) > 2:
-            walltime = ":".join(walltime.split(":")[:2])
-        self.walltime = walltime
+        # For compatibility with other launchers, as explained in docstring
+        if walltime:
+            if len(walltime.split(":")) > 2:
+                walltime = ":".join(walltime.split(":")[:2])
+            self.walltime = walltime
 
     def set_smts(self, smts):
         """Set SMTs
@@ -387,9 +390,10 @@ class BsubBatchSettings(BatchSettings):
         :param account: project name
         :type account: str
         """
-        self.set_project(account)
+        if account:
+            self.set_project(account)
 
-    def set_nodes(self, nodes):
+    def set_nodes(self, num_nodes):
         """Set the number of nodes for this batch job
 
         This sets ``-nnodes``.
@@ -397,7 +401,8 @@ class BsubBatchSettings(BatchSettings):
         :param nodes: number of nodes
         :type nodes: int
         """
-        self.batch_args["nnodes"] = int(nodes)
+        if num_nodes:
+            self.batch_args["nnodes"] = int(num_nodes)
 
     def set_expert_mode_req(self, res_req, slots):
         """Set allocation for expert mode. This
@@ -442,7 +447,8 @@ class BsubBatchSettings(BatchSettings):
         :param queue: The queue to submit the job on
         :type queue: str
         """
-        self.batch_args["q"] = queue
+        if queue:
+            self.batch_args["q"] = queue
 
     def _format_alloc_flags(self):
         """Format ``alloc_flags`` checking if user already

--- a/smartsim/settings/lsfSettings.py
+++ b/smartsim/settings/lsfSettings.py
@@ -331,10 +331,13 @@ class BsubBatchSettings(BatchSettings):
         :param smts: SMTs, defaults to None
         :type smts: int, optional
         """
+        if project:
+            kwargs.pop("account", None)
         super().__init__("bsub",
-         batch_args=batch_args,
+                         batch_args=batch_args,
                          nodes=nodes,
-                         time=time, 
+                         account=project,
+                         time=time,
                          **kwargs)
 
         if smts:

--- a/smartsim/settings/pbsSettings.py
+++ b/smartsim/settings/pbsSettings.py
@@ -64,16 +64,18 @@ class QsubBatchSettings(BatchSettings):
         :param batch_args: overrides for PBS batch arguments, defaults to None
         :type batch_args: dict[str, str], optional
         """
-        super().__init__("qsub", batch_args=batch_args)
+
+        super().__init__("qsub", 
+                         batch_args=batch_args,
+                         nodes=nodes, 
+                         account=account, 
+                         queue=queue, 
+                         time=time, 
+                         **kwargs)
         self.resources = init_default({}, resources, dict)
-        self._nodes = nodes
-        self._time = time
+
         self._ncpus = ncpus
         self._hosts = None
-        if account:
-            self.set_account(account)
-        if queue:
-            self.set_queue(queue)
 
     def set_nodes(self, num_nodes):
         """Set the number of nodes for this batch job
@@ -84,7 +86,8 @@ class QsubBatchSettings(BatchSettings):
         :param num_nodes: number of nodes
         :type num_nodes: int
         """
-        self._nodes = int(num_nodes)
+        if num_nodes:
+            self._nodes = int(num_nodes)
 
     def set_hostlist(self, host_list):
         """Specify the hostlist for this job
@@ -113,7 +116,8 @@ class QsubBatchSettings(BatchSettings):
         :param walltime: wall time
         :type walltime: str
         """
-        self._time = walltime
+        if walltime:
+            self._time = walltime
 
     def set_queue(self, queue):
         """Set the queue for the batch job
@@ -121,7 +125,8 @@ class QsubBatchSettings(BatchSettings):
         :param queue: queue name
         :type queue: str
         """
-        self.batch_args["q"] = str(queue)
+        if queue:
+            self.batch_args["q"] = str(queue)
 
     def set_ncpus(self, num_cpus):
         """Set the number of cpus obtained in each node.
@@ -135,13 +140,14 @@ class QsubBatchSettings(BatchSettings):
         """
         self._ncpus = int(num_cpus)
 
-    def set_account(self, acct):
+    def set_account(self, account):
         """Set the account for this batch job
 
         :param acct: account id
         :type acct: str
         """
-        self.batch_args["A"] = str(acct)
+        if account:
+            self.batch_args["A"] = str(account)
 
     def set_resource(self, resource_name, value):
         """Set a resource value for the Qsub batch

--- a/smartsim/settings/settings.py
+++ b/smartsim/settings/settings.py
@@ -68,13 +68,8 @@ def create_batch_settings(
     try:
         batch_class = by_launcher[launcher]
         batch_settings = batch_class(
-            nodes=nodes, time=time, batch_args=batch_args, **kwargs
+            nodes=nodes, time=time, batch_args=batch_args, queue=queue, account=account, **kwargs
         )
-        # put these two in the init once classes like BsubBatch are unified
-        if queue:
-            batch_settings.set_queue(queue)
-        if account:
-            batch_settings.set_account(account)
         return batch_settings
 
     except KeyError:

--- a/smartsim/settings/slurmSettings.py
+++ b/smartsim/settings/slurmSettings.py
@@ -224,7 +224,6 @@ class SbatchSettings(BatchSettings):
         :param batch_args: extra batch arguments, defaults to None
         :type batch_args: dict[str, str], optional
         """
-        print("SbatchSettings", kwargs)
         super().__init__("sbatch",
                          batch_args=batch_args,
                          nodes=nodes, 

--- a/smartsim/settings/slurmSettings.py
+++ b/smartsim/settings/slurmSettings.py
@@ -224,13 +224,13 @@ class SbatchSettings(BatchSettings):
         :param batch_args: extra batch arguments, defaults to None
         :type batch_args: dict[str, str], optional
         """
-        super().__init__("sbatch", batch_args=batch_args)
-        if nodes:
-            self.set_nodes(nodes)
-        if time:
-            self.set_walltime(time)
-        if account:
-            self.set_account(account)
+        print("SbatchSettings", kwargs)
+        super().__init__("sbatch",
+                         batch_args=batch_args,
+                         nodes=nodes, 
+                         account=account, 
+                         time=time,  
+                         **kwargs)
 
     def set_walltime(self, walltime):
         """Set the walltime of the job
@@ -241,7 +241,8 @@ class SbatchSettings(BatchSettings):
         :type walltime: str
         """
         # TODO check for formatting here
-        self.batch_args["time"] = walltime
+        if walltime:
+            self.batch_args["time"] = walltime
 
     def set_nodes(self, num_nodes):
         """Set the number of nodes for this batch job
@@ -249,7 +250,8 @@ class SbatchSettings(BatchSettings):
         :param num_nodes: number of nodes
         :type num_nodes: int
         """
-        self.batch_args["nodes"] = int(num_nodes)
+        if num_nodes:
+            self.batch_args["nodes"] = int(num_nodes)
 
     def set_account(self, account):
         """Set the account for this batch job
@@ -257,7 +259,8 @@ class SbatchSettings(BatchSettings):
         :param account: account id
         :type account: str
         """
-        self.batch_args["account"] = account
+        if account:
+            self.batch_args["account"] = account
 
     def set_partition(self, partition):
         """Set the partition for the batch job
@@ -275,7 +278,8 @@ class SbatchSettings(BatchSettings):
         :param queue: the partition to run the batch job on
         :type queue: str
         """
-        self.set_partition(queue)
+        if queue:
+            self.set_partition(queue)
 
     def set_hostlist(self, host_list):
         """Specify the hostlist for this job

--- a/tests/backends/test_tf.py
+++ b/tests/backends/test_tf.py
@@ -43,7 +43,9 @@ def test_keras_model(fileutils, mlutils, wlmutils):
     run_settings = exp.create_run_settings(
         "python", f"run_tf.py --device={test_device}"
     )
-    run_settings.set_tasks(1)
+
+    if wlmutils.get_test_launcher() != "local":
+        run_settings.set_tasks(1)
     model = exp.create_model("tf_script", run_settings)
 
     script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/backends/test_tf.py
+++ b/tests/backends/test_tf.py
@@ -43,6 +43,7 @@ def test_keras_model(fileutils, mlutils, wlmutils):
     run_settings = exp.create_run_settings(
         "python", f"run_tf.py --device={test_device}"
     )
+    run_settings.set_tasks(1)
     model = exp.create_model("tf_script", run_settings)
 
     script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/backends/test_torch.py
+++ b/tests/backends/test_torch.py
@@ -40,7 +40,8 @@ def test_torch_model_and_script(fileutils, mlutils, wlmutils):
     run_settings = exp.create_run_settings(
         "python", f"run_torch.py --device={test_device}"
     )
-    run_settings.set_tasks(1)
+    if wlmutils.get_test_launcher() != "local":
+        run_settings.set_tasks(1)
     model = exp.create_model("torch_script", run_settings)
 
     script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/backends/test_torch.py
+++ b/tests/backends/test_torch.py
@@ -40,6 +40,7 @@ def test_torch_model_and_script(fileutils, mlutils, wlmutils):
     run_settings = exp.create_run_settings(
         "python", f"run_torch.py --device={test_device}"
     )
+    run_settings.set_tasks(1)
     model = exp.create_model("torch_script", run_settings)
 
     script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/full_wlm/test_generic_batch_launch.py
+++ b/tests/full_wlm/test_generic_batch_launch.py
@@ -20,6 +20,8 @@ def test_batch_ensemble(fileutils, wlmutils):
     M2 = exp.create_model("m2", path=test_dir, run_settings=settings)
 
     batch = exp.create_batch_settings(nodes=1, time="00:01:00")
+    if wlmutils.get_test_launcher() == "lsf":
+        batch.set_project(wlmutils.get_test_account())
     ensemble = exp.create_ensemble("batch-ens", batch_settings=batch)
     ensemble.add_model(M1)
     ensemble.add_model(M2)
@@ -39,6 +41,8 @@ def test_batch_ensemble_replicas(fileutils, wlmutils):
     settings = wlmutils.get_run_settings("python", f"{script} --time=5")
 
     batch = exp.create_batch_settings(nodes=1, time="00:01:00")
+    if wlmutils.get_test_launcher() == "lsf":
+        batch.set_project(wlmutils.get_test_account())
     ensemble = exp.create_ensemble(
         "batch-ens-replicas", batch_settings=batch, run_settings=settings, replicas=2
     )

--- a/tests/on_wlm/test_launch_orc_slurm.py
+++ b/tests/on_wlm/test_launch_orc_slurm.py
@@ -69,6 +69,10 @@ def test_launch_slurm_cluster_orc(fileutils, wlmutils):
 def test_incoming_entities(fileutils, wlmutils):
     """Mirroring of how SmartSim generates SSKEYIN"""
 
+    launcher = wlmutils.get_test_launcher()
+    if launcher != "slurm":
+        pytest.skip("Test only runs on systems with Slurm as WLM")
+        
     exp_name = "test-incoming-entities"
     exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir(exp_name)

--- a/tests/on_wlm/test_simple_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_simple_base_settings_on_wlm.py
@@ -24,8 +24,8 @@ if pytest.test_launcher not in pytest.wlm_options:
 
 def test_simple_model_on_wlm(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
-    if launcher not in ["pbs", "slurm", "cobalt"]:
-        pytest.skip("Test only runs on systems with PBSPro, Slurm, or Cobalt as WLM")
+    if launcher not in ["pbs", "slurm", "cobalt", "lsf"]:
+        pytest.skip("Test only runs on systems with LSF, PBSPro, Slurm, or Cobalt as WLM")
 
     exp_name = "test-simplebase-settings-model-launch"
     exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
@@ -43,8 +43,8 @@ def test_simple_model_on_wlm(fileutils, wlmutils):
 
 def test_simple_model_stop_on_wlm(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
-    if launcher not in ["pbs", "slurm", "cobalt"]:
-        pytest.skip("Test only runs on systems with PBSPro, Slurm, or Cobalt as WLM")
+    if launcher not in ["pbs", "slurm", "cobalt", "lsf"]:
+        pytest.skip("Test only runs on systems with LSF, PBSPro, Slurm, or Cobalt as WLM")
 
     exp_name = "test-simplebase-settings-model-stop"
     exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())


### PR DESCRIPTION
One function `set_hostlist` needs to `pass`, as this is only available (and already present) at batch level. The other two missing functions map the concept of node to that of RS, as it is the closest entity in LSF.