### PR TITLE
Refactor Orchestrator to launch in single command

### DIFF
--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -254,7 +254,7 @@ class Controller:
         """
         orchestrator = manifest.db
         if orchestrator:
-            if len(orchestrator) > 1 and isinstance(self._launcher, LocalLauncher):
+            if orchestrator.num_shards > 1 and isinstance(self._launcher, LocalLauncher):
                 raise SmartSimError(
                     "Local launcher does not support multi-host orchestrators"
                 )

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -317,7 +317,7 @@ class JobManager:
                 self.db_jobs[orchestrator.name].hosts = orchestrator.hosts
             else:
                 for dbnode in orchestrator:
-                    if not dbnode._multihost:
+                    if not dbnode._mpmd:
                         self.db_jobs[dbnode.name].hosts = [dbnode.host]
                     else:
                         self.db_jobs[dbnode.name].hosts = dbnode.hosts

--- a/smartsim/_core/launcher/step/alpsStep.py
+++ b/smartsim/_core/launcher/step/alpsStep.py
@@ -25,7 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-
+from shlex import split as sh_split
 from ....error import AllocationError
 from ....log import get_logger
 from .step import Step
@@ -112,4 +112,5 @@ class AprunStep(Step):
             cmd += mpmd.format_run_args()
             cmd += mpmd.exe
             cmd += mpmd.exe_args
+        cmd = sh_split(" ".join(cmd))
         return cmd

--- a/smartsim/_core/launcher/step/mpirunStep.py
+++ b/smartsim/_core/launcher/step/mpirunStep.py
@@ -29,6 +29,7 @@ import os
 from ....error import AllocationError
 from ....log import get_logger
 from .step import Step
+from shlex import split as sh_split
 
 logger = get_logger(__name__)
 
@@ -123,4 +124,6 @@ class MpirunStep(Step):
             cmd += mpmd.format_env_vars()
             cmd += mpmd.exe
             cmd += mpmd.exe_args
+        
+        cmd = sh_split(" ".join(cmd))
         return cmd

--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -125,7 +125,7 @@ class SrunStep(Step):
         :rtype: list[str]
         """
         srun = self.run_settings.run_command
-        output, error = self.get_output_files()
+        output, error = self.get_output_files(name_suffix=self.run_settings.suffix)
 
         srun_cmd = [srun, "--output", output, "--error", error, "--job-name", self.name]
 

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -44,10 +44,10 @@ class Step:
         step_name = entity_name + "-" + str(np.base_repr(time.time_ns(), 36))
         return step_name
 
-    def get_output_files(self):
+    def get_output_files(self, name_suffix=""):
         """Return two paths to error and output files based on cwd"""
-        output = self.get_step_file(ending=".out")
-        error = self.get_step_file(ending=".err")
+        output = self.get_step_file(ending=name_suffix+".out")
+        error = self.get_step_file(ending=name_suffix+".err")
         return output, error
 
     def get_step_file(self, ending=".sh"):

--- a/smartsim/database/lsfOrchestrator.py
+++ b/smartsim/database/lsfOrchestrator.py
@@ -285,7 +285,7 @@ class LSFOrchestrator(Orchestrator):
 
         run_settings = self._build_run_settings("python", exe_args, **kwargs)
         node = DBNode(self.name, self.path, run_settings, ports)
-        node._multihost = True
+        node._mpmd = True
         node._shard_ids = range(db_nodes)
         self.entities.append(node)
         self.ports = ports

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -31,9 +31,6 @@ from pathlib import Path
 
 import psutil
 import redis
-from ..database import CobaltOrchestrator, PBSOrchestrator, SlurmOrchestrator, LSFOrchestrator
-
-from ..wlm import detect_launcher
 
 from .._core.config import CONFIG
 from .._core.utils import check_cluster_status
@@ -42,6 +39,7 @@ from ..entity import DBNode, EntityList
 from ..error import SmartSimError, SSConfigError, SSInternalError
 from ..log import get_logger
 from ..settings.base import RunSettings
+from ..wlm import detect_launcher
 
 logger = get_logger(__name__)
 
@@ -305,21 +303,21 @@ def create_orchestrator(launcher="auto",
         raise SmartSimError(msg)
 
     if run_command == "auto":
-        _detect_command(launcher)
+        run_command = _detect_command(launcher)
     else:
         if run_command not in by_launcher[launcher]:
             msg = f"Run command {run_command} is not supported by launcher {launcher}\n"
             msg+= f"Supported run commands are: {by_launcher[launcher]}"
             raise SmartSimError(msg)
 
-    
+    from . import CobaltOrchestrator, PBSOrchestrator, SlurmOrchestrator, LSFOrchestrator    
     launcher_class = {'local': Orchestrator,
                       'slurm': SlurmOrchestrator,
                       'pbs': PBSOrchestrator,
                       'cobalt': CobaltOrchestrator,
                       'lsf': LSFOrchestrator}
 
-    return launcher_class(
+    return launcher_class[launcher](
                           launcher=launcher,
                           port=port,
                           db_nodes=db_nodes,

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -250,7 +250,7 @@ class Orchestrator(EntityList):
     def _get_db_hosts(self):
         hosts = []
         for dbnode in self.entities:
-            if not dbnode._multihost:
+            if not dbnode._mpmd:
                 hosts.append(dbnode.host)
             else:
                 hosts.extend(dbnode.hosts)

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -269,8 +269,7 @@ class Orchestrator(EntityList):
             logger.warning(f"Found network interfaces are: {available}")
 
 
-def create_orchestrator(launcher="auto",
-                        port=6379,
+def create_orchestrator(port=6379,
                         db_nodes=1,
                         batch=True,
                         hosts=None,
@@ -280,8 +279,40 @@ def create_orchestrator(launcher="auto",
                         time=None,
                         queue=None,
                         single_cmd=True,
+                        launcher="auto",
                         **kwargs,
                         ):
+    """Create an Orchestrator
+
+    See Experiment.create_orchestrator for more details
+
+    :param launcher: launcher used to start the orchestrator, defaults to "auto"
+    :type launcher: str, optional
+    :param port: TCP/IP port, defaults to 6379
+    :type port: int, optional
+    :param db_nodes: numver of database shards, defaults to 1
+    :type db_nodes: int, optional
+    :param batch: Run as a batch workload, defaults to True
+    :type batch: bool, optional
+    :param hosts: specify hosts to launch on, defaults to None
+    :type hosts: list[str], optional
+    :param run_command: specify launch binary or detect automatically, defaults to "auto"
+    :type run_command: str, optional
+    :param interface: Network interface, defaults to "ipogif0"
+    :type interface: str, optional
+    :param account: account to run batch on, defaults to None
+    :type account: str, optional
+    :param time: walltime for batch 'HH:MM:SS' format, defaults to None
+    :type time: str, optional
+    :param queue: queue to run the batch on, defaults to None
+    :type queue: str, optional
+    :param single_cmd: run all shards with one (MPMD) command, defaults to True
+    :type single_cmd: bool, optional
+    :raises SmartSimError: If detection of launcher or of run command fails
+    :raises SmartSimError: If user indicated an incompatible run command for the launcher
+    :return: Orchestrator
+    :rtype: Orchestrator or derived class
+    """
 
     if launcher == "auto":
         launcher = detect_launcher()

--- a/smartsim/database/pbsOrchestrator.py
+++ b/smartsim/database/pbsOrchestrator.py
@@ -146,7 +146,7 @@ class PBSOrchestrator(Orchestrator):
         if self.batch:
             self.batch_settings.set_hostlist(host_list)
         for host, db in zip(host_list, self.entities):
-            db.set_host(host)
+            #db.set_host(host)
 
             # Aprun doesn't like settings hosts in batch launch
             if isinstance(db.run_settings, AprunSettings):
@@ -154,6 +154,10 @@ class PBSOrchestrator(Orchestrator):
                     db.run_settings.set_hostlist([host])
             else:
                 db.run_settings.set_hostlist([host])
+
+            if db._mpmd:
+                for i, mpmd_runsettings in enumerate(db.run_settings.mpmd):
+                    mpmd_runsettings.set_hostlist(host_list[i+1])
 
     def set_batch_arg(self, arg, value):
         """Set a ``qsub`` argument the ``PBSOrchestrator`` should launch with
@@ -260,9 +264,7 @@ class PBSOrchestrator(Orchestrator):
         db_nodes = kwargs.get("db_nodes", 1)
         self.db_nodes = db_nodes
         single_cmd = kwargs.get("single_cmd", True)
-
         mpmd_nodes = single_cmd and db_nodes>1
-
         cluster = not bool(db_nodes < 3)
         if int(db_nodes) == 2:
             raise SSUnsupportedError(

--- a/smartsim/database/slurmOrchestrator.py
+++ b/smartsim/database/slurmOrchestrator.py
@@ -153,12 +153,10 @@ class SlurmOrchestrator(Orchestrator):
             self.batch_settings.set_hostlist(host_list)
         
         for host, db in zip(host_list, self.entities):
+            db.run_settings.set_hostlist([host])
             if db._mpmd:
-                db.run_settings.set_hostlist([host])
                 for i, mpmd_runsettings in enumerate(db.run_settings.mpmd):
                     mpmd_runsettings.set_hostlist(host_list[i+1])
-            else:
-                db.run_settings.set_hostlist([host])
 
     def set_batch_arg(self, arg, value):
         """Set a Sbatch argument the orchestrator should launch with

--- a/smartsim/database/slurmOrchestrator.py
+++ b/smartsim/database/slurmOrchestrator.py
@@ -83,6 +83,8 @@ class SlurmOrchestrator(Orchestrator):
         :type alloc: str, optional
         :param db_per_host: number of database shards per system host (MPMD), defaults to 1
         :type db_per_host: int, optional
+        :param single_cmd: run all shards with one (MPMD) command, defaults to True
+        :type single_cmd: bool
         """
         super().__init__(
             port,

--- a/smartsim/database/slurmOrchestrator.py
+++ b/smartsim/database/slurmOrchestrator.py
@@ -154,14 +154,10 @@ class SlurmOrchestrator(Orchestrator):
         
         for host, db in zip(host_list, self.entities):
             if db._mpmd:
-                # Hack for Osprey, have to investigate
-                db.set_hosts([host+"-ib" for host in host_list])
                 db.run_settings.set_hostlist([host])
                 for i, mpmd_runsettings in enumerate(db.run_settings.mpmd):
                     mpmd_runsettings.set_hostlist(host_list[i+1])
             else:
-                # Hack for Osprey, have to investigate
-                db.set_host(host+"-ib")
                 db.run_settings.set_hostlist([host])
 
     def set_batch_arg(self, arg, value):

--- a/smartsim/entity/dbnode.py
+++ b/smartsim/entity/dbnode.py
@@ -60,7 +60,7 @@ class DBNode(SmartSimEntity):
         return self._host
 
     @property
-    def hosts(self):  # cov-lsf
+    def hosts(self):
         if not self._hosts:
             self._hosts = self._parse_db_hosts()
         return self._hosts
@@ -68,7 +68,7 @@ class DBNode(SmartSimEntity):
     def set_host(self, host):
         self._host = str(host)
 
-    def set_hosts(self, hosts):  # cov-lsf
+    def set_hosts(self, hosts):
         self._hosts = [str(host) for host in hosts]
 
     def remove_stale_dbnode_files(self):
@@ -165,7 +165,7 @@ class DBNode(SmartSimEntity):
 
         return ip
 
-    def _parse_db_hosts(self):  # cov-lsf
+    def _parse_db_hosts(self):
         """Parse the database hosts/IPs from the output files
 
         this uses the RedisIP module that is built as a dependency

--- a/smartsim/entity/dbnode.py
+++ b/smartsim/entity/dbnode.py
@@ -49,7 +49,7 @@ class DBNode(SmartSimEntity):
         self.ports = ports
         self._host = None
         super().__init__(name, path, run_settings)
-        self._multihost = False
+        self._mpmd = False
         self._shard_ids = None
         self._hosts = None
 
@@ -78,7 +78,7 @@ class DBNode(SmartSimEntity):
         """
 
         for port in self.ports:
-            if not self._multihost:
+            if not self._mpmd:
                 conf_file = osp.join(self.path, self._get_cluster_conf_filename(port))
                 if osp.exists(conf_file):
                     os.remove(conf_file)
@@ -95,7 +95,7 @@ class DBNode(SmartSimEntity):
             file_name = osp.join(self.path, self.name + file_ending)
             if osp.exists(file_name):
                 os.remove(file_name)
-        if self._multihost:
+        if self._mpmd:
             for file_ending in [".err", ".out"]:
                 for shard_id in self._shard_ids:
                     file_name = osp.join(
@@ -117,7 +117,7 @@ class DBNode(SmartSimEntity):
     def _get_cluster_conf_filenames(self, port):  # cov-lsf
         """Returns the .conf file name for the given port number
 
-        This function should bu used if and only if ``_multihost==True``
+        This function should bu used if and only if ``_mpmd==True``
 
         :param port: port number
         :type port: int
@@ -171,7 +171,7 @@ class DBNode(SmartSimEntity):
         this uses the RedisIP module that is built as a dependency
         The IP address is preferred, but if hostname is only present
         then a lookup to /etc/hosts is done through the socket library.
-        This function must be called only if ``_multihost==True``.
+        This function must be called only if ``_mpmd==True``.
 
         :raises SmartSimError: if host/ip could not be found
         :return: ip addresses | hostnames

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -448,22 +448,54 @@ class Experiment:
 
 
     def create_orchestrator(self,
-                        launcher="auto",
-                        port=6379,
-                        db_nodes=1,
-                        batch=True,
-                        hosts=None,
-                        run_command="auto",
-                        interface="ipogif0",
-                        account=None,
-                        time=None,
-                        queue=None,
-                        single_cmd=True,
-                        **kwargs,
-                        ):
+                            port=6379,
+                            db_nodes=1,
+                            batch=True,
+                            hosts=None,
+                            run_command="auto",
+                            interface="ipogif0",
+                            account=None,
+                            time=None,
+                            queue=None,
+                            single_cmd=True,
+                            launcher="auto",
+                            **kwargs,
+                           ):
+        """Create an Orchestrator
 
-        return orchestrator.create_orchestrator(launcher=launcher,
-                                                port=port,
+        The returned object is an instance of a sub-class of Orchestrator,
+        such as SlurmOrchestrator, PBSOrchestrator, LSFOrchestrator, or CobaltOrchestrator,
+        depending on the selected (or detected) launcher. See corresponding documentation
+        for more details.
+
+        :param launcher: launcher used to start the orchestrator, defaults to "auto"
+        :type launcher: str, optional
+        :param port: TCP/IP port, defaults to 6379
+        :type port: int, optional
+        :param db_nodes: numver of database shards, defaults to 1
+        :type db_nodes: int, optional
+        :param batch: Run as a batch workload, defaults to True
+        :type batch: bool, optional
+        :param hosts: specify hosts to launch on, defaults to None
+        :type hosts: list[str], optional
+        :param run_command: specify launch binary or detect automatically, defaults to "auto"
+        :type run_command: str, optional
+        :param interface: Network interface, defaults to "ipogif0"
+        :type interface: str, optional
+        :param account: account to run batch on, defaults to None
+        :type account: str, optional
+        :param time: walltime for batch 'HH:MM:SS' format, defaults to None
+        :type time: str, optional
+        :param queue: queue to run the batch on, defaults to None
+        :type queue: str, optional
+        :param single_cmd: run all shards with one (MPMD) command, defaults to True
+        :type single_cmd: bool, optional
+        :raises SmartSimError: If detection of launcher or of run command fails
+        :raises SmartSimError: If user indicated an incompatible run command for the launcher
+        :return: Orchestrator
+        :rtype: Orchestrator or derived class
+        """
+        return orchestrator.create_orchestrator(port=port,
                                                 db_nodes=db_nodes,
                                                 batch=batch,
                                                 hosts=hosts,
@@ -473,6 +505,7 @@ class Experiment:
                                                 time=time,
                                                 queue=queue,
                                                 single_cmd=single_cmd,
+                                                launcher=launcher,
                                                 **kwargs)
 
     def reconnect_orchestrator(self, checkpoint):

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -34,6 +34,7 @@ from tqdm import trange
 
 from ._core import Controller, Generator, Manifest
 from ._core.utils import colorize, init_default
+from .database import orchestrator
 from .entity import Ensemble, Model
 from .error import SmartSimError
 from .log import get_logger
@@ -444,6 +445,35 @@ class Experiment:
         except SmartSimError as e:
             logger.error(e)
             raise
+
+
+    def create_orchestrator(self,
+                        launcher="auto",
+                        port=6379,
+                        db_nodes=1,
+                        batch=True,
+                        hosts=None,
+                        run_command="auto",
+                        interface="ipogif0",
+                        account=None,
+                        time=None,
+                        queue=None,
+                        single_cmd=True,
+                        **kwargs,
+                        ):
+
+        return orchestrator.create_orchestrator(launcher=launcher,
+                                                port=port,
+                                                db_nodes=db_nodes,
+                                                batch=batch,
+                                                hosts=hosts,
+                                                run_command=run_command,
+                                                interface=interface,
+                                                account=account,
+                                                time=time,
+                                                queue=queue,
+                                                single_cmd=single_cmd,
+                                                **kwargs)
 
     def reconnect_orchestrator(self, checkpoint):
         """Reconnect to a running ``Orchestrator``

--- a/smartsim/settings/settings.py
+++ b/smartsim/settings/settings.py
@@ -26,6 +26,7 @@
 
 from .._core.utils.helpers import is_valid_cmd
 from ..error import SmartSimError
+from ..wlm import detect_launcher
 from . import *
 
 

--- a/smartsim/settings/slurmSettings.py
+++ b/smartsim/settings/slurmSettings.py
@@ -61,6 +61,7 @@ class SrunSettings(RunSettings):
         )
         self.alloc = alloc
         self.mpmd = False
+        self.suffix = ""
 
     def set_nodes(self, nodes):
         """Set the number of nodes
@@ -201,6 +202,21 @@ class SrunSettings(RunSettings):
                 format_str += "=".join((k, str(v))) + ","
         return format_str.rstrip(","), comma_separated_format_str
 
+    def set_output_suffix(self, suffix=""):
+        """Add a special suffix to output and error files
+
+        Normally, output (error) file name is entity_name+".out"
+        (entity_name+".err"). The suffix will be inserted
+        before the file extension, to allow for special characters
+        such as "%t" and "%o" 
+        (see https://slurm.schedmd.com/srun.html#OPT_filename-pattern).
+
+        :param suffix: Suffix to append to file name, defaults to ""
+        :type suffix: str, optional
+        """
+
+        if suffix:
+            self.suffix = suffix
 
 class SbatchSettings(BatchSettings):
     def __init__(self, nodes=None, time="", account=None, batch_args=None, **kwargs):

--- a/tests/full_wlm/test_generic_batch_launch.py
+++ b/tests/full_wlm/test_generic_batch_launch.py
@@ -21,7 +21,10 @@ def test_batch_ensemble(fileutils, wlmutils):
 
     batch = exp.create_batch_settings(nodes=1, time="00:01:00")
     if wlmutils.get_test_launcher() == "lsf":
-        batch.set_project(wlmutils.get_test_account())
+        batch.set_account(wlmutils.get_test_account())
+    if wlmutils.get_test_launcher() == "cobalt":
+        batch.set_account(wlmutils.get_test_account())
+        batch.set_queue("debug-flat-quad")
     ensemble = exp.create_ensemble("batch-ens", batch_settings=batch)
     ensemble.add_model(M1)
     ensemble.add_model(M2)
@@ -42,7 +45,10 @@ def test_batch_ensemble_replicas(fileutils, wlmutils):
 
     batch = exp.create_batch_settings(nodes=1, time="00:01:00")
     if wlmutils.get_test_launcher() == "lsf":
-        batch.set_project(wlmutils.get_test_account())
+        batch.set_account(wlmutils.get_test_account())
+    if wlmutils.get_test_launcher() == "cobalt":
+        batch.set_account(wlmutils.get_test_account())
+        batch.set_queue("debug-cache-quad")
     ensemble = exp.create_ensemble(
         "batch-ens-replicas", batch_settings=batch, run_settings=settings, replicas=2
     )

--- a/tests/full_wlm/with_ray/test_ray_batch.py
+++ b/tests/full_wlm/with_ray/test_ray_batch.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import time
 from os import environ
+import os.path as osp
 
 import pytest
 
@@ -50,25 +51,32 @@ def test_ray_launch_and_shutdown_batch(fileutils, wlmutils, caplog):
         batch_args={"A": wlmutils.get_test_account(), "queue": "debug-flat-quad"}
         if launcher == "cobalt"
         else None,
+        time="00:05:00"
     )
 
     exp.generate(cluster)
-    exp.start(cluster, block=False, summary=True)
-    ctx = ray.init("ray://" + cluster.get_head_address() + ":10001")
 
-    right_resources = False
-    trials = 10
-    while not right_resources and trials > 0:
-        right_resources = (len(ray.nodes()), ray.cluster_resources()["CPU"]) == (2, 8)
-        trials -= 1
-        time.sleep(1)
+    try:
+        exp.start(cluster, block=False, summary=True)
+        ctx = ray.init("ray://" + cluster.get_head_address() + ":10001")
 
-    if not right_resources:
+        right_resources = False
+        trials = 10
+        while not right_resources and trials > 0:
+            right_resources = (len(ray.nodes()), ray.cluster_resources()["CPU"]) == (2, 8)
+            trials -= 1
+            time.sleep(1)
+
+        if not right_resources:
+            ctx.disconnect()
+            ray.shutdown()
+            exp.stop(cluster)
+            assert False
+
         ctx.disconnect()
         ray.shutdown()
         exp.stop(cluster)
+    except:
+        # Catch all errors, most of which can come from Ray
+        exp.stop(cluster)
         assert False
-
-    ctx.disconnect()
-    ray.shutdown()
-    exp.stop(cluster)

--- a/tests/on_wlm/test_launch_orc_cobalt.py
+++ b/tests/on_wlm/test_launch_orc_cobalt.py
@@ -24,16 +24,16 @@ def test_launch_cobalt_orc(fileutils, wlmutils):
     orc.set_path(test_dir)
 
     exp.start(orc, block=True)
-    status = exp.get_status(orc)
+    statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in status:
+    if status.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
-    status = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in status])
+    statuses = exp.get_status(orc)
+    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
 
 
 def test_launch_cobalt_cluster_orc(fileutils, wlmutils):
@@ -58,13 +58,13 @@ def test_launch_cobalt_cluster_orc(fileutils, wlmutils):
     orc.set_path(test_dir)
 
     exp.start(orc, block=True)
-    status = exp.get_status(orc)
+    statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in status:
+    if status.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
-    status = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in status])
+    statuses = exp.get_status(orc)
+    assert all([stat == status.STATUS_CANCELLED for stat in statuses])

--- a/tests/on_wlm/test_launch_orc_pbs.py
+++ b/tests/on_wlm/test_launch_orc_pbs.py
@@ -24,16 +24,16 @@ def test_launch_pbs_orc(fileutils, wlmutils):
     orc.set_path(test_dir)
 
     exp.start(orc, block=True)
-    status = exp.get_status(orc)
+    statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in status:
+    if status.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
-    status = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in status])
+    statuses = exp.get_status(orc)
+    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
 
 
 def test_launch_pbs_cluster_orc(fileutils, wlmutils):
@@ -61,13 +61,13 @@ def test_launch_pbs_cluster_orc(fileutils, wlmutils):
     orc.set_path(test_dir)
 
     exp.start(orc, block=True)
-    status = exp.get_status(orc)
+    statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in status:
+    if status.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
-    status = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in status])
+    statuses = exp.get_status(orc)
+    assert all([stat == status.STATUS_CANCELLED for stat in statuses])


### PR DESCRIPTION
This PR adds a new `single_cmd` option to all Orchestrators. The single-cmd launch is based on the underlying MPMD mechanism (depending on the launcher).

Also, in this PR, the new `Experiment.create_orchestrator` function was introduced.