### PR TITLE
Remove numpy

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ smartredis>=0.1.1
 redis==3.5.3
 redis-py-cluster==2.1.3
 sphinx==3.1.1
-numpy>=1.18.2
+numpy~=1.19.2
 tqdm>=4.50.2
 psutil>=5.7.2
 tabulate>=0.8.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ smartredis>=0.1.1
 redis==3.5.3
 redis-py-cluster==2.1.3
 sphinx==3.1.1
-numpy~=1.19.2
 tqdm>=4.50.2
 psutil>=5.7.2
 tabulate>=0.8.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ tabulate>=0.8.9
 smartredis>=0.1.1
 redis==3.5.3
 redis-py-cluster==2.1.3
-numpy>=1.18.2
 tqdm>=4.50.2

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,6 @@ deps = [
     "tabulate>=0.8.9",
     "redis-py-cluster==2.1.3",
     "redis==3.5.3",
-    "numpy>=1.18.2",
     "tqdm>=4.50.2"
 ]
 

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -27,7 +27,7 @@
 import os.path as osp
 import time
 
-import numpy as np
+from ...utils.helpers import get_base_36_repr
 
 
 class Step:
@@ -41,7 +41,7 @@ class Step:
         raise NotImplementedError
 
     def _create_unique_name(self, entity_name):
-        step_name = entity_name + "-" + str(np.base_repr(time.time_ns(), 36))
+        step_name = entity_name + "-" + get_base_36_repr(time.time_ns())
         return step_name
 
     def get_output_files(self):

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -41,7 +41,7 @@ def get_base_36_repr(positive_int):
     :return: base 36 representation of the given positive int
     :rtype: str
     """
-    digits = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     result = []
 
     while positive_int:
@@ -49,7 +49,7 @@ def get_base_36_repr(positive_int):
         result.append(next_digit)
         positive_int //= 36
 
-    return ''.join(reversed(result))
+    return "".join(reversed(result))
 
 
 def get_ip_from_host(host):

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -34,6 +34,24 @@ from shutil import which
 import psutil
 
 
+def get_base_36_repr(positive_int):
+    """Converts a positive integer to its base 36 representation
+    :param positive_int: the positive integer to convert
+    :type positive_int: int
+    :return: base 36 representation of the given positive int
+    :rtype: str
+    """
+    digits = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    result = []
+
+    while positive_int:
+        next_digit = digits[positive_int % 36]
+        result.append(next_digit)
+        positive_int //= 36
+
+    return ''.join(reversed(result))
+
+
 def get_ip_from_host(host):
     """Return the IP address for the interconnect.
 


### PR DESCRIPTION
# Description
This PR removes the numpy dependency from SmartSim since SmartRedis already has numpy as a dependency. `step.py` needed to be altered such that it does not use numpy to generate a unique string. numpy was also removed from `requirements.txt`, `requirements-dev.txt`, and `setup.py`.