### PR TITLE
Add RAI checker for installed backends

### DIFF
--- a/doc/api/smartsim_api.rst
+++ b/doc/api/smartsim_api.rst
@@ -415,7 +415,6 @@ in an interactive allocation.
 Model
 =====
 
-
 .. currentmodule:: smartsim.entity.model
 
 .. autosummary::
@@ -455,22 +454,65 @@ Ensemble
    :inherited-members:
 
 
+Machine Learning
+================
+
+.. _ml_api:
+
+SmartSim includes built-in utilities for supporting TensorFlow, Keras, and Pytorch.
+
 TensorFlow
-==========
+----------
 
 .. _smartsim_tf_api:
 
-SmartSim includes built-in utilities for supporting TensorFlow and Keras in SmartSim.
+SmartSim includes built-in utilities for supporting TensorFlow and Keras in training and inference.
 
-.. currentmodule:: smartsim.tf.utils
+.. currentmodule:: smartsim.ml.tf.utils
 
 .. autosummary::
 
     freeze_model
 
-.. automodule:: smartsim.tf.utils
+.. automodule:: smartsim.ml.tf.utils
     :members:
 
+
+.. currentmodule:: smartsim.ml.tf.data
+
+.. autoclass:: StaticDataGenerator
+   :show-inheritance:
+   :inherited-members:
+   :members:
+
+.. autoclass:: DataGenerator
+   :members:
+   :show-inheritance:
+   :inherited-members:
+
+PyTorch
+----------
+
+.. _smartsim_torch_api:
+
+SmartSim includes built-in utilities for supporting PyTorch in training and inference.
+
+.. currentmodule:: smartsim.ml.torch.data
+
+.. autoclass:: StaticDataGenerator
+   :members:
+   :show-inheritance:
+   :inherited-members:
+
+.. autoclass:: DataGenerator
+   :members:
+   :show-inheritance:
+   :inherited-members:
+
+.. autoclass:: DataLoader
+   :members:
+   :show-inheritance:
+   :inherited-members:
 
 Slurm
 =====

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,7 +17,8 @@
    tutorials/02_using_clients
    tutorials/03_lattice_boltz_analysis
    tutorials/04_inference
-   tutorials/05_starting_ray/05_starting_ray_builtin
+   tutorials/05_training
+   tutorials/06_starting_ray/06_starting_ray_builtin
 
 
 .. toctree::

--- a/doc/tutorials/04_inference.rst
+++ b/doc/tutorials/04_inference.rst
@@ -348,3 +348,4 @@ RandomForestRegressor. As with the other examples, the skl2onnx function
     client.set_model("rf_regressor", model, "ONNX", device="CPU")
     client.run_model("rf_regressor", inputs="input", outputs="output")
     print(client.get_tensor("output"))
+

--- a/doc/tutorials/05_training.rst
+++ b/doc/tutorials/05_training.rst
@@ -1,0 +1,153 @@
+
+=============================
+Online training with SmartSim
+=============================
+
+A SmartSim ``Orchestrator`` can be used to store and retrieve samples and targets used to
+train a ML model. A typical example is one in which one simulation produces samples at
+each time step and another application needs to download the samples as they are produced 
+to train a Deep Neural Network (e.g. a surrogate model).
+
+In this section, we will use components implemented in ``smartsim.ml.tf.data``, to train a
+Neural Network implemented in TensorFlow and Keras. In particular, we will be using
+two classes:
+- ``smartsim.ml.data.TrainingUploader`` which streamlines the uploading of samples and corresponding targets to the DB
+- ``smartsim.ml.tf.data.DataGenerator`` which is a Keras ``Generator`` which can be used to train a DNN,
+and will download the samples from the DB updating the training set at the end of each epoch.
+
+The SmartSim ``Experiment`` will consist in one mock simulation (the ``producer``) uploading samples,
+and one application (the ``training_service``) downloading the samples to train a DNN.
+
+A richer example, entirely implemented in Python, is available as a Jupyter Notebook in the
+``tutorials`` section of the SmartSim repository.
+An equivalent example using PyTorch instead of TensorFlow is available in the same directory.
+
+
+5.1.1 Producing and uploading the samples
+-----------------------------------------
+
+.. _ml_training_producer_code:
+
+The first application in the workflow, the ``producer`` will upload batches of samples at regular intervals,
+mimicking the behavior of an iterative simulation. 
+
+Since the ``training_service`` will use a ``smartsim.ml.tf.DataGenerator`` two download the samples, their
+keys need to follow a pre-defined format. Assuming that only one process in the simulation
+uploads the data, this format is ``<sample_prefix>_<iteration>``. And for targets
+(which can also be integer labels), the key format is ``<target_prefix>_<iteration>``. Both ``<sample_prefix>``
+and ``<target_prefix>`` are user-defined, and will need to be used to initialize the
+``smartsim.ml.tf.DataGenerator`` object.
+
+Assuming the simulation is written in Python, then the code would look like
+
+.. code-block:: python
+
+    from SmartRedis import Client
+    # simulation initialization code
+    client = Client(cluster=False, address=None)
+
+    for iteration in range(num_iterations):
+        # simulation code producing two tensors, data_points
+        # and data_values
+        client.put_tensor(f"points_{iteration}", data_points)
+        client.put_tensor(f"values_{iteration}", data_values)
+
+
+For simple simulations, this is sufficient. But if the simulation
+uses MPI, then each rank could upload a portion of the data set. In that case,
+the format for sample and target keys will be ``<sample_prefix>_<sub-index>_<iteration>``
+and ``<target_prefix>_<sub-index>_<iteration>``, where ``<sub_index>`` can be, e.g.
+the MPI rank id.
+
+
+5.1.2 Downloading the samples and training the model
+----------------------------------------------------
+
+The second part of the workflow is the ``training_service``, an application that
+downloads the data uploaded by the ``producer`` and uses them to train a ML model.
+Most importantly, the ``training_service`` needs to keep looking for new samples,
+and download them as they are available. The training data set size thus needs to grow at
+each ``producer`` iteration.
+
+In Keras, a ``Sequence`` represents a data set and can be passed to ``model.fit()``.
+The class ``smartsim.ml.tf.DataGenerator`` is a Keras ``Sequence``, which updates
+its data set at the end of each training epoch, looking for newly produced batches of samples.
+A current limitation of the TensorFlow training algorithm is that it does not take
+into account changes of size in the data sets once the training has started, i.e. it is always
+assumed that the training (and validation) data does not change during the training. To
+overcome this limitation, we need to train one epoch at the time. Thus, 
+following what we defined in the :ref:`producer section <ml_training_produced_code>`,
+the ``training_service`` would look like
+
+.. code-block:: python
+
+    from smartsim.ml.tf.data import DataGenerator
+    generator = DataGenerator(
+        sample_prefix="points",
+        target_prefix="value",
+        batch_size=32,
+        cluster=False)
+
+    model = # some ML model
+    # model initialization
+
+    for epoch in range(100):
+        model.fit(generator,
+                  steps_per_epoch=None, 
+                  epochs=epoch+1,
+                  initial_epoch=epoch, 
+                  batch_size=generator.batch_size,
+                  verbose=2)
+
+
+Again, this is enough for simple simulations. If the simulation uses MPI,
+then the ``DataGenerator`` needs to know about the possible sub-indices. For example,
+if the simulation runs 8 MPI ranks, the ``DataGenerator`` initialization will
+need to be adapted as follows
+
+.. code-block:: python
+
+    generator = DataGenerator(
+        sample_prefix="points",
+        target_prefix="value",
+        batch_size=32,
+        cluster=False,
+        uploader_ranks=8)
+
+
+5.1.3 Launching the experiment
+------------------------------
+
+To launch the ``producer`` and the ``training_service`` as models
+within a SmartSim ``Experiment``, we can use the following code:
+
+.. code-block:: python
+    
+    from smartsim import Experiment
+    from smartsim.database import Orchestrator
+
+    db = Orchestrator(port=6780)
+    exp = Experiment("online-training", launcher="local")
+
+    # producer
+    producer_script = "producer.py"
+    settings = exp.create_run_settings("python", exe_args=producer_script)
+    uploader_model = exp.create_model("producer", settings, enable_key_prefixing=True)
+    uploader_model.attach_generator_files(to_copy=producer_script)
+
+    # training_service
+    training_script = "training_service.py"
+    settings = exp.create_run_settings("python", exe_args=training_script)
+    trainer_model = exp.create_model("training_service", settings)
+    trainer_model.register_incoming_entity(uploader_model)
+
+    exp.start(db, uploader_model, block=False, summary=False)
+    exp.start(trainer_model, block=True, summary=False)
+
+
+Two lines require attention, as they are needed by the ``DataGenerator`` to work:
+- ``uploader_model.enable_key_prefixing()`` will ensure that the ``producer`` prefixes
+all tensor keys with its name
+- ``trainer_model.register_incoming_entity(uploader_model)`` enables the ``DataGenerator``
+in the ``training_service`` to know that it needs to download samples produced by the ``producer``
+

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -27,7 +27,6 @@
 import os
 from functools import lru_cache
 from pathlib import Path
-from typing import List
 
 import psutil
 

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -171,20 +171,6 @@ class Config:
         # no account by default
         return os.environ.get("SMARTSIM_TEST_ACCOUNT", "")
 
-    @property
-    def installed_backends(self) -> List[str]:
-        installed = []
-        backends_path = self.lib_path / "backends"
-        for backend in ["tensorflow", "torch", "onnx"]:
-            backend_path = (
-                backends_path / f"redisai_{backend}" / f"redisai_{backend}.so"
-            )
-            backend_so = Path(os.environ.get("RAI_PATH", backend_path)).resolve()
-            if backend_so.is_file():
-                installed.append(backend)
-
-        return installed
-
 
 @lru_cache(maxsize=128, typed=False)
 def get_config():

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -83,6 +83,7 @@ from ..utils.helpers import expand_exe_path
 #  - Account used to run full launcher test suite on external systems
 #  - Default: None
 
+
 class Config:
     def __init__(self):
         # SmartSim/smartsim/_core
@@ -175,7 +176,9 @@ class Config:
         installed = []
         backends_path = self.lib_path / "backends"
         for backend in ["tensorflow", "torch", "onnx"]:
-            backend_path = backends_path / f"redisai_{backend}" / f"redisai_{backend}.so"
+            backend_path = (
+                backends_path / f"redisai_{backend}" / f"redisai_{backend}.so"
+            )
             backend_so = Path(os.environ.get("RAI_PATH", backend_path)).resolve()
             if backend_so.is_file():
                 installed.append(backend)

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -27,6 +27,7 @@
 import os
 from functools import lru_cache
 from pathlib import Path
+from typing import List
 
 import psutil
 
@@ -81,7 +82,6 @@ from ..utils.helpers import expand_exe_path
 # SMARTSIM_TEST_ACCOUNT
 #  - Account used to run full launcher test suite on external systems
 #  - Default: None
-
 
 class Config:
     def __init__(self):
@@ -169,6 +169,18 @@ class Config:
     def test_account(self) -> str:
         # no account by default
         return os.environ.get("SMARTSIM_TEST_ACCOUNT", "")
+
+    @property
+    def installed_backends(self) -> List[str]:
+        installed = []
+        backends_path = self.lib_path / "backends"
+        for backend in ["tensorflow", "torch", "onnx"]:
+            backend_path = backends_path / f"redisai_{backend}" / f"redisai_{backend}.so"
+            backend_so = Path(os.environ.get("RAI_PATH", backend_path)).resolve()
+            if backend_so.is_file():
+                installed.append(backend)
+
+        return installed
 
 
 @lru_cache(maxsize=128, typed=False)

--- a/smartsim/_core/utils/__init__.py
+++ b/smartsim/_core/utils/__init__.py
@@ -1,2 +1,2 @@
-from .helpers import colorize, delete_elements, init_default
+from .helpers import colorize, delete_elements, init_default, installed_redisai_backends
 from .redisUtils import check_cluster_status, create_cluster

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -29,6 +29,7 @@ A file of helper functions for SmartSim
 """
 import os
 import socket
+from pathlib import Path
 from shutil import which
 
 import psutil
@@ -198,3 +199,33 @@ def cat_arg_and_value(arg_name, value):
         return " ".join(("-" + arg_name, str(value)))
     else:
         return "=".join(("--" + arg_name, str(value)))
+
+
+def installed_redisai_backends(backends_path=None):
+    """Check which ML backends are available for the RedisAI module.
+
+    The optional argument ``backends_path`` is needed if the backends
+    have not been built as part of the SmartSim building process (i.e.
+    they have not been built by invoking `smart build`). In that case
+    ``backends_path`` should point to the directory containing e.g.
+    the backend directories (`redisai_tensorflow`, `redisai_torch`,
+    `redisai_onnxruntime`, or `redisai_tflite`).
+
+    :param backends_path: path containing backends, defaults to None
+    :type backends_path: str, optional
+    :return: list of installed RedisAI backends
+    :rtype: list[str]
+    """
+    # import here to avoid circular import
+    from ..._core.config import CONFIG
+
+    installed = []
+    if not backends_path:
+        backends_path = CONFIG.lib_path / "backends"
+    for backend in ["tensorflow", "torch", "onnxruntime", "tflite"]:
+        backend_path = backends_path / f"redisai_{backend}" / f"redisai_{backend}.so"
+        backend_so = Path(os.environ.get("RAI_PATH", backend_path)).resolve()
+        if backend_so.is_file():
+            installed.append(backend)
+
+    return installed

--- a/smartsim/ml/__init__.py
+++ b/smartsim/ml/__init__.py
@@ -1,0 +1,6 @@
+from .data import (
+    DynamicDataDownloader,
+    StaticDataDownloader,
+    TrainingDataUploader,
+    form_name,
+)

--- a/smartsim/ml/data.py
+++ b/smartsim/ml/data.py
@@ -1,0 +1,707 @@
+import time
+from os import environ
+
+import numpy as np
+from smartredis import Client, Dataset
+
+from ..error import SmartSimError
+from ..log import get_logger
+
+logger = get_logger(__name__)
+
+
+def form_name(*args):
+    return "_".join(str(arg) for arg in args if arg is not None)
+
+
+class TrainingDataUploader:
+    """A class to simplify uploading batches of samples to train a model.
+
+    This class can be used to upload samples following a simple convention
+    for naming. Once created, the function `publish_info` can be used
+    to put all details about the data set on the Orchestrator. A training
+    process can thus access them and get all relevant information to download
+    the batches which are uploaded.
+
+    Each time a new batch is available, it is sufficient to call `put_batch`,
+    and the data will be stored following the naming convention specified
+    by the attributes of this class.
+
+    :param name: Name of the dataset as stored on the Orchestrator
+    :type name: str
+    :param sample_prefix: Prefix of samples batches
+    :type sample_prefix: str
+    :param target_prefix: Prefix of target batches (if needed)
+    :type target_prefix: str
+    :param num_classes: Number of classes of targets, if categorical
+    :type num_classes: int
+    :param producer_prefixes: Prefixes of processes which will be producing batches.
+                              This can be useful in case the consumer processes also
+                              have other incoming entities.
+    :type producer_prefixes: str or list[str]
+    :param cluster: Whether the SmartSim Orchestrator is being run as a cluster
+    :type cluster: bool
+    :param address: Address of Redis DB as <ip_address>:<port>
+    :type address: str
+    :param num_ranks: Number of processes (e.g. MPI ranks) of application using
+                      DataUploader.
+    :type num_ranks: int
+    :param rank: Rank of DataUploader in multi-process application (e.g. MPI rank).
+    :type rank: int
+    :param verbose: If output should be logged to screen.
+    :type verbose: bool
+
+    """
+
+    def __init__(
+        self,
+        name="training_data",
+        sample_prefix="samples",
+        target_prefix="targets",
+        num_classes=None,
+        producer_prefixes=None,
+        cluster=True,
+        address=None,
+        num_ranks=None,
+        rank=None,
+        verbose=False,
+    ):
+        if not name:
+            raise ValueError("Name can not be empty")
+        if not sample_prefix:
+            raise ValueError("Sample prefix can not be empty")
+
+        self.name = name
+        self.sample_prefix = sample_prefix
+        self.target_prefix = target_prefix
+        if isinstance(producer_prefixes, str):
+            producer_prefixes = [producer_prefixes]
+        self.producer_prefixes = producer_prefixes
+        self.num_classes = num_classes
+        if num_ranks is None:
+            self.num_ranks = None
+        else:
+            self.num_ranks = int(num_ranks)
+        self.rank = rank
+
+        self.client = Client(address=address, cluster=cluster)
+        self.batch_idx = 0
+        self.verbose = verbose
+
+    def publish_info(self):
+        info_ds = Dataset(form_name(self.name, "info"))
+        info_ds.add_meta_string("sample_prefix", self.sample_prefix)
+        if self.target_prefix:
+            info_ds.add_meta_string("target_prefix", self.target_prefix)
+        if self.producer_prefixes:
+            for producer_prefix in self.producer_prefixes:
+                info_ds.add_meta_string("producer_prefixes", producer_prefix)
+        if self.num_classes:
+            info_ds.add_meta_scalar("num_classes", self.num_classes)
+        if self.num_ranks:
+            info_ds.add_meta_scalar("num_ranks", self.num_ranks)
+        self.client.put_dataset(info_ds)
+
+    def put_batch(self, samples, targets=None):
+        batch_key = form_name(self.sample_prefix, self.batch_idx, self.rank)
+        self.client.put_tensor(batch_key, samples)
+        if self.verbose:
+            logger.info(f"Put batch {batch_key}")
+
+        if (
+            targets is not None
+            and self.target_prefix
+            and (self.target_prefix != self.sample_prefix)
+        ):
+            labels_key = form_name(self.target_prefix, self.batch_idx, self.rank)
+            self.client.put_tensor(labels_key, targets)
+
+        self.batch_idx += 1
+
+
+class StaticDataDownloader:
+    """A class to download a dataset from the DB.
+
+    By default, the StaticDataDownloader has to be created in a process
+    launched through SmartSim, with sample producers listed as incoming
+    entities.
+
+    All details about the batches must be defined in
+    the constructor; two mechanisms are available, `manual` and
+    `auto`.
+
+     - When specifying `auto`, the user must also specify
+      `uploader_name`. StaticDataDownloader will get all needed information
+      from the database (this expects a Dataset like the one created
+      by TrainingDataUploader to be available and stored as `uploader_name`
+      on the DB).
+
+     - When specifying `manual`, the user must also specify details
+       of batch naming. Specifically, for each incoming entity with
+       a name starting with an element of `producer_prefixes`,
+       StaticDataDownloader will query the DB
+       for all batches named <sample_prefix>_<sub_index> for all indices
+       in `sub_indexes` if supplied, and, if
+       `target_prefix` is supplied, it will also query for all targets
+       named <target_prefix>.<sub_index>. If `producer_prefixes` is
+       None, then all incoming entities will be treated as producers,
+       and for each one, the corresponding batches will be downloaded.
+
+    The flag `init_samples` defines whether sources (the list of batches
+    to be fetched) and samples (the actual data) should automatically
+    be set up in the costructor.
+
+    If the user needs to modify the list of sources, then `init_samples=False`
+    has to be set. In that case, to set up a `BatchDownlaoder`, the user has to call
+    `init_sources()` (which initializes the list of sources and the SmartRedis client)
+    and `init_samples()`.  After `init_sources()` is called,
+    a list of data sources is populated, representing the batches which
+    will be downloaded.
+
+    Each source is represented as a tuple `(producer_name, sub_index)`.
+    Before `init_samples()` is called, the user can modify the list.
+    Once `init_samples()` is called, all data is downloaded and batches
+    can be obtained with iter().
+
+    After initialization, samples and targets will not be updated. The data can
+    be shuffled by calling `update_data()`, if `shuffle` is set to ``True`` at
+    initialization.
+
+    :param batch_size: Size of batches obtained with __iter__
+    :type batch_size: int
+    :param shuffle: whether order of samples has to be shuffled when calling `update_data`
+    :type shuffle: bool
+    :param uploader_info: Set to `auto` uploader information has to be downloaded from DB,
+                          or to `manual` if it is provided by the user
+    :type uploader_info: str
+    :param uploader_name: Name of uploader info dataset, only used if `uploader_info` is `auto`
+    :type uploader_name: str
+    :param sample_prefix: prefix of keys representing batches
+    :type sample_prefix: str
+    :param target_prefix: prefix of keys representing targets
+    :type target_prefix: str
+    :param uploader_ranks: Number of processes every uploader runs on (e.g, if each
+                           rank in an MPI simulation is uploading its own batches,
+                           this will be the MPI comm world size of the simulation).
+    :type uploader_ranks: int
+    :param num_classes: Number of classes of targets, if categorical
+    :type num_classes: int
+    :param producer_prefixes: Prefixes of names of which will be producing batches.
+                              These can be e.g. prefixes of SmartSim entity names in
+                              an ensemble.
+    :type producer_prefixes: str
+    :param cluster: Whether the Orchestrator will be run as a cluster
+    :type cluster: bool
+    :param address: Address of Redis client as <ip_address>:<port>
+    :type address: str
+    :param replica_rank: When StaticDataDownloader is used distributedly, indicates
+                         the rank of this object
+    :type replica_rank: int
+    :param num_replicas: When BatchDownlaoder is used distributedly, indicates
+                         the total number of ranks
+    :type num_replicas: int
+    :param verbose: Whether log messages should be printed
+    :type verbose: bool
+    :param init_samples: whether samples should be initialized in the constructor
+    :type init_samples: bool
+    """
+
+    def __init__(
+        self,
+        batch_size=32,
+        shuffle=True,
+        uploader_info="auto",
+        uploader_name="training_data",
+        sample_prefix="samples",
+        target_prefix="targets",
+        uploader_ranks=None,
+        num_classes=None,
+        producer_prefixes=None,
+        cluster=True,
+        address=None,
+        replica_rank=0,
+        num_replicas=1,
+        verbose=False,
+        init_samples=True,
+        **kwargs,
+    ):
+        self.replica_rank = replica_rank
+        self.num_replicas = num_replicas
+        self.address = address
+        self.cluster = cluster
+        self.uploader_info = uploader_info
+        self.uploader_name = uploader_name
+        self.verbose = verbose
+        self.samples = None
+        self.targets = None
+        self.num_samples = 0
+        self.indices = np.arange(0)
+        self.shuffle = shuffle
+        self.batch_size = batch_size
+        if uploader_info == "manual":
+            self.sample_prefix = sample_prefix
+            self.target_prefix = target_prefix
+            if uploader_ranks is not None:
+                self.sub_indices = [str(rank) for rank in range(uploader_ranks)]
+            else:
+                self.sub_indices = None
+            if producer_prefixes:
+                self.producer_prefixes = list(producer_prefixes)
+            else:
+                producer_prefixes = [""]
+            self.num_classes = num_classes
+        elif self.uploader_info == "auto":
+            pass
+        else:
+            raise ValueError(
+                f"uploader_info must be one of 'auto' or 'manual', but was {self.uploader_info}"
+            )
+
+        if init_samples:
+            self.init_sources()
+            self.init_samples()
+        else:
+            self.client = Client(self.address, self.cluster)
+            if self.uploader_info == "auto":
+                if not self.uploader_name:
+                    raise ValueError(
+                        "uploader_name can not be empty if uploader_info is 'auto'"
+                    )
+                self._get_uploader_info(self.uploader_name)
+            # This avoids problems with Pytorch
+            self.client = None
+
+    def log(self, message):
+        if self.verbose:
+            logger.info(message)
+
+    def _list_all_sources(self):
+        uploaders = environ["SSKEYIN"].split(",")
+        sources = []
+        for uploader in uploaders:
+            if any(
+                [
+                    uploader.startswith(producer_prefix)
+                    for producer_prefix in self.producer_prefixes
+                ]
+            ):
+                if self.sub_indices:
+                    sources.extend(
+                        [[uploader, sub_index] for sub_index in self.sub_indices]
+                    )
+                else:
+                    sources.append([uploader, None])
+
+        per_replica = len(sources) // self.num_replicas
+        if per_replica > 0:
+            if self.replica_rank < self.num_replicas - 1:
+                sources = sources[
+                    self.replica_rank
+                    * per_replica : (self.replica_rank + 1)
+                    * per_replica
+                ]
+            else:
+                sources = sources[self.replica_rank * per_replica :]
+        else:
+            self.log(
+                "Number of loader replicas is higher than number of sources, automatic split cannot be performed, "
+                "all replicas will have the same dataset. If this is not intended, then implement a distribution strategy "
+                "and modify `sources`."
+            )
+
+        return sources
+
+    def init_sources(self):
+        """Initalize list of data sources based on incoming entitites and self.sub_indices.
+
+
+        Each source is represented as a tuple `(producer_name, sub_index)`.
+        Before `init_samples()` is called, the user can modify the list.
+        Once `init_samples()` is called, all data is downloaded and batches
+        can be obtained with iter(). The list of all sources is stored as `self.sources`.
+
+        :raises ValueError: If self.uploader_info is set to `auto` but no `uploader_name` is specified.
+        :raises ValueError: If self.uploader_info is not set to `auto` or `manual`.
+        """
+        self.client = Client(self.address, self.cluster)
+        if self.uploader_info == "auto":
+            if not self.uploader_name:
+                raise ValueError(
+                    "uploader_name can not be empty if uploader_info is 'auto'"
+                )
+            self._get_uploader_info(self.uploader_name)
+        elif self.uploader_info == "manual":
+            pass
+        else:
+            raise ValueError(
+                f"uploader_info must be one of 'auto' or 'manual', but was {self.uploader_info}"
+            )
+
+        self.sources = self._list_all_sources()
+
+    @property
+    def need_targets(self):
+        """Compute if targets have to be downloaded.
+
+        :return: Whether targets (or labels) should be downloaded
+        :rtype: bool
+        """
+        return self.target_prefix and not self.autoencoding
+
+    def __len__(self):
+        length = int(np.floor(self.num_samples / self.batch_size))
+        return length
+
+    def __iter__(self):
+
+        if self.sources:
+            self.update_data()
+            # Generate data
+            if len(self) < 1:
+                msg = "Not enough samples in generator for one batch. "
+                msg += "Please run init_samples() or initialize generator with init_samples=True"
+                raise ValueError(msg)
+
+            for index in range(len(self)):
+                indices = self.indices[
+                    index * self.batch_size : (index + 1) * self.batch_size
+                ]
+
+                x, y = self.__data_generation(indices)
+
+                if y is not None:
+                    yield x, y
+                else:
+                    yield x
+
+    def init_samples(self, sources=None):
+        """Initialize samples (and targets, if needed).
+
+        This function will not return until samples have been downloaded
+        from all sources.
+
+        :param sources: List of sources as defined in `init_sources`, defaults to None,
+                        in which case sources will be initialized, unless `self.sources`
+                        is already set
+        :type sources: list[tuple], optional
+        """
+        self.autoencoding = self.sample_prefix == self.target_prefix
+
+        if sources is not None:
+            self.sources = sources
+
+        if self.sources is None:
+            self.sources = self._list_all_sources()
+
+        self.log("Generator initialization complete")
+
+        self._update_samples_and_targets()
+        if self.shuffle:
+            np.random.shuffle(self.indices)
+
+    def _data_exists(self, batch_name, target_name):
+
+        if self.need_targets:
+            return self.client.tensor_exists(batch_name) and self.client.tensor_exists(
+                target_name
+            )
+        else:
+            return self.client.tensor_exists(batch_name)
+
+    def _add_samples(self, batch_name, target_name):
+        if self.samples is None:
+            self.samples = self.client.get_tensor(batch_name)
+            if self.need_targets:
+                self.targets = self.client.get_tensor(target_name)
+        else:
+            self.samples = np.concatenate(
+                (self.samples, self.client.get_tensor(batch_name))
+            )
+            if self.need_targets:
+                self.targets = np.concatenate(
+                    (self.targets, self.client.get_tensor(target_name))
+                )
+
+        self.num_samples = self.samples.shape[0]
+        self.indices = np.arange(self.num_samples)
+        self.log("Success!")
+        self.log(f"New dataset size: {self.num_samples}, batches: {len(self)}")
+
+    def _get_uploader_info(self, uploader_name):
+        dataset_name = form_name(uploader_name, "info")
+        self.log(f"Uploader dataset name: {dataset_name}")
+
+        ds_exists = False
+        try:
+            ds_exists = self.client.dataset_exists(dataset_name)
+        # As long as required SmartRedis version is not 0.3 we
+        # need a workaround for the missing function
+        except AttributeError:
+            try:
+                uploaders = environ["SSKEYIN"].split(",")
+                for uploader in uploaders:
+                    if self.client.key_exists(uploader + "." + dataset_name):
+                        ds_exists = True
+            except KeyError:
+                msg = "Uploader must be launched with SmartSim and added to incoming entity, "
+                msg += "when setting uploader_info to 'auto'"
+                raise SmartSimError(msg)
+
+        trials = 6
+        while not ds_exists:
+            trials -= 1
+            if trials == 0:
+                raise SmartSimError("Could not find uploader dataset")
+            time.sleep(5)
+            try:
+                ds_exists = self.client.dataset_exists(dataset_name)
+            except AttributeError:
+                try:
+                    uploaders = environ["SSKEYIN"].split(",")
+                    for uploader in uploaders:
+                        if self.client.key_exists(uploader + "." + dataset_name):
+                            ds_exists = True
+                except KeyError:
+                    msg = "Uploader must be launched with SmartSim and added to incoming entity, "
+                    msg += "when setting uploader_info to 'auto'"
+                    raise SmartSimError(msg)
+
+        uploader_info = self.client.get_dataset(dataset_name)
+        self.sample_prefix = uploader_info.get_meta_strings("sample_prefix")[0]
+        self.log(f"Uploader sample prefix: {self.sample_prefix}")
+
+        try:
+            self.target_prefix = uploader_info.get_meta_strings("target_prefix")[0]
+        except:
+            self.target_prefix = None
+        self.log(f"Uploader target prefix: {self.target_prefix}")
+
+        try:
+            self.producer_prefixes = uploader_info.get_meta_strings("producer_prefixes")
+        except:
+            self.producer_prefixes = [""]
+        self.log(f"Uploader producer prefixes: {self.producer_prefixes}")
+
+        try:
+            self.num_classes = uploader_info.get_meta_scalars("num_classes")[0]
+        except:
+            self.num_classes = None
+        self.log(f"Uploader num classes: {self.num_classes}")
+
+        try:
+            num_ranks = uploader_info.get_meta_scalars("num_ranks")[0]
+            self.sub_indices = [str(rank) for rank in range(num_ranks)]
+        except:
+            self.sub_indices = None
+        self.log(f"Uploader sub-indices: {self.sub_indices}")
+
+    def _update_samples_and_targets(self):
+        for source in self.sources:
+            entity = source[0]
+            sub_index = source[1]
+            self.client.set_data_source(entity)
+            batch_name = form_name(self.sample_prefix, sub_index)
+            if self.need_targets:
+                target_name = form_name(self.target_prefix, sub_index)
+            else:
+                target_name = None
+
+            self.log(f"Retrieving {batch_name} from {entity}")
+            trials = 6
+            while not self._data_exists(batch_name, target_name):
+                trials -= 1
+                if trials == 0:
+                    raise SmartSimError(
+                        f"Could not retrieve batch {batch_name} from entity {entity}"
+                    )
+                time.sleep(5)
+
+            self._add_samples(batch_name, target_name)
+
+    def update_data(self):
+        self._update_samples_and_targets()
+
+    def __data_generation(self, indices):
+        # Initialization
+        x = self.samples[indices]
+
+        if self.need_targets:
+            y = self.targets[indices]
+
+        elif self.autoencoding:
+            y = x
+        else:
+            y = None
+
+        return x, y
+
+    def __len__(self):
+        length = int(np.floor(self.num_samples / self.batch_size))
+        return length
+
+
+class DynamicDataDownloader(StaticDataDownloader):
+    """A class to download batches from the DB as they are produced.
+
+    By default, the DynamicDataDownloader has to be created in a process
+    launched through SmartSim, with sample producers listed as incoming
+    entities.
+
+    All details about the batches must be defined in
+    the constructor; two mechanisms are available, `manual` and
+    `auto`.
+
+     - When specifying `auto`, the user must also specify
+      `uploader_name`. DynamicDataDownloader will get all needed information
+      from the database (this expects a Dataset like the one created
+      by TrainingDataUploader to be available and stored as `uploader_name`
+      on the DB).
+
+     - When specifying `manual`, the user must also specify details
+       of batch naming. Specifically, for each incoming entity with
+       a name starting with an element of `producer_prefixes`,
+       DynamicDataDownloader will query the DB
+       for all batches named <sample_prefix>_<sub_index>_<iteration> for all indices
+       in `sub_indices` if supplied, and, if
+       `target_prefix` is supplied, it will also query for all targets
+       named <target_prefix>.<sub_index>.<iteration>. If `producer_prefixes` is
+       None, then all incoming entities will be treated as producers,
+       and for each one, the corresponding batches will be downloaded.
+
+    The flag `init_samples` defines whether sources (the list of batches
+    to be fetched) and samples (the actual data) should automatically
+    be set up in the costructor.
+
+    If the user needs to modify the list of sources, then `init_samples=False`
+    has to be set. In that case, to set up a `DynamicDataDownloader`, the user has to call
+    `init_sources()` (which initializes the list of sources and the SmartRedis client)
+    and `init_samples()`.  After `init_sources()` is called,
+    a list of data sources is populated, representing the batches which
+    will be downloaded. See `init_sources()`
+
+    Each source is represented as a tuple `(producer_name, sub_index, iteration)`.
+    Before `init_samples()` is called, the user can modify the list.
+    Once `init_samples()` is called, all data is downloaded and batches
+    can be obtained with iter().
+
+    After initialization, samples and targets can be updated calling `update_data()`,
+    which shuffles the available samples, if `shuffle` is set to ``True`` at initialization.
+
+    :param batch_size: Size of batches obtained with __iter__
+    :type batch_size: int
+    :param shuffle: whether order of samples has to be shuffled when calling `update_data`
+    :type shuffle: bool
+    :param uploader_info: Set to `auto` uploader information has to be downloaded from DB,
+                          or to `manual` if it is provided by the user
+    :type uploader_info: str
+    :param uploader_name: Name of uploader info dataset, only used if `uploader_info` is `auto`
+    :type uploader_name: str
+    :param sample_prefix: prefix of keys representing batches
+    :type sample_prefix: str
+    :param target_prefix: prefix of keys representing targets
+    :type target_prefix: str
+    :param uploader_ranks: Number of processes every uploader runs on (e.g, if each
+                           rank in an MPI simulation is uploading its own batches,
+                           this will be the MPI comm world size of the simulation).
+    :type uploader_ranks: int
+    :param num_classes: Number of classes of targets, if categorical
+    :type num_classes: int
+    :param producer_prefixes: Prefixes of processes which will be producing batches.
+                              This can be useful in case the consumer processes also
+                              have other incoming entities.
+    :type producer_prefixes: str
+    :param cluster: Whether the Orchestrator is being run as a cluster
+    :type cluster: bool
+    :param address: Address of Redis DB as <ip_address>:<port>
+    :type address: str
+    :param replica_rank: When StaticDataDownloader is used in a distributed setting, indicates
+                         the rank of this replica
+    :type replica_rank: int
+    :param num_replicas: When ContinuousBatchDownlaoder is used in a distributed setting,
+                         indicates the total number of replicas (ranks)
+    :type num_replicas: int
+    :param verbose: Whether log messages should be printed
+    :type verbose: bool
+    :param init_samples: whether samples should be initialized in the constructor
+    :type init_samples: bool
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def _list_all_sources(self):
+        sources = super()._list_all_sources()
+        # Append the batch index to each source
+        for source in sources:
+            source.append(0)
+        return sources
+
+    def _update_samples_and_targets(self):
+        for source in self.sources:
+            entity = source[0]
+            sub_index = source[1]
+            index = source[2]
+            self.client.set_data_source(entity)
+            batch_name = form_name(self.sample_prefix, index, sub_index)
+            if self.need_targets:
+                target_name = form_name(self.target_prefix, index, sub_index)
+            else:
+                target_name = None
+
+            self.log(f"Retrieving {batch_name} from {entity}")
+            # Poll next batch based on index, if available: retrieve it, update index and loop
+            while self._data_exists(batch_name, target_name):
+                self._add_samples(batch_name, target_name)
+                source[2] += 1
+                index = source[2]
+                batch_name = form_name(self.sample_prefix, index, sub_index)
+                if self.need_targets:
+                    target_name = form_name(self.target_prefix, index, sub_index)
+
+                self.log(f"Retrieving {batch_name}...")
+
+    def update_data(self):
+        """Update data.
+
+        Fetch new batches (if available) from the DB. Also shuffle
+        list of samples if `self.shuffle` is set to ``True``.
+        """
+        self._update_samples_and_targets()
+        if self.shuffle:
+            np.random.shuffle(self.indices)
+
+    def init_samples(self, sources=None):
+        """Initialize samples (and targets, if needed).
+
+        This function will not return until at least one batch worth of data
+        has been downloaded.
+
+        :param sources: List of sources as defined in `init_sources`, defaults to None,
+                        in which case sources will be initialized, unless `self.sources`
+                        is already set
+        :type sources: list[tuple], optional
+        """
+        self.autoencoding = self.sample_prefix == self.target_prefix
+
+        if sources is not None:
+            self.sources = sources
+
+        if self.sources is None:
+            self.sources = self._list_all_sources()
+
+        if self.sources:
+
+            while len(self) < 1:
+                self._update_samples_and_targets()
+                trials = 6
+                if len(self) < 1:
+                    trials -= 1
+                    if trials == 0:
+                        raise SmartSimError("Could not find samples")
+                    time.sleep(5)
+            self.log("Generator initialization complete")
+        else:
+            self.log(
+                "Generator has no associated sources, this can happen if the number of "
+                "loader workers is larger than the number of available sources."
+            )

--- a/smartsim/ml/tf/__init__.py
+++ b/smartsim/ml/tf/__init__.py
@@ -1,16 +1,6 @@
-import warnings
-
-msg = "smartsim.tf has been deprecated in favor of smartsim.ml.tf and\n"
-msg += "will be removed in a future release. Please update your import statements."
-warnings.warn(
-    msg,
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from .._core._install.buildenv import Version_, Versioner
-from ..error import SmartSimError
-from ..log import get_logger
+from ..._core._install.buildenv import Version_, Versioner
+from ...error import SmartSimError
+from ...log import get_logger
 
 logger = get_logger(__name__)
 
@@ -31,3 +21,7 @@ except AssertionError:  # pragma: no cover
     raise SmartSimError(
         f"TensorFlow >= {TF_VERSION} is required for smartsim.tf, you have {tf.__version__}"
     ) from None
+
+
+from .data import DynamicDataGenerator, StaticDataGenerator
+from .utils import freeze_model

--- a/smartsim/ml/tf/data.py
+++ b/smartsim/ml/tf/data.py
@@ -1,0 +1,76 @@
+import numpy as np
+import tensorflow.keras as keras
+
+from smartsim.ml import DynamicDataDownloader, StaticDataDownloader
+
+
+class StaticDataGenerator(StaticDataDownloader, keras.utils.Sequence):
+    """A class to download a dataset from the DB.
+
+    Details about parameters and features of this class can be found
+    in the documentation of ``StaticDataDownloader``, of which it is just
+    a TensorFlow-specialized sub-class.
+    """
+
+    def __init__(self, **kwargs):
+        StaticDataDownloader.__init__(self, **kwargs)
+
+    def __getitem__(self, index):
+        if len(self) < 1:
+            msg = "Not enough samples in generator for one batch. "
+            msg += "Please run init_samples() or initialize generator with init_samples=True"
+            raise ValueError(msg)
+        # Generate indices of the batch
+        indices = self.indices[index * self.batch_size : (index + 1) * self.batch_size]
+
+        # Generate data
+        x, y = self.__data_generation(indices)
+
+        if y is not None:
+            return x, y
+        else:
+            return x
+
+    def on_epoch_end(self):
+        """Callback called at the end of each training epoch
+
+        If `self.shuffle` is set to `True`, data is shuffled.
+        """
+        if self.shuffle:
+            np.random.shuffle(self.indices)
+
+    def __data_generation(self, indices):
+        # Initialization
+        x = self.samples[indices]
+
+        if self.need_targets:
+            y = self.targets[indices]
+            if self.num_classes is not None:
+                y = keras.utils.to_categorical(y, num_classes=self.num_classes)
+        elif self.autoencoding:
+            y = x
+        else:
+            y = None
+
+        return x, y
+
+
+class DynamicDataGenerator(DynamicDataDownloader, StaticDataGenerator):
+    """A class to download batches from the DB.
+
+    Details about parameters and features of this class can be found
+    in the documentation of ``DynamicDataDownloader``, of which it is just
+    a TensorFlow-specialized sub-class.
+    """
+
+    def __init__(self, **kwargs):
+        StaticDataGenerator.__init__(self, **kwargs)
+
+    def on_epoch_end(self):
+        """Callback called at the end of each training epoch
+
+        Update data (the DB is queried for new batches) and
+        if `self.shuffle` is set to `True`, data is also shuffled.
+        """
+        self.update_data()
+        super().on_epoch_end()

--- a/smartsim/ml/tf/utils.py
+++ b/smartsim/ml/tf/utils.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import tensorflow as tf
+from tensorflow.python.framework.convert_to_constants import (
+    convert_variables_to_constants_v2,
+)
+
+
+def freeze_model(model, output_dir, file_name):
+    """Freeze a Keras or TensorFlow Graph
+
+    to use a Keras or TensorFlow model in SmartSim, the model
+    must be frozen and the inputs and outputs provided to the
+    smartredis.client.set_model_from_file() method.
+
+    This utiliy function provides everything users need to take
+    a trained model and put it inside an ``orchestrator`` instance
+
+    :param model: TensorFlow or Keras model
+    :type model: tf.Module
+    :param output_dir: output dir to save model file to
+    :type output_dir: str
+    :param file_name: name of model file to create
+    :type file_name: str
+    :return: path to model file, model input layer names, model output layer names
+    :rtype: str, list[str], list[str]
+    """
+    # TODO figure out why layer names don't match up to
+    # specified name in Model init.
+
+    if not file_name.endswith(".pb"):
+        file_name = file_name + ".pb"
+
+    full_model = tf.function(lambda x: model(x))
+    full_model = full_model.get_concrete_function(
+        tf.TensorSpec(model.inputs[0].shape, model.inputs[0].dtype)
+    )
+
+    frozen_func = convert_variables_to_constants_v2(full_model)
+    frozen_func.graph.as_graph_def()
+
+    input_names = [x.name.split(":")[0] for x in frozen_func.inputs]
+    output_names = [x.name.split(":")[0] for x in frozen_func.outputs]
+
+    tf.io.write_graph(
+        graph_or_graph_def=frozen_func.graph,
+        logdir=output_dir,
+        name=file_name,
+        as_text=False,
+    )
+    model_file_path = str(Path(output_dir, file_name).resolve())
+    return model_file_path, input_names, output_names

--- a/smartsim/ml/torch/__init__.py
+++ b/smartsim/ml/torch/__init__.py
@@ -1,0 +1,1 @@
+from .data import DataLoader, DynamicDataGenerator, StaticDataGenerator

--- a/smartsim/ml/torch/data.py
+++ b/smartsim/ml/torch/data.py
@@ -1,0 +1,118 @@
+import numpy as np
+import torch
+
+from smartsim.ml.data import DynamicDataDownloader, StaticDataDownloader
+
+
+class StaticDataGenerator(StaticDataDownloader, torch.utils.data.IterableDataset):
+    """A class to download a dataset from the DB.
+
+    Details about parameters and features of this class can be found
+    in the documentation of ``StaticDataDownloader``, of which it is just
+    a PyTorch-specialized sub-class.
+
+    Note that if the ``StaticDataGenerator`` has to be used through a ``DataLoader``,
+    `init_samples` must be set to `False`, as sources and samples will be initialized
+    by the ``DataLoader`` workers.
+    """
+
+    def __init__(self, **kwargs):
+        StaticDataDownloader.__init__(self, **kwargs)
+
+    def _add_samples(self, batch_name, target_name):
+        if self.samples is None:
+            self.samples = torch.tensor(self.client.get_tensor(batch_name))
+            if self.need_targets:
+                self.targets = torch.tensor(self.client.get_tensor(target_name))
+        else:
+            self.samples = torch.cat(
+                (self.samples, torch.tensor(self.client.get_tensor(batch_name)))
+            )
+            if self.need_targets:
+                self.targets = torch.cat(
+                    (self.targets, torch.tensor(self.client.get_tensor(target_name)))
+                )
+
+        self.num_samples = self.samples.shape[0]
+        self.indices = np.arange(self.num_samples)
+        self.log("Success!")
+        self.log(f"New dataset size: {self.num_samples}")
+
+    def update_data(self):
+        self._update_samples_and_targets()
+        if self.shuffle:
+            np.random.shuffle(self.indices)
+
+
+class DynamicDataGenerator(DynamicDataDownloader, StaticDataGenerator):
+    """A class to download batches from the DB.
+
+    Details about parameters and features of this class can be found
+    in the documentation of ``DynamicDataDownloader``, of which it is just
+    a PyTorch-specialized sub-class.
+
+    Note that if the ``DynamicDataGenerator`` has to be used through a ``DataLoader``,
+    `init_samples` must be set to `False`, as sources and samples will be initialized
+    by the ``DataLoader`` workers.
+    """
+
+    def __init__(self, **kwargs):
+        StaticDataGenerator.__init__(self, **kwargs)
+
+    def __iter__(self):
+        if self.sources:
+            self.update_data()
+        return super().__iter__()
+
+    def _add_samples(self, batch_name, target_name):
+        StaticDataGenerator._add_samples(self, batch_name, target_name)
+
+    def __iter__(self):
+        if self.sources:
+            self.update_data()
+        return super().__iter__()
+
+
+class DataLoader(torch.utils.data.DataLoader):  # pragma: no cover
+    """DataLoader to be used as a wrapper of StaticDataGenerator or DynamicDataGenerator
+
+    This is just a sub-class of ``torch.utils.data.DataLoader`` which
+    sets up sources of a data generator correctly. DataLoader parameters
+    such as `num_workers` can be passed at initialization. `batch_size` should always
+    be set to None.
+    """
+
+    def __init__(self, dataset: StaticDataGenerator, **kwargs):
+        super().__init__(
+            dataset,
+            worker_init_fn=self.worker_init_fn,
+            persistent_workers=True,
+            **kwargs,
+        )
+
+    @staticmethod
+    def worker_init_fn(worker_id):
+        worker_info = torch.utils.data.get_worker_info()
+        dataset = worker_info.dataset  # the dataset copy in this worker process
+        dataset.init_sources()
+        overall_sources = dataset.sources
+
+        worker_id = worker_info.id
+
+        # configure the dataset to only process the split workload
+        per_worker = int((len(overall_sources)) // worker_info.num_workers)
+
+        if per_worker > 0:
+            if worker_id < worker_info.num_workers - 1:
+                sources = overall_sources[
+                    worker_id * per_worker : (worker_id + 1) * per_worker
+                ]
+            else:
+                sources = overall_sources[worker_id * per_worker :]
+        else:
+            if worker_id < len(overall_sources):
+                sources = overall_sources[worker_id]
+            else:
+                sources = []
+
+        dataset.init_samples(sources)

--- a/tests/backends/run_sklearn_onnx.py
+++ b/tests/backends/run_sklearn_onnx.py
@@ -15,7 +15,7 @@ def build_lin_reg():
 
     linreg = LinearRegression()
     linreg.fit(x, y)
-    linreg = to_onnx(linreg, x.astype(np.float32))
+    linreg = to_onnx(linreg, x.astype(np.float32), target_opset=13)
     return linreg.SerializeToString()
 
 
@@ -36,7 +36,7 @@ def build_random_forest():
     clr = RandomForestRegressor(n_jobs=1, n_estimators=100)
     clr.fit(X_train, y_train)
 
-    rf_model = to_onnx(clr, X_test.astype(np.float32))
+    rf_model = to_onnx(clr, X_test.astype(np.float32), target_opset=13)
     return rf_model.SerializeToString()
 
 

--- a/tests/backends/run_sklearn_onnx.py
+++ b/tests/backends/run_sklearn_onnx.py
@@ -5,6 +5,7 @@ from sklearn.datasets import load_iris
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import train_test_split
+
 from smartredis import Client
 
 

--- a/tests/backends/run_torch.py
+++ b/tests/backends/run_torch.py
@@ -4,6 +4,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
 from smartredis import Client
 
 

--- a/tests/backends/test_dataloader.py
+++ b/tests/backends/test_dataloader.py
@@ -1,0 +1,171 @@
+import os.path as osp
+import time
+
+import pytest
+
+from smartsim import status
+from smartsim.database import Orchestrator
+from smartsim.error.errors import SmartSimError
+from smartsim.experiment import Experiment
+from smartsim.ml.tf import DynamicDataGenerator as TFDataGenerator
+from smartsim.ml.tf import DynamicDataGenerator as TorchDataGenerator
+
+shouldrun = True
+try:
+    import smartredis
+except ImportError:
+    shouldrun = False
+
+pytestmark = pytest.mark.skipif(
+    not shouldrun,
+    reason="requires SmartRedis",
+)
+
+shouldrun_tf = shouldrun
+if shouldrun_tf:
+    try:
+        from tensorflow import keras
+    except:
+        shouldrun_tf = False
+
+shouldrun_torch = shouldrun
+if shouldrun_torch:
+    try:
+        import torch
+    except:
+        shouldrun_torch = False
+
+
+def create_uploader(experiment: Experiment, filedir, format):
+    """Start an ensemble of two processes producing sample batches at
+    regular intervals.
+    """
+    run_settings = experiment.create_run_settings(
+        exe="python",
+        exe_args=["data_uploader.py", f"--format={format}"],
+        env_vars={"PYTHONUNBUFFERED": "1"},
+    )
+
+    uploader = experiment.create_ensemble(
+        "test_uploader", replicas=2, run_settings=run_settings
+    )
+
+    uploader.attach_generator_files(to_copy=[osp.join(filedir, "data_uploader.py")])
+    uploader.enable_key_prefixing()
+    experiment.generate(uploader, overwrite=True)
+    return uploader
+
+
+def create_trainer_tf(experiment: Experiment, filedir):
+    run_settings = experiment.create_run_settings(
+        exe="python",
+        exe_args=["training_service_tf.py"],
+        env_vars={"PYTHONUNBUFFERED": "1"},
+    )
+
+    trainer = experiment.create_model("trainer", run_settings=run_settings)
+
+    trainer.attach_generator_files(
+        to_copy=[osp.join(filedir, "training_service_tf.py")]
+    )
+    experiment.generate(trainer, overwrite=True)
+    return trainer
+
+
+def create_trainer_torch(experiment: Experiment, filedir):
+    run_settings = experiment.create_run_settings(
+        exe="python",
+        exe_args=["training_service_torch.py"],
+        env_vars={"PYTHONUNBUFFERED": "1"},
+    )
+
+    trainer = experiment.create_model("trainer", run_settings=run_settings)
+
+    trainer.attach_generator_files(
+        to_copy=[osp.join(filedir, "training_service_torch.py")]
+    )
+    experiment.generate(trainer, overwrite=True)
+    return trainer
+
+
+def test_batch_dataloader_tf(fileutils):
+    if not shouldrun_tf:
+        pytest.skip("Test needs TensorFlow to run.")
+
+    test_dir = fileutils.make_test_dir("test-batch-dataloader-tf")
+    exp = Experiment("test-batch-dataloader-tf", exp_path=test_dir)
+    config_path = fileutils.get_test_conf_path("ml")
+    dataloader = create_uploader(exp, config_path, "tf")
+    trainer_tf = create_trainer_tf(exp, config_path)
+
+    orc = Orchestrator()
+    exp.generate(orc)
+    exp.start(orc)
+    exp.start(dataloader, block=False)
+
+    for entity in dataloader:
+        trainer_tf.register_incoming_entity(entity)
+
+    exp.start(trainer_tf, block=True)
+    if exp.get_status(trainer_tf)[0] != status.STATUS_COMPLETED:
+        exp.stop(orc)
+        assert False
+
+    exp.stop(orc)
+
+    trials = 5
+    if exp.get_status(dataloader)[0] != status.STATUS_COMPLETED:
+        time.sleep(5)
+        trials -= 1
+        if trials == 0:
+            assert False
+
+
+def test_batch_dataloader_torch(fileutils):
+    if not shouldrun_torch:
+        pytest.skip("Test needs PyTorch to run.")
+
+    test_dir = fileutils.make_test_dir("test-batch-dataloader-torch")
+    exp = Experiment("test-batch-dataloader-tf", exp_path=test_dir)
+    config_path = fileutils.get_test_conf_path("ml")
+    dataloader = create_uploader(exp, config_path, "torch")
+    trainer_torch = create_trainer_torch(exp, config_path)
+
+    orc = Orchestrator()
+    exp.generate(orc)
+    exp.start(orc)
+    exp.start(dataloader, block=False)
+
+    for entity in dataloader:
+        trainer_torch.register_incoming_entity(entity)
+
+    exp.start(trainer_torch, block=True)
+    if exp.get_status(trainer_torch)[0] != status.STATUS_COMPLETED:
+        exp.stop(orc)
+        assert False
+
+    exp.stop(orc)
+
+    trials = 5
+    if exp.get_status(dataloader)[0] != status.STATUS_COMPLETED:
+        time.sleep(5)
+        trials -= 1
+        if trials == 0:
+            assert False
+
+
+def test_wrong_dataloaders(fileutils):
+    test_dir = fileutils.make_test_dir("test-wrong-dataloaders")
+    exp = Experiment("test-wrong-dataloaders", exp_path=test_dir)
+    orc = Orchestrator()
+    exp.generate(orc)
+    exp.start(orc)
+
+    with pytest.raises(SmartSimError):
+        _ = TFDataGenerator(address=orc.get_address()[0], cluster=False)
+
+    with pytest.raises(SmartSimError):
+        torch_data_gen = TorchDataGenerator(address=orc.get_address()[0], cluster=False)
+        torch_data_gen.init_samples()
+
+    exp.stop(orc)

--- a/tests/backends/test_onnx.py
+++ b/tests/backends/test_onnx.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from smartsim import Experiment
-from smartsim._core.config import CONFIG
+from smartsim._core.utils import installed_redisai_backends
 from smartsim.status import STATUS_FAILED
 
 sklearn_available = True
@@ -20,7 +20,7 @@ except ImportError:
     sklearn_available = False
 
 
-onnx_backend_available = "onnx" in CONFIG.installed_backends
+onnx_backend_available = "onnxruntime" in installed_redisai_backends()
 
 should_run = sklearn_available and onnx_backend_available
 

--- a/tests/backends/test_onnx.py
+++ b/tests/backends/test_onnx.py
@@ -29,6 +29,7 @@ pytestmark = pytest.mark.skipif(
     reason="Requires scikit-learn, onnxmltools, skl2onnx and RedisAI onnx backend",
 )
 
+
 def test_sklearn_onnx(fileutils, mlutils, wlmutils):
     """This test needs two free nodes, 1 for the db and 1 some sklearn models
 

--- a/tests/backends/test_tf.py
+++ b/tests/backends/test_tf.py
@@ -4,10 +4,9 @@ from pathlib import Path
 import pytest
 
 from smartsim import Experiment
+from smartsim._core.config import CONFIG
 from smartsim.error import SmartSimError
 from smartsim.status import STATUS_FAILED
-
-from smartsim._core.config import CONFIG
 
 tf_available = True
 try:
@@ -20,8 +19,10 @@ except (ImportError, SmartSimError):
 tf_backend_available = "tensorflow" in CONFIG.installed_backends
 
 
-@pytest.mark.skipif((not tf_backend_available) or (not tf_available),
-                    reason="Requires RedisAI TF backend")
+@pytest.mark.skipif(
+    (not tf_backend_available) or (not tf_available),
+    reason="Requires RedisAI TF backend",
+)
 def test_keras_model(fileutils, mlutils, wlmutils):
     """This test needs two free nodes, 1 for the db and 1 for a keras model script
 
@@ -81,8 +82,7 @@ def create_tf_model():
     return model
 
 
-@pytest.mark.skipif(not tf_available,
-                    reason="Requires Tensorflow and Keras")
+@pytest.mark.skipif(not tf_available, reason="Requires Tensorflow and Keras")
 def test_freeze_model(fileutils):
     test_name = "test_tf_freeze_model"
     test_dir = fileutils.make_test_dir(test_name)

--- a/tests/backends/test_tf.py
+++ b/tests/backends/test_tf.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from smartsim import Experiment
-from smartsim._core.config import CONFIG
+from smartsim._core.utils import installed_redisai_backends
 from smartsim.error import SmartSimError
 from smartsim.status import STATUS_FAILED
 
@@ -16,7 +16,7 @@ try:
 except (ImportError, SmartSimError):
     tf_availavble = False
 
-tf_backend_available = "tensorflow" in CONFIG.installed_backends
+tf_backend_available = "tensorflow" in installed_redisai_backends()
 
 
 @pytest.mark.skipif(

--- a/tests/backends/test_tf.py
+++ b/tests/backends/test_tf.py
@@ -14,7 +14,7 @@ try:
 
     from smartsim.tf import freeze_model
 except (ImportError, SmartSimError):
-    tf_availavble = False
+    tf_available = False
 
 tf_backend_available = "tensorflow" in installed_redisai_backends()
 

--- a/tests/backends/test_tf.py
+++ b/tests/backends/test_tf.py
@@ -7,20 +7,21 @@ from smartsim import Experiment
 from smartsim.error import SmartSimError
 from smartsim.status import STATUS_FAILED
 
-should_run = True
+from smartsim._core.config import CONFIG
+
+tf_available = True
 try:
     from tensorflow import keras
 
     from smartsim.tf import freeze_model
 except (ImportError, SmartSimError):
-    should_run = False
+    tf_availavble = False
 
-pytestmark = pytest.mark.skipif(
-    not should_run,
-    reason="requires tensorflow/keras",
-)
+tf_backend_available = "tensorflow" in CONFIG.installed_backends
 
 
+@pytest.mark.skipif((not tf_backend_available) or (not tf_available),
+                    reason="Requires RedisAI TF backend")
 def test_keras_model(fileutils, mlutils, wlmutils):
     """This test needs two free nodes, 1 for the db and 1 for a keras model script
 
@@ -57,7 +58,7 @@ def test_keras_model(fileutils, mlutils, wlmutils):
 
     exp.stop(db)
     # if model failed, test will fail
-    model_status = exp.get_status(model)
+    model_status = exp.get_status(model)[0]
     assert model_status != STATUS_FAILED
 
 
@@ -80,6 +81,8 @@ def create_tf_model():
     return model
 
 
+@pytest.mark.skipif(not tf_available,
+                    reason="Requires Tensorflow and Keras")
 def test_freeze_model(fileutils):
     test_name = "test_tf_freeze_model"
     test_dir = fileutils.make_test_dir(test_name)

--- a/tests/backends/test_torch.py
+++ b/tests/backends/test_torch.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import STATUS_FAILED
 from smartsim._core.config import CONFIG
+from smartsim.status import STATUS_FAILED
 
 torch_available = True
 try:
@@ -17,7 +17,9 @@ except ImportError:
 torch_backend_available = "torch" in CONFIG.installed_backends
 
 should_run = torch_available and torch_backend_available
-pytestmark = pytest.mark.skipif(not should_run, reason="Requires torch RedisAI torch backend")
+pytestmark = pytest.mark.skipif(
+    not should_run, reason="Requires torch RedisAI torch backend"
+)
 
 
 def test_torch_model_and_script(fileutils, mlutils, wlmutils):

--- a/tests/backends/test_torch.py
+++ b/tests/backends/test_torch.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from smartsim import Experiment
-from smartsim._core.config import CONFIG
+from smartsim._core.utils import installed_redisai_backends
 from smartsim.status import STATUS_FAILED
 
 torch_available = True
@@ -14,7 +14,7 @@ try:
 except ImportError:
     torch_available = False
 
-torch_backend_available = "torch" in CONFIG.installed_backends
+torch_backend_available = "torch" in installed_redisai_backends()
 
 should_run = torch_available and torch_backend_available
 pytestmark = pytest.mark.skipif(

--- a/tests/backends/test_torch.py
+++ b/tests/backends/test_torch.py
@@ -5,15 +5,19 @@ import pytest
 
 from smartsim import Experiment
 from smartsim.status import STATUS_FAILED
+from smartsim._core.config import CONFIG
 
-should_run = True
+torch_available = True
 try:
     import torch
     import torch.nn as nn
 except ImportError:
-    should_run = False
+    torch_available = False
 
-pytestmark = pytest.mark.skipif(not should_run, reason="requires torch==1.7.1")
+torch_backend_available = "torch" in CONFIG.installed_backends
+
+should_run = torch_available and torch_backend_available
+pytestmark = pytest.mark.skipif(not should_run, reason="Requires torch RedisAI torch backend")
 
 
 def test_torch_model_and_script(fileutils, mlutils, wlmutils):
@@ -53,5 +57,5 @@ def test_torch_model_and_script(fileutils, mlutils, wlmutils):
 
     exp.stop(db)
     # if model failed, test will fail
-    model_status = exp.get_status(model)
+    model_status = exp.get_status(model)[0]
     assert model_status != STATUS_FAILED

--- a/tests/on_wlm/test_launch_orc_cobalt.py
+++ b/tests/on_wlm/test_launch_orc_cobalt.py
@@ -24,16 +24,16 @@ def test_launch_cobalt_orc(fileutils, wlmutils):
     orc.set_path(test_dir)
 
     exp.start(orc, block=True)
-    status = exp.get_status(orc)
+    statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in status:
+    if status.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
-    status = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in status])
+    statuses = exp.get_status(orc)
+    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
 
 
 def test_launch_cobalt_cluster_orc(fileutils, wlmutils):

--- a/tests/on_wlm/test_launch_orc_lsf.py
+++ b/tests/on_wlm/test_launch_orc_lsf.py
@@ -26,16 +26,16 @@ def test_launch_lsf_orc(fileutils, wlmutils):
     orc.set_path(test_dir)
 
     exp.start(orc, block=True)
-    status = exp.get_status(orc)
+    statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in status:
+    if status.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
-    status = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in status])
+    statuses = exp.get_status(orc)
+    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
 
     time.sleep(5)
 
@@ -58,15 +58,15 @@ def test_launch_lsf_cluster_orc(fileutils, wlmutils):
     orc.set_path(test_dir)
 
     exp.start(orc, block=True)
-    status = exp.get_status(orc)
+    statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in status:
+    if status.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
-    status = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in status])
+    statuses = exp.get_status(orc)
+    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
 
     time.sleep(5)

--- a/tests/test_configs/ml/data_uploader.py
+++ b/tests/test_configs/ml/data_uploader.py
@@ -1,0 +1,59 @@
+from argparse import ArgumentParser
+from os import environ
+
+import numpy as np
+
+from smartsim.ml import TrainingDataUploader
+
+# simulate multi-rank without requesting mpi4py as dep
+mpi_size = 2
+
+
+def create_data_uploader(rank):
+    return TrainingDataUploader(
+        name="test_data",
+        sample_prefix="test_samples",
+        target_prefix="test_targets",
+        num_classes=mpi_size,
+        producer_prefixes="test_uploader",
+        cluster=False,
+        address=None,
+        num_ranks=mpi_size,
+        rank=rank,
+        verbose=True,
+    )
+
+
+if __name__ == "__main__":
+
+    parser = ArgumentParser()
+    parser.add_argument("--format", default="tf", type=str)
+    args = parser.parse_args()
+    format = args.format
+
+    batch_size = 4
+    data_uploaders = [create_data_uploader(rank) for rank in range(mpi_size)]
+
+    print(environ["SSKEYOUT"])
+    if environ["SSKEYOUT"] == "test_uploader_0":
+        data_uploaders[0].publish_info()
+
+    batches_per_loop = 1
+    shape = (
+        (batch_size * batches_per_loop, 32, 32, 1)
+        if format == "tf"
+        else (batch_size * batches_per_loop, 1, 32, 32)
+    )
+
+    # Start "simulation", produce data every two minutes, for thirty minutes
+    for _ in range(2):
+        for mpi_rank in range(mpi_size):
+            new_batch = np.random.normal(
+                loc=float(mpi_rank), scale=5.0, size=shape
+            ).astype(float)
+            new_labels = (
+                np.ones(shape=(batch_size * batches_per_loop,)).astype(int) * mpi_rank
+            )
+
+            data_uploaders[mpi_rank].put_batch(new_batch, new_labels)
+            print(f"{mpi_rank}: New data pushed to DB")

--- a/tests/test_configs/ml/training_service_tf.py
+++ b/tests/test_configs/ml/training_service_tf.py
@@ -1,0 +1,75 @@
+import tensorflow.keras as keras
+
+from smartsim.ml.tf import DynamicDataGenerator
+
+
+def check_dataloader(dl, rank):
+    assert dl.uploader_name == "test_data"
+    assert dl.sample_prefix == "test_samples"
+    assert dl.target_prefix == "test_targets"
+    assert dl.uploader_info == "auto"
+    assert dl.num_classes == 2
+    assert dl.producer_prefixes == ["test_uploader"]
+    assert dl.sub_indices == ["0", "1"]
+    assert dl.verbose == True
+    assert dl.replica_rank == rank
+    assert dl.num_replicas == 2
+    assert dl.address == None
+    assert dl.cluster == False
+    assert dl.shuffle == True
+    assert dl.batch_size == 4
+    assert len(dl.sources) == 2
+    for i in range(2):
+        assert dl.sources[i][0:2] == [f"test_uploader_{rank}", str(i)]
+        assert type(dl.sources[i][2]) == int
+
+
+# Pretend we are running distributed without requiring Horovod
+hvd_size = 2
+
+
+def create_data_generator(rank):
+    return DynamicDataGenerator(
+        cluster=False,
+        uploader_name="test_data",
+        verbose=True,
+        num_replicas=2,
+        replica_rank=rank,
+        batch_size=4,
+    )
+
+
+training_generators = [create_data_generator(rank) for rank in range(hvd_size)]
+
+[
+    check_dataloader(training_generator, rank)
+    for (rank, training_generator) in enumerate(training_generators)
+]
+
+model = keras.models.Sequential(
+    [
+        keras.layers.Conv2D(
+            filters=4, kernel_size=(3, 3), activation="relu", input_shape=(32, 32, 1)
+        ),
+        keras.layers.Flatten(),
+        keras.layers.Dense(training_generators[0].num_classes, activation="softmax"),
+    ]
+)
+
+model.compile(optimizer="Adam", loss="mse", metrics=["mae"])
+
+print("Starting training")
+
+for epoch in range(2):
+    print(f"Epoch {epoch}")
+    for rank in range(hvd_size):
+        model.fit(
+            training_generators[rank],
+            steps_per_epoch=None,
+            epochs=epoch + 1,
+            initial_epoch=epoch,
+            batch_size=training_generators[rank].batch_size,
+            verbose=2,
+        )
+
+assert all([len(training_generators[rank]) == 4 for rank in range(hvd_size)])

--- a/tests/test_configs/ml/training_service_torch.py
+++ b/tests/test_configs/ml/training_service_torch.py
@@ -1,0 +1,95 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+
+from smartsim.ml.torch import DataLoader, DynamicDataGenerator
+
+
+class Net(nn.Module):
+    def __init__(self, num_classes=10):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 8, 3, 1)
+        self.fc1 = nn.Linear(7200, num_classes)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+def check_dataloader(dl):
+    assert dl.uploader_name == "test_data"
+    assert dl.sample_prefix == "test_samples"
+    assert dl.target_prefix == "test_targets"
+    assert dl.uploader_info == "auto"
+    assert dl.num_classes == 2
+    assert dl.producer_prefixes == ["test_uploader"]
+    assert dl.sub_indices == ["0", "1"]
+    assert dl.verbose == True
+    assert dl.replica_rank == 0
+    assert dl.num_replicas == 1
+    assert dl.address == None
+    assert dl.cluster == False
+    assert dl.shuffle == True
+    assert dl.batch_size == 4
+
+
+# This test should run without error, but no explicit
+# assertion is performed
+if __name__ == "__main__":
+    torch.multiprocessing.set_start_method("spawn")
+
+    training_set = DynamicDataGenerator(
+        cluster=False,
+        shuffle=True,
+        batch_size=4,
+        init_samples=False,
+        verbose=True,
+        uploader_name="test_data",
+    )
+
+    trainloader = DataLoader(training_set, batch_size=None, num_workers=2)
+
+    check_dataloader(training_set)
+    model = Net(num_classes=training_set.num_classes).double()
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.parameters(), lr=0.0001)
+    print("Started training")
+
+    for epoch in range(1):  # loop over the dataset multiple times
+
+        running_loss = 0.0
+        epoch_running_loss = 0.0
+        output_period = 1
+        print(f"Epoch {epoch}")
+        for i, data in enumerate(trainloader):
+            # get the inputs; data is a list of [inputs, labels]
+            inputs, labels = data[0].double(), data[1]
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = model(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # print statistics
+            running_loss += loss.item()
+            epoch_running_loss += loss.item()
+
+            if i % output_period == (output_period - 1):
+                print(
+                    "[%d, %5d] loss: %.3f"
+                    % (epoch + 1, i + 1, running_loss / output_period)
+                )
+                running_loss = 0.0
+
+        print("[%d, %5d] loss: %.3f" % (epoch + 1, i + 1, epoch_running_loss / (i + 1)))
+        epoch_running_loss = 0.0
+
+    print("Finished Training")

--- a/tests/test_configs/smartredis/consumer.py
+++ b/tests/test_configs/smartredis/consumer.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import torch
 import torch.nn as nn
+
 from smartredis import Client
 
 if __name__ == "__main__":

--- a/tests/test_configs/smartredis/producer.py
+++ b/tests/test_configs/smartredis/producer.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import torch
 import torch.nn as nn
+
 from smartredis import Client
 
 

--- a/tests/test_smartredis.py
+++ b/tests/test_smartredis.py
@@ -1,7 +1,7 @@
 import pytest
 
 from smartsim import Experiment, status
-from smartsim._core.config import CONFIG
+from smartsim._core.utils import installed_redisai_backends
 from smartsim.database import Orchestrator
 from smartsim.entity import Ensemble, Model
 
@@ -17,12 +17,13 @@ REDIS_PORT = 6780
 
 shouldrun = True
 try:
-    import smartredis
     import torch
+
+    import smartredis
 except ImportError:
     shouldrun = False
 
-torch_available = "torch" in CONFIG.installed_backends
+torch_available = "torch" in installed_redisai_backends()
 
 shouldrun &= torch_available
 

--- a/tests/test_smartredis.py
+++ b/tests/test_smartredis.py
@@ -1,6 +1,7 @@
 import pytest
 
 from smartsim import Experiment, status
+from smartsim._core.config import CONFIG
 from smartsim.database import Orchestrator
 from smartsim.entity import Ensemble, Model
 
@@ -21,10 +22,13 @@ try:
 except ImportError:
     shouldrun = False
 
+torch_available = "torch" in CONFIG.installed_backends
+
+shouldrun &= torch_available
 
 pytestmark = pytest.mark.skipif(
     not shouldrun,
-    reason="requires PyTorch and SmartRedis",
+    reason="requires PyTorch, SmartRedis, and RedisAI's Torch backend",
 )
 
 

--- a/tutorials/05_ml_training/tf/data_uploader.py
+++ b/tutorials/05_ml_training/tf/data_uploader.py
@@ -1,0 +1,30 @@
+from smartsim.ml import TrainingDataUploader
+from os import environ
+from time import sleep
+import numpy as np
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+mpi_rank = comm.Get_rank()
+mpi_size = comm.Get_size()
+
+batches_per_loop = 10
+
+data_uploader = TrainingDataUploader(num_classes=mpi_size,
+                                     smartredis_cluster=False, 
+                                     producer_prefixes="uploader",
+                                     num_ranks=mpi_size,
+                                     rank=mpi_rank)
+
+if environ["SSKEYOUT"] == "uploader_0" and mpi_rank==0:
+    data_uploader.publish_info()
+
+
+# Start "simulation", produce data every two minutes, for thirty minutes
+for _ in range(15):
+    new_batch = np.random.normal(loc=float(mpi_rank), scale=5.0, size=(32*batches_per_loop, 224, 224, 3)).astype(float)
+    new_labels = np.ones(shape=(32*batches_per_loop,)).astype(int) * mpi_rank
+
+    data_uploader.put_batch(new_batch, new_labels)
+    print(f"{mpi_rank}: New data pushed to DB")
+    sleep(120)

--- a/tutorials/05_ml_training/tf/training_service.py
+++ b/tutorials/05_ml_training/tf/training_service.py
@@ -1,0 +1,16 @@
+import tensorflow.keras as keras
+
+from smartsim.ml.tf import DynamicDataGenerator
+
+
+training_generator = DynamicDataGenerator(cluster=False, verbose=True)
+model = keras.applications.MobileNetV2(weights=None, classes=training_generator.num_classes)
+model.compile(optimizer="Adam", loss="mse", metrics=["mae"])
+
+print("Starting training")
+
+for epoch in range(100):
+    print(f"Epoch {epoch}")
+    model.fit(training_generator, steps_per_epoch=None, 
+              epochs=epoch+1, initial_epoch=epoch, batch_size=training_generator.batch_size,
+              verbose=2)

--- a/tutorials/05_ml_training/tf/training_service_hvd.py
+++ b/tutorials/05_ml_training/tf/training_service_hvd.py
@@ -1,0 +1,39 @@
+import tensorflow.keras as keras
+import tensorflow as tf
+
+from smartsim.ml.tf import DynamicDataGenerator
+
+import horovod.tensorflow.keras as hvd
+
+# HVD initialization
+hvd.init()
+hvd_rank = hvd.rank()
+hvd_size = hvd.size()
+
+gpus = tf.config.experimental.list_physical_devices('GPU')
+for gpu in gpus:
+    tf.config.experimental.set_memory_growth(gpu, True)
+if gpus:
+    tf.config.experimental.set_visible_devices(gpus[hvd.local_rank()], 'GPU')
+
+
+training_generator = DynamicDataGenerator(cluster=False, init_samples=True, replica_rank=hvd_rank, num_replicas=hvd_size)
+model = keras.applications.MobileNetV2(weights=None, classes=training_generator.num_classes)
+
+opt = keras.optimizers.Adam(0.001 * hvd.size())
+# Horovod: add Horovod Distributed Optimizer.
+opt = hvd.DistributedOptimizer(opt)
+model.compile(optimizer=opt, loss="mse", metrics=["mae"])
+callbacks = [
+    # Horovod: broadcast initial variable states from rank 0 to all other processes.
+    # This is necessary to ensure consistent initialization of all workers when
+    # training is started with random weights or restored from a checkpoint.
+    hvd.callbacks.BroadcastGlobalVariablesCallback(0),
+]
+
+print("Starting training")
+
+for epoch in range(100):
+    model.fit(training_generator, steps_per_epoch=None, callbacks=callbacks,
+              epochs=epoch+1, initial_epoch=epoch, batch_size=training_generator.batch_size,
+              verbose=2 if hvd_rank==0 else 0)

--- a/tutorials/05_ml_training/torch/data_uploader.py
+++ b/tutorials/05_ml_training/torch/data_uploader.py
@@ -1,0 +1,30 @@
+from smartsim.ml import TrainingDataUploader
+from os import environ
+from time import sleep
+import numpy as np
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+mpi_rank = comm.Get_rank()
+mpi_size = comm.Get_size()
+
+batches_per_loop = 10
+
+data_uploader = TrainingDataUploader(num_classes=mpi_size,
+                                     cluster=False, 
+                                     producer_prefixes="uploader", 
+                                     num_ranks=mpi_size,
+                                     ranks=mpi_rank)
+                                     
+if environ["SSKEYOUT"] == "uploader_0" and mpi_rank==0:
+    data_uploader.publish_info()
+
+
+# Start "simulation", produce data every two minutes, for thirty minutes
+for _ in range(15):
+    new_batch = np.random.normal(loc=float(mpi_rank), scale=5.0, size=(32*batches_per_loop, 3, 224, 224)).astype(float)
+    new_labels = np.ones(shape=(32*batches_per_loop,)).astype(int) * mpi_rank
+
+    data_uploader.put_batch(new_batch, new_labels)
+    print(f"{mpi_rank}: New data pushed to DB")
+    sleep(120)

--- a/tutorials/05_ml_training/torch/training_service.py
+++ b/tutorials/05_ml_training/torch/training_service.py
@@ -1,0 +1,56 @@
+import torchvision.models as models
+
+from smartsim.ml.torch import DynamicDataGenerator, DataLoader
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+
+if __name__ == '__main__':
+    torch.multiprocessing.set_start_method('spawn')
+    training_set = DynamicDataGenerator(cluster=False,
+                                 shuffle=True,
+                                 batch_size=32,
+                                 init_samples=False)
+    trainloader = DataLoader(training_set,
+                             batch_size=None,
+                             num_workers=2)
+    model = models.mobilenet_v2().double().to('cuda')
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.parameters(), lr=0.0001)
+    print("Started training")
+
+    for epoch in range(50):  # loop over the dataset multiple times
+
+        running_loss = 0.0
+        epoch_running_loss = 0.0
+        output_period = 100
+        print(f"Epoch {epoch}")
+        for i, data in enumerate(trainloader):
+            # get the inputs; data is a list of [inputs, labels]
+            inputs, labels = data[0].double().to('cuda'), data[1].to('cuda')
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = model(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # print statistics
+            running_loss += loss.item()
+            epoch_running_loss += loss.item()
+
+            if i % output_period == (output_period-1):    # print every "output_period" mini-batches
+                print('[%d, %5d] loss: %.3f' %
+                    (epoch + 1, i + 1, running_loss / output_period))
+                running_loss = 0.0
+
+        
+        print('[%d, %5d] loss: %.3f' %
+            (epoch + 1, i + 1, epoch_running_loss / (i+1)))
+        epoch_running_loss = 0.0
+                
+    print('Finished Training')

--- a/tutorials/05_ml_training/torch/training_service_hvd.py
+++ b/tutorials/05_ml_training/torch/training_service_hvd.py
@@ -1,0 +1,75 @@
+import torchvision.models as models
+
+from smartsim.ml.torch import DynamicDataGenerator, DataLoader
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+import horovod.torch as hvd
+
+if __name__ == '__main__':
+
+    # Initialize Horovod
+    hvd.init()
+
+    hvd_rank = hvd.rank()
+    hvd_size = hvd.size()
+
+    # Pin GPU to be used to process local rank (one GPU per process)
+    torch.cuda.set_device(hvd.local_rank())
+
+    torch.multiprocessing.set_start_method('spawn')
+    training_set = DynamicDataGenerator(cluster=False,
+                                 verbose=True,
+                                 init_samples=False,
+                                 num_replicas=hvd_size,
+                                 replica_rank=hvd_rank)
+
+    trainloader = DataLoader(training_set,
+                             batch_size=None,
+                             num_workers=2)
+
+    model = models.mobilenet_v2().double().to('cuda')
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.parameters(), lr=0.0001*hvd_size)
+    optimizer = hvd.DistributedOptimizer(optimizer, named_parameters=model.named_parameters())
+    hvd.broadcast_parameters(model.state_dict(), root_rank=0)
+    print(f"Rank {hvd_rank}: Started training")
+
+    for epoch in range(100):  # loop over the dataset multiple times
+
+        running_loss = 0.0
+        epoch_running_loss = 0.0
+        if hvd_rank == 0:
+            print(f"Epoch {epoch}")
+        output_period = 100
+
+        for i, data in enumerate(trainloader):
+            # get the inputs; data is a list of [inputs, labels]
+            inputs, labels = data[0].double().to('cuda'), data[1].to('cuda')
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = model(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # print statistics
+            running_loss += loss.item()
+            epoch_running_loss += loss.item()
+
+            if hvd_rank == 0:
+                if i % output_period == (output_period-1):    # print every "output_period" mini-batches
+                    print('[%d, %5d] loss: %.3f' %
+                        (epoch + 1, i + 1, running_loss / output_period))
+                    running_loss = 0.0
+
+        if hvd_rank == 0:    
+            print('[%d, %5d] loss: %.3f' %
+                (epoch + 1, i + 1, epoch_running_loss / (i+1)))
+            epoch_running_loss = 0.0
+                
+    print('Finished Training')

--- a/tutorials/05_ml_training/train_tf.ipynb
+++ b/tutorials/05_ml_training/train_tf.ipynb
@@ -1,0 +1,508 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train a Neural Network loading data from and to SmartSim\n",
+    "\n",
+    "In this tutorial, we will see how one can set up a workflow in which one or multiple processes produce data (e.g. in a simulation) and one or multiple processes consume the data to train a neural network. The key to achieve this behavior is to use SmartSim to load data from and to the database.\n",
+    "\n",
+    "This tutorial works on Slurm, but can easily be adapted to any supported Workload Manager (PBS, Cobalt, or LSF), with an only difference: in Slurm, we are allocating the resources *from* this Notebook, whereas with other WLMs, this Notebook has to be started *within* an existing allocation.\n",
+    "\n",
+    "Note: this tutorial requires the python packages `tensorflow`, `mpi4py` and `horovod`.\n",
+    "\n",
+    "## 1. First scenario: an ensemble of parallel producers and a single trainer\n",
+    "\n",
+    "The first use case is similar to a common workflow:\n",
+    "- several copies of a simulation (possibly with different initializations) are running, each one consisting of multiple MPI ranks. Each rank produces samples (e.g. data points computed by the simulation) at regular intervals (e.g. each time iteration)\n",
+    "- a neural network has to be trained on the data produced by the simulation, and as new data is produced, the neural network needs to add it to its training data set.\n",
+    "\n",
+    "\n",
+    "### 1.1 Workflow components\n",
+    "We will use SmartSim to allow the exchange of data between the data-producing processes and the training service. Thus, the first component which we will need to launch is the `Orchestrator`. This is a fairly small example, thus we will run a single-node DB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from smartsim import Experiment\n",
+    "from smartsim.database import SlurmOrchestrator\n",
+    "from smartsim.settings import SrunSettings\n",
+    "from smartsim import slurm\n",
+    "\n",
+    "def launch_cluster_orc(experiment, port, alloc):\n",
+    "    \"\"\"Spin up a cluster\"\"\"\n",
+    "    db = SlurmOrchestrator(port=port,\n",
+    "                            db_nodes=1,\n",
+    "                            batch=False,\n",
+    "                            alloc=alloc,\n",
+    "                            interface=\"ib0\")\n",
+    "    \n",
+    "\n",
+    "    # generate directories for output files\n",
+    "    # pass in objects to make dirs for\n",
+    "    experiment.generate(db, overwrite=True)\n",
+    "\n",
+    "    # start the database on interactive allocation\n",
+    "    experiment.start(db, block=True)\n",
+    "\n",
+    "    return db"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our data will be very simple: each rank will produce random samples, drawing values from a Gaussian distribution centered at the rank id, and each sample will be labeled with the rank id. The neural network will be trained to infer which rank produced a data sample. Thus, our data set will have a total number of labels equal to the number of ranks in each replicas.\n",
+    "\n",
+    "The data-producing processes will be started as part of an ensemble of two replicas (this mimics the execution of two copies of the simulation). The actual script producing the data is called `data_uploader.py` and is contained in the `tf` directory. Its content is\n",
+    "\n",
+    "```python\n",
+    "from smartsim.ml import TrainingDataUploader\n",
+    "from os import environ\n",
+    "from time import sleep\n",
+    "import numpy as np\n",
+    "from mpi4py import MPI\n",
+    "\n",
+    "comm = MPI.COMM_WORLD\n",
+    "mpi_rank = comm.Get_rank()\n",
+    "mpi_size = comm.Get_size()\n",
+    "\n",
+    "batches_per_loop = 10\n",
+    "\n",
+    "data_uploader = TrainingDataUploader(num_classes=mpi_size,\n",
+    "                                     cluster=False, \n",
+    "                                     producer_prefixes=\"uploader\",\n",
+    "                                     num_ranks=mpi_size,\n",
+    "                                     rank=mpi_rank)\n",
+    "                                     \n",
+    "if environ[\"SSKEYOUT\"] == \"uploader_0\":\n",
+    "    data_uploader.publish_info()\n",
+    "\n",
+    "\n",
+    "# Start \"simulation\", produce data every two minutes, for thirty minutes\n",
+    "for _ in range(15):\n",
+    "    new_batch = np.random.normal(loc=float(mpi_rank), scale=5.0, size=(32*batches_per_loop, 224, 224, 3)).astype(float)\n",
+    "    new_labels = np.ones(shape=(32*batches_per_loop,)).astype(int) * mpi_rank\n",
+    "\n",
+    "    data_uploader.put_batch(new_batch, new_labels)\n",
+    "    print(f\"{mpi_rank}: New data pushed to DB\")\n",
+    "    sleep(120)\n",
+    "\n",
+    "```\n",
+    "\n",
+    "as the script is running in python, we can use the `TrainingDataUploader` class, which streamlines uploading of the data samples from the simulation. Here is an explanation of the arguments:\n",
+    "- `num_classes` is the number of classes of our training data set\n",
+    "- `smartredis_cluster=False` specifies that the DB is not a cluster (it is a single shard)\n",
+    "- `producer_prefixes` is used to identify the SmartSim entity names of the processes producing data: this is useful in the case the training service has several incoming entities (as defined in SmartSim, through the environment variable `SSKEYIN`), but it should expect data only from a subset of them. \n",
+    "- `num_ranks` is the number of concurrent data loaders withing this application, in this case it is simply the number of MPI ranks, as each process will upload its own data.\n",
+    "\n",
+    "At each iteration, each rank of \"simulation\" calls `put_batch` to upload a batch of samples and the corresponding labels. The batch will be uploaded on the DB and stored under a key composed by a prefix (defaulting to `samples`), the sub-index, and the iteration number, which increases monotonically every time a batch is uploaded.\n",
+    "\n",
+    "Now that we know the content of `data_uploader.py`, we can create an entity representing the uploader ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def create_uploader(experiment, alloc, nodes=1, tasks_per_node=1):\n",
+    "    \"\"\"Start an ensemble of two processes producing sample batches at\n",
+    "       regular intervals.\n",
+    "    \"\"\"\n",
+    "    srun = SrunSettings(exe=\"python\",\n",
+    "                        exe_args=\"data_uploader.py\",\n",
+    "                        env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
+    "                        alloc=alloc)\n",
+    "    srun.set_nodes(nodes)\n",
+    "    srun.set_tasks_per_node(tasks_per_node)\n",
+    "\n",
+    "    uploader = experiment.create_ensemble(\"uploader\", replicas=2, run_settings=srun)\n",
+    "\n",
+    "    # create directories for the output files and copy\n",
+    "    # scripts to execution location inside newly created dir\n",
+    "    # only necessary if its not an executable (python is executable here)\n",
+    "    uploader.attach_generator_files(to_copy=[\"./tf/data_uploader.py\"])\n",
+    "    experiment.generate(uploader, overwrite=True)\n",
+    "    return uploader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The last component of our workflow is the trainer. This process will keep downloading samples as they are produced, and use them to train a neural network.\n",
+    "\n",
+    "Here is the content of the `training_service.py` script, stored in the `tf` directory\n",
+    "```python\n",
+    "import tensorflow.keras as keras\n",
+    "\n",
+    "from smartsim.ml.tf import DynamicDataGenerator\n",
+    "\n",
+    "training_generator = DynamicDataGenerator(cluster=False, verbose=True)\n",
+    "model = keras.applications.MobileNetV2(weights=None, classes=training_generator.num_classes)\n",
+    "model.compile(optimizer=\"Adam\", loss=\"mse\", metrics=[\"mae\"])\n",
+    "\n",
+    "print(\"Starting training\")\n",
+    "\n",
+    "for epoch in range(100):\n",
+    "    print(f\"Epoch {epoch}\")\n",
+    "    model.fit(training_generator, steps_per_epoch=None, \n",
+    "              epochs=epoch+1, initial_epoch=epoch, batch_size=training_generator.batch_size,\n",
+    "              verbose=2)\n",
+    "```\n",
+    "\n",
+    "The key component is the `DynamicDataGenerator` object. Since the DB contains the metadata of the `TrainingDataUploader`, and these are stored under a default key, the `DynamicDataGenerator` will retrieve them and use them to know the key of the uploaded batches of samples and labels. We create a SmartSim entity representing the trainer and we are ready to go!\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def create_trainer(experiment, alloc):\n",
+    "    \"\"\"Start a process running a training service which will\n",
+    "       download batches from the DB.\n",
+    "    \"\"\"\n",
+    "    srun = SrunSettings(exe=\"python\",\n",
+    "                        exe_args=\"training_service.py\",\n",
+    "                        env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
+    "                        alloc=alloc)\n",
+    "    srun.set_tasks(1)\n",
+    "\n",
+    "    trainer = experiment.create_model(\"trainer\", srun)\n",
+    "\n",
+    "    # create directories for the output files and copy\n",
+    "    # scripts to execution location inside newly created dir\n",
+    "    # only necessary if its not an executable (python is executable here)\n",
+    "    trainer.attach_generator_files(to_copy=\"./tf/training_service.py\")\n",
+    "    experiment.generate(trainer, overwrite=True)\n",
+    "    return trainer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### 1.2 Request an allocation\n",
+    "\n",
+    "We need one node for the DB, two for the producer ensemble, and one for the trainer, thus we request 4 nodes to be allocated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "alloc = slurm.get_allocation(nodes=4, time=\"03:00:00\", options={\"constraint\": \"V100\", \"partition\": \"spider\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.3 Run the workflow\n",
+    "\n",
+    "Now that all components are available, we create the SmartSim experiment representing our workflow. \n",
+    "Notice that the line\n",
+    "```python\n",
+    "uploader_model.enable_key_prefixing()\n",
+    "```\n",
+    "sets the ``uploader`` process so that tensor keys produced within it will be prefixed with its\n",
+    "SmartSim entity name, and the lines\n",
+    "```python\n",
+    "for uploader in uploader_model.entities:\n",
+    "    trainer_model.register_incoming_entity(uploader)\n",
+    "```\n",
+    "make sure that each uploader replica (within the ensemble) is set as an incoming entity of the `trainer_model`. This will allow the `trainer_model` to know which processes are producing batches it will need to download.\n",
+    "\n",
+    "We call `exp.start` and the workflow is launched! As the trainer was started with `verbose=True`, we can look at its output in `launch_streaming`: we will see that it keeps downloading batches at the end of each epoch, as expected. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "exp = Experiment(\"launch_streaming\", launcher=\"slurm\")\n",
+    "\n",
+    "db_port = 6780\n",
+    "\n",
+    "# start the database\n",
+    "db = launch_cluster_orc(exp, db_port, alloc)\n",
+    "uploader_model = create_uploader(exp, alloc, 1, 2)\n",
+    "uploader_model.enable_key_prefixing()\n",
+    "exp.start(uploader_model, block=False, summary=False)\n",
+    "trainer_model = create_trainer(exp, alloc)\n",
+    "for uploader in uploader_model.entities:\n",
+    "    trainer_model.register_incoming_entity(uploader)\n",
+    "\n",
+    "exp.start(trainer_model, block=True, summary=False)\n",
+    "\n",
+    "print(exp.summary())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp.stop(db, uploader_model, trainer_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Finally, we release the allocation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "slurm.release_allocation(alloc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 Second scenario: an ensemble of parallel producers and a distributed trainer\n",
+    "\n",
+    "In the second scenario, we use Horovod to distribute the training and use multiple ranks. Each rank will download only a portion of the dataset, thus speeding up the download and training process.\n",
+    "\n",
+    "\n",
+    "### 2.1 Workflow components\n",
+    "The only component we change with respect to the previous example, is the training service, which is now defined in `training_service_hvd.py`:\n",
+    "\n",
+    "```python\n",
+    "import numpy as np\n",
+    "import tensorflow.keras as keras\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "from smartsim.ml.tf import DynamicDataGenerator\n",
+    "\n",
+    "import horovod.tensorflow.keras as hvd\n",
+    "\n",
+    "# HVD initialization\n",
+    "hvd.init()\n",
+    "hvd_rank = hvd.rank()\n",
+    "hvd_size = hvd.size()\n",
+    "\n",
+    "gpus = tf.config.experimental.list_physical_devices('GPU')\n",
+    "for gpu in gpus:\n",
+    "    tf.config.experimental.set_memory_growth(gpu, True)\n",
+    "if gpus:\n",
+    "    tf.config.experimental.set_visible_devices(gpus[hvd.local_rank()], 'GPU')\n",
+    "\n",
+    "\n",
+    "training_generator = DynamicDataGenerator(cluster=False,\n",
+    "                                          replica_rank=hvd_rank, \n",
+    "                                          num_replicas=hvd_size,\n",
+    "                                          verbose=True)\n",
+    "model = keras.applications.MobileNetV2(weights=None, classes=training_generator.num_classes)\n",
+    "\n",
+    "opt = keras.optimizers.Adam(0.0001*hvd_size)\n",
+    "# Horovod: add Horovod Distributed Optimizer.\n",
+    "opt = hvd.DistributedOptimizer(opt)\n",
+    "model.compile(optimizer=opt, loss=\"mse\", metrics=[\"mae\"])\n",
+    "callbacks = [\n",
+    "    # Horovod: broadcast initial variable states from rank 0 to all other processes.\n",
+    "    # This is necessary to ensure consistent initialization of all workers when\n",
+    "    # training is started with random weights or restored from a checkpoint.\n",
+    "    hvd.callbacks.BroadcastGlobalVariablesCallback(0),\n",
+    "]\n",
+    "\n",
+    "print(\"Starting training\")\n",
+    "\n",
+    "for epoch in range(100):\n",
+    "    model.fit(training_generator, steps_per_epoch=None, callbacks=callbacks,\n",
+    "              epochs=epoch+1, initial_epoch=epoch, batch_size=training_generator.batch_size,\n",
+    "              verbose=2 if hvd_rank==0 else 0)\n",
+    "\n",
+    "```\n",
+    "\n",
+    "Compared to the previous training service, we notice that the only thing changing for the `DataGenerator` is that we need to specify the total number of replicas, which is equal to the total number of Horovod ranks, and the rank of each replica, which corresponds to the Horovod rank. The rest of the training service script is modified according to the standard Horovod distributed training rules.\n",
+    "\n",
+    "Let's define the SmartSim entity representing the training service."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_trainer_hvd(experiment, alloc, nodes=1, tasks_per_node=1):\n",
+    "    \"\"\"Start a process running a distributed training service which will\n",
+    "       download batches from the DB and use Horovod to distribute\n",
+    "       data and compute global weight updates.\n",
+    "    \"\"\"\n",
+    "    srun = SrunSettings(exe=\"python\",\n",
+    "                        exe_args=\"training_service_hvd.py\",\n",
+    "                        env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
+    "                        alloc=alloc)\n",
+    "    srun.set_nodes(nodes)\n",
+    "    srun.set_tasks_per_node(tasks_per_node)\n",
+    "\n",
+    "    trainer = experiment.create_model(\"trainer\", srun)\n",
+    "\n",
+    "    # create directories for the output files and copy\n",
+    "    # scripts to execution location inside newly created dir\n",
+    "    # only necessary if its not an executable (python is executable here)\n",
+    "    trainer.attach_generator_files(to_copy=\"./tf/training_service_hvd.py\")\n",
+    "    experiment.generate(trainer, overwrite=True)\n",
+    "    return trainer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### 2.2 Request an allocation\n",
+    "\n",
+    "We need one node for the DB, two for the producer ensemble, and one for the trainer, thus we request 4 nodes to be allocated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "alloc = slurm.get_allocation(nodes=4, time=\"03:00:00\", options={\"constraint\": \"V100\", \"partition\": \"spider\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Run the workflow\n",
+    "\n",
+    "Now that all components are available, we create the SmartSim experiment representing our workflow. The setup is completely identical to the previous example, thus we can start the experiment and look at the output files to see that now each replica has a smaller portion of the dataset, and the training proceeds much faster!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "exp = Experiment(\"launch_streaming_hvd\", launcher=\"slurm\")\n",
+    "\n",
+    "db_port = 6780\n",
+    "\n",
+    "# start the database\n",
+    "db = launch_cluster_orc(exp, db_port, alloc)\n",
+    "uploader_model = create_uploader(exp, alloc, 1, 8)\n",
+    "uploader_model.enable_key_prefixing()\n",
+    "exp.start(uploader_model, block=False, summary=False)\n",
+    "trainer_model = create_trainer_hvd(exp, alloc, 1, 8)\n",
+    "for uploader in uploader_model.entities:\n",
+    "    trainer_model.register_incoming_entity(uploader)\n",
+    "\n",
+    "exp.start(trainer_model, block=True, summary=False)\n",
+    "\n",
+    "print(exp.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.4 Stop the workflow (optional) and release the allocation\n",
+    "If we did not wait until completion of the previous cell, but we stopped it, we need to stop the SmartSim entities. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "exp.stop(db, uploader_model, trainer_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we release the allocation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slurm.release_allocation(alloc)"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "5f96b028d35977f3d62414249e8a4fc42677d517daea4eab9bcc2f5f43a2f69b"
+  },
+  "kernelspec": {
+   "display_name": "smartsim",
+   "language": "python",
+   "name": "smartsim"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tutorials/05_ml_training/train_torch.ipynb
+++ b/tutorials/05_ml_training/train_torch.ipynb
@@ -1,0 +1,584 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train a Neural Network loading data from and to SmartSim\n",
+    "\n",
+    "In this tutorial, we will see how one can set up a workflow in which one or multiple processes produce data (e.g. in a simulation) and one or multiple processes consume the data to train a neural network. The key to achieve this behavior is to use SmartSim to load data from and to the database.\n",
+    "\n",
+    "This tutorial works on Slurm, but can easily be adapted to any supported Workload Manager (PBS, Cobalt, or LSF), with an only difference: in Slurm, we are allocating the resources *from* this Notebook, whereas with other WLMs, this Notebook has to be started *within* an existing allocation.\n",
+    "\n",
+    "Note: this tutorial requires the python packages `torch`, `mpi4py` and `horovod`.\n",
+    "\n",
+    "## 1. First scenario: an ensemble of parallel producers and a single trainer\n",
+    "\n",
+    "The first use case is similar to a common workflow:\n",
+    "- several copies of a simulation (possibly with different initializations) are running, each one consisting of multiple MPI ranks. Each rank produces samples (e.g. data points computed by the simulation) at regular intervals (e.g. each time iteration)\n",
+    "- a neural network has to be trained on the data produced by the simulation, and as new data is produced, the neural network needs to add it to its training data set.\n",
+    "\n",
+    "\n",
+    "### 1.1 Workflow components\n",
+    "We will use SmartSim to allow the exchange of data between the data-producing processes and the training service. Thus, the first component which we will need to launch is the `Orchestrator`. This is a fairly small example, thus we will run a single-node DB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from smartsim import Experiment\n",
+    "from smartsim.database import SlurmOrchestrator\n",
+    "from smartsim.settings import SrunSettings\n",
+    "from smartsim import slurm\n",
+    "\n",
+    "def launch_cluster_orc(experiment, port, alloc):\n",
+    "    \"\"\"Just spin up a database cluster\"\"\"\n",
+    "\n",
+    "    db = SlurmOrchestrator(port=port,\n",
+    "                            db_nodes=1,\n",
+    "                            batch=False,\n",
+    "                            alloc=alloc,\n",
+    "                            interface=\"ib0\")\n",
+    "    \n",
+    "\n",
+    "    # generate directories for output files\n",
+    "    # pass in objects to make dirs for\n",
+    "    experiment.generate(db, overwrite=True)\n",
+    "\n",
+    "    # start the database on interactive allocation\n",
+    "    experiment.start(db, block=True)\n",
+    "\n",
+    "    return db"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our data will be very simple: each rank will produce random samples, drawing values from a Gaussian distribution centered at the rank id, and each sample will be labeled with the rank id. The neural network will be trained to infer which rank produced a data sample. Thus, our data set will have a total number of labels equal to the number of ranks in each replicas.\n",
+    "\n",
+    "The data-producing processes will be started as part of an ensemble of two replicas (this mimics the execution of two copies of the simulation). The actual script producing the data is called `data_uploader.py` and is contained in the `torch` directory. Its content is\n",
+    "\n",
+    "\n",
+    "```python\n",
+    "from smartsim.ml import TrainingDataUploader\n",
+    "from os import environ\n",
+    "from time import sleep\n",
+    "import numpy as np\n",
+    "from mpi4py import MPI\n",
+    "\n",
+    "comm = MPI.COMM_WORLD\n",
+    "mpi_rank = comm.Get_rank()\n",
+    "mpi_size = comm.Get_size()\n",
+    "\n",
+    "batches_per_loop = 10\n",
+    "\n",
+    "data_uploader = TrainingDataUploader(num_classes=mpi_size,\n",
+    "                                     cluster=False, \n",
+    "                                     producer_prefixes=\"uploader\",\n",
+    "                                     num_ranks=mpi_size)\n",
+    "                                     \n",
+    "if environ[\"SSKEYOUT\"] == \"uploader_0\":\n",
+    "    data_uploader.publish_info()\n",
+    "\n",
+    "\n",
+    "# Start \"simulation\", produce data every two minutes, for thirty minutes\n",
+    "for _ in range(15):\n",
+    "    new_batch = np.random.normal(loc=float(mpi_rank), scale=5.0, size=(32*batches_per_loop, 224, 224, 3)).astype(float)\n",
+    "    new_labels = np.ones(shape=(32*batches_per_loop,)).astype(int) * mpi_rank\n",
+    "\n",
+    "    data_uploader.put_batch(new_batch, new_labels)\n",
+    "    print(f\"{mpi_rank}: New data pushed to DB\")\n",
+    "    sleep(120)\n",
+    "\n",
+    "```\n",
+    "\n",
+    "as the script is running in python, we can use the `TrainingDataUploader` class, which streamlines uploading of the data samples from the simulation. Here is an explanation of the arguments:\n",
+    "- `num_classes` is the number of classes of our training data set\n",
+    "- `smartredis_cluster=False` specifies that the DB is not a cluster (it is a single shard)\n",
+    "- `producer_prefixes` is used to identify the SmartSim entity names of the processes producing data: this is useful in the case the training service has several incoming entities (as defined in SmartSim, through the environment variable `SSKEYIN`), but it should expect data only from a subset of them. \n",
+    "- `num_ranks` is the number of concurrent data loaders withing this application, in this case it is simply the number of MPI ranks, as each process will upload its own data.\n",
+    "\n",
+    "At each iteration, each rank of \"simulation\" calls `put_batch` to upload a batch of samples and the corresponding labels. The batch will be uploaded on the DB and stored under a key composed by a prefix (defaulting to `samples`), the sub-index, and the iteration number, which increases monotonically every time a batch is uploaded.\n",
+    "\n",
+    "Now that we know the content of `data_uploader.py`, we can create an entity representing the uploader ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def create_uploader(experiment, alloc, nodes=1, tasks_per_node=1):\n",
+    "    \"\"\"Start an ensemble of two processes producing sample batches at\n",
+    "       regular intervals.\n",
+    "    \"\"\"\n",
+    "    srun = SrunSettings(exe=\"python\",\n",
+    "                        exe_args=\"data_uploader.py\",\n",
+    "                        env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
+    "                        alloc=alloc)\n",
+    "    srun.set_nodes(nodes)\n",
+    "    srun.set_tasks_per_node(tasks_per_node)\n",
+    "\n",
+    "    uploader = experiment.create_ensemble(\"uploader\", replicas=2, run_settings=srun)\n",
+    "\n",
+    "    # create directories for the output files and copy\n",
+    "    # scripts to execution location inside newly created dir\n",
+    "    # only necessary if its not an executable (python is executable here)\n",
+    "    uploader.attach_generator_files(to_copy=[\"./torch/data_uploader.py\"])\n",
+    "    experiment.generate(uploader, overwrite=True)\n",
+    "    return uploader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The last component of our workflow is the trainer. This process will keep downloading samples as they are produced, and use them to train a neural network.\n",
+    "\n",
+    "Here is the content of the `training_service.py` script, stored in the `torch` directory\n",
+    "\n",
+    "```python\n",
+    "import numpy as np\n",
+    "import torchvision.models as models\n",
+    "from smartsim.ml.torch import DynamicDataGenerator, DataLoader\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.optim as optim\n",
+    "\n",
+    "if __name__ == '__main__':\n",
+    "    torch.multiprocessing.set_start_method('spawn')\n",
+    "    training_set = DynamicDataGenerator(cluster=False,\n",
+    "                                 init_samples=False,\n",
+    "                                 verbose=True)\n",
+    "    trainloader = DataLoader(training_set, batch_size=None,\n",
+    "                             num_workers=2)\n",
+    "    model = models.mobilenet_v2().double().to('cuda')\n",
+    "    criterion = nn.CrossEntropyLoss()\n",
+    "    optimizer = optim.Adam(model.parameters(), lr=0.0001)\n",
+    "    print(\"Started training\")\n",
+    "\n",
+    "    for epoch in range(50):  # loop over the dataset multiple times\n",
+    "\n",
+    "        running_loss = 0.0\n",
+    "        epoch_running_loss = 0.0\n",
+    "        output_period = 100\n",
+    "        print(f\"Epoch {epoch}\")\n",
+    "        for i, data in enumerate(trainloader):\n",
+    "            # get the inputs; data is a list of [inputs, labels]\n",
+    "            inputs, labels = data[0].double().to('cuda'), data[1].to('cuda')\n",
+    "            # zero the parameter gradients\n",
+    "            optimizer.zero_grad()\n",
+    "\n",
+    "            # forward + backward + optimize\n",
+    "            outputs = model(inputs)\n",
+    "            loss = criterion(outputs, labels)\n",
+    "            loss.backward()\n",
+    "            optimizer.step()\n",
+    "\n",
+    "            # print statistics\n",
+    "            running_loss += loss.item()\n",
+    "            epoch_running_loss += loss.item()\n",
+    "\n",
+    "            if i % output_period == (output_period-1):    # print every \"output_period\" mini-batches\n",
+    "                print('[%d, %5d] loss: %.3f' %\n",
+    "                    (epoch + 1, i + 1, running_loss / output_period))\n",
+    "                running_loss = 0.0\n",
+    "\n",
+    "        \n",
+    "        print('[%d, %5d] loss: %.3f' %\n",
+    "            (epoch + 1, i + 1, epoch_running_loss / (i+1)))\n",
+    "        epoch_running_loss = 0.0\n",
+    "                \n",
+    "    print('Finished Training')\n",
+    "```\n",
+    "\n",
+    "The key component is the `DataGenerator` object. Since the DB contains the metadata of the `TrainingDataUploader`, and these are stored under a default key, the `DataGenerator` will retrieve them and use them to know the key of the uploaded batches of samples and labels. We need to specify `init_samples=False`, because initialization of the data set will be performed by the `DataLoader` workers: notice that the `DataLoader` is imported from `smartsim.ml.torch`: it is our custom implementation of a data loader, which will also triger a data update at the beginning of each epoch, to check if there are new samples available.\n",
+    "\n",
+    "We create a SmartSim entity representing the trainer and we are ready to go!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def create_trainer(experiment, alloc):\n",
+    "    \"\"\"Start a process running a training service which will\n",
+    "       download batches from the DB.\n",
+    "    \"\"\"\n",
+    "    srun = SrunSettings(exe=\"python\",\n",
+    "                        exe_args=\"training_service.py\",\n",
+    "                        env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
+    "                        alloc=alloc)\n",
+    "    srun.set_tasks(1)\n",
+    "\n",
+    "    trainer = experiment.create_model(\"trainer\", srun)\n",
+    "\n",
+    "    # create directories for the output files and copy\n",
+    "    # scripts to execution location inside newly created dir\n",
+    "    # only necessary if its not an executable (python is executable here)\n",
+    "    trainer.attach_generator_files(to_copy=\"./torch/training_service.py\")\n",
+    "    experiment.generate(trainer, overwrite=True)\n",
+    "    return trainer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Request an allocation\n",
+    "\n",
+    "We need one node for the DB, two for the producer ensemble, and one for the trainer, thus we request 4 nodes to be allocated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alloc = slurm.get_allocation(nodes=4, time=\"03:00:00\", options={\"constraint\": \"V100\", \"partition\": \"spider\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.3 Run the workflow\n",
+    "\n",
+    "Now that all components are available, we create the SmartSim experiment representing our workflow. \n",
+    "Notice that the line\n",
+    "```python\n",
+    "uploader_model.enable_key_prefixing()\n",
+    "```\n",
+    "sets the ``uploader`` process so that tensor keys produced within it will be prefixed with its\n",
+    "SmartSim entity name, and the lines\n",
+    "```python\n",
+    "for uploader in uploader_model.entities:\n",
+    "    trainer_model.register_incoming_entity(uploader)\n",
+    "```\n",
+    "make sure that each uploader replica (within the ensemble) is set as an incoming entity of the `trainer_model`. This will allow the `trainer_model` to know which processes are producing batches it will need to download.\n",
+    "\n",
+    "We call `exp.start` and the workflow is launched! As the trainer was started with `verbose=True`, we can look at its output in `launch_streaming`: we will see that it keeps downloading batches at the end of each epoch, as expected. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "exp = Experiment(\"launch_streaming\", launcher=\"slurm\")\n",
+    "\n",
+    "db_port = 6780\n",
+    "\n",
+    "# start the database\n",
+    "db = launch_cluster_orc(exp, db_port, alloc)\n",
+    "uploader_model = create_uploader(exp, alloc, 1, 2)\n",
+    "uploader_model.enable_key_prefixing()\n",
+    "exp.start(uploader_model, block=False, summary=False)\n",
+    "trainer_model = create_trainer(exp, alloc)\n",
+    "for uploader in uploader_model.entities:\n",
+    "    trainer_model.register_incoming_entity(uploader)\n",
+    "\n",
+    "exp.start(trainer_model, block=True, summary=False)\n",
+    "\n",
+    "# shutdown the database because we don't need it anymore\n",
+    "exp.stop(db)\n",
+    "\n",
+    "print(exp.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.4 Stop the workflow (optional) and release the allocation\n",
+    "If we did not wait until completion of the previous cell, but we stopped it, we need to stop the SmartSim entities. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "exp.stop(db, uploader_model, trainer_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Finally, we release the allocation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slurm.release_allocation(alloc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 Second scenario: an ensemble of parallel producers and a distributed trainer\n",
+    "\n",
+    "In the second scenario, we use Horovod to distribute the training and use multiple ranks. Each rank will download only a portion of the dataset, thus speeding up the download and training process.\n",
+    "\n",
+    "\n",
+    "### 2.1 Workflow components\n",
+    "The only component we change with respect to the previous example, is the training service, which is now defined in `training_service_hvd.py`:\n",
+    "\n",
+    "```python\n",
+    "import numpy as np\n",
+    "import torchvision.models as models\n",
+    "\n",
+    "from smartsim.ml.torch import DynamicDataGenerator, DataLoader\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.optim as optim\n",
+    "\n",
+    "import horovod.torch as hvd\n",
+    "\n",
+    "if __name__ == '__main__':\n",
+    "\n",
+    "    # Initialize Horovod\n",
+    "    hvd.init()\n",
+    "\n",
+    "    hvd_rank = hvd.rank()\n",
+    "    hvd_size = hvd.size()\n",
+    "\n",
+    "    # Pin GPU to be used to process local rank (one GPU per process)\n",
+    "    torch.cuda.set_device(hvd.local_rank())\n",
+    "\n",
+    "    torch.multiprocessing.set_start_method('spawn')\n",
+    "    training_set = DynamicDataGenerator(cluster=False,\n",
+    "                                 verbose=True,\n",
+    "                                 init_samples=False,\n",
+    "                                 num_replicas=hvd_size,\n",
+    "                                 replica_rank=hvd_rank)\n",
+    "\n",
+    "    trainloader = DataLoader(training_set, batch_size=None,\n",
+    "                             num_workers=2)\n",
+    "\n",
+    "    model = models.mobilenet_v2().double().to('cuda')\n",
+    "    criterion = nn.CrossEntropyLoss()\n",
+    "    optimizer = optim.Adam(model.parameters(), lr=0.0001*hvd_size)\n",
+    "    optimizer = hvd.DistributedOptimizer(optimizer, named_parameters=model.named_parameters())\n",
+    "    hvd.broadcast_parameters(model.state_dict(), root_rank=0)\n",
+    "    print(f\"Rank {hvd_rank}: Started training\")\n",
+    "\n",
+    "    for epoch in range(100):  # loop over the dataset multiple times\n",
+    "\n",
+    "        running_loss = 0.0\n",
+    "        epoch_running_loss = 0.0\n",
+    "        if hvd_rank == 0:\n",
+    "            print(f\"Epoch {epoch}\")\n",
+    "        output_period = 100\n",
+    "\n",
+    "        for i, data in enumerate(trainloader):\n",
+    "            # get the inputs; data is a list of [inputs, labels]\n",
+    "            inputs, labels = data[0].double().to('cuda'), data[1].to('cuda')\n",
+    "            # zero the parameter gradients\n",
+    "            optimizer.zero_grad()\n",
+    "\n",
+    "            # forward + backward + optimize\n",
+    "            outputs = model(inputs)\n",
+    "            loss = criterion(outputs, labels)\n",
+    "            loss.backward()\n",
+    "            optimizer.step()\n",
+    "\n",
+    "            # print statistics\n",
+    "            running_loss += loss.item()\n",
+    "            epoch_running_loss += loss.item()\n",
+    "\n",
+    "            if hvd_rank == 0:\n",
+    "                if i % output_period == (output_period-1):    # print every \"output_period\" mini-batches\n",
+    "                    print('[%d, %5d] loss: %.3f' %\n",
+    "                        (epoch + 1, i + 1, running_loss / output_period))\n",
+    "                    running_loss = 0.0\n",
+    "\n",
+    "        if hvd_rank == 0:    \n",
+    "            print('[%d, %5d] loss: %.3f' %\n",
+    "                (epoch + 1, i + 1, epoch_running_loss / (i+1)))\n",
+    "            epoch_running_loss = 0.0\n",
+    "                \n",
+    "    print('Finished Training')\n",
+    "```\n",
+    "\n",
+    "Compared to the previous training service, we notice that the only thing changing for the `DataGenerator` is that we need to specify the total number of replicas, which is equal to the total number of Horovod ranks, and the rank of each replica, which corresponds to the Horovod rank. The rest of the training service script is modified according to the standard Horovod distributed training rules.\n",
+    "\n",
+    "Let's define the SmartSim entity representing the training service."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_trainer_hvd(experiment, alloc, nodes=1, tasks_per_node=1):\n",
+    "    \"\"\"Start a process running a distributed training service which will\n",
+    "       download batches from the DB and use Horovod to distribute\n",
+    "       data and compute global weight updates.\n",
+    "    \"\"\"\n",
+    "    srun = SrunSettings(exe=\"python\",\n",
+    "                        exe_args=\"training_service_hvd.py\",\n",
+    "                        env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
+    "                        alloc=alloc)\n",
+    "    srun.set_nodes(nodes)\n",
+    "    srun.set_tasks_per_node(tasks_per_node)\n",
+    "\n",
+    "    trainer = experiment.create_model(\"trainer\", srun)\n",
+    "\n",
+    "    # create directories for the output files and copy\n",
+    "    # scripts to execution location inside newly created dir\n",
+    "    # only necessary if its not an executable (python is executable here)\n",
+    "    trainer.attach_generator_files(to_copy=\"./torch/training_service_hvd.py\")\n",
+    "    experiment.generate(trainer, overwrite=True)\n",
+    "    return trainer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 Request an allocation\n",
+    "\n",
+    "As before, we need one node for the DB, two for the producer ensemble, and one for the trainer, thus we request 4 nodes to be allocated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alloc = slurm.get_allocation(nodes=4, time=\"03:00:00\", options={\"constraint\": \"V100\", \"partition\": \"spider\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Run the workflow\n",
+    "\n",
+    "Now that all components are available, we create the SmartSim experiment representing our workflow. The setup is completely identical to the previous example, thus we can start the experiment and look at the output files to see that now each replica has a smaller portion of the dataset, and the training proceeds much faster!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "exp = Experiment(\"launch_streaming_hvd\", launcher=\"slurm\")\n",
+    "\n",
+    "db_port = 6780\n",
+    "\n",
+    "# start the database\n",
+    "db = launch_cluster_orc(exp, db_port, alloc)\n",
+    "uploader_model = create_uploader(exp, alloc, 1, 16)\n",
+    "uploader_model.enable_key_prefixing()\n",
+    "exp.start(uploader_model, block=False, summary=False)\n",
+    "trainer_model = create_trainer_hvd(exp, alloc, 1, 8)\n",
+    "for uploader in uploader_model.entities:\n",
+    "    trainer_model.register_incoming_entity(uploader)\n",
+    "\n",
+    "exp.start(trainer_model, block=True, summary=False)\n",
+    "\n",
+    "# shutdown the database because we don't need it anymore\n",
+    "exp.stop(db)\n",
+    "\n",
+    "print(exp.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.4 Stop the workflow (optional) and release the allocation\n",
+    "If we did not wait until completion of the previous cell, but we stopped it, we need to stop the SmartSim entities. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "exp.stop(db, uploader_model, trainer_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Finally, we release the allocation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slurm.release_allocation(alloc)"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "5f96b028d35977f3d62414249e8a4fc42677d517daea4eab9bcc2f5f43a2f69b"
+  },
+  "kernelspec": {
+   "display_name": "smartsim",
+   "language": "python",
+   "name": "smartsim"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tutorials/06_starting_ray/06_starting_ray_builtin.ipynb
+++ b/tutorials/06_starting_ray/06_starting_ray_builtin.ipynb
@@ -13,7 +13,7 @@
    "id": "624cb31c",
    "metadata": {},
    "source": [
-    "## 5.1 Start the Cluster\n",
+    "## 1 Start the Cluster\n",
     "\n",
     "Before we can begin starting up a Cluster, first we import the relevant modules. We will also deine some global variables of clarity and ease of use:\n",
     " 1. `NUM_NODES` is the number of Ray nodes we will deploy with the first one will be the head node. We will run one node on each host.\n",
@@ -125,7 +125,7 @@
    "id": "847a4a74",
    "metadata": {},
    "source": [
-    "## 5.2 Start the Ray Driver Script\n",
+    "## 2 Start the Ray Driver Script\n",
     "\n",
     "Now we can just connect to our running server."
    ]
@@ -232,7 +232,7 @@
    "id": "6da5f0a5",
    "metadata": {},
    "source": [
-    "## 5.3 Stop Cluster and Release Allocation\n",
+    "## 3 Stop Cluster and Release Allocation\n",
     "\n",
     "When we are finished with the cluster and ready to deallocate resources, we must first shut down the Ray runtime, followed by disconnecting the context."
    ]


### PR DESCRIPTION
This PR mainly adds `CONFIG.get_installed_backends`, a property returning a list of installed Redis AI backends.

This is used e.g. in tests, to check whether the corresponding test should be run. This also helps distinguishing between tests we cannot run because there is no backend, and tests we cannot run because the library is not installed (e.g. `test_freeze_model` which does not need Redis AI).

Notice that for backend tests, we also check whether the module is (still) available, to prevent cases in which a user might have built RedisAI in another env.