### PR TITLE
Fix is_active() call to check_cluster_status()

### DIFF
--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -168,7 +168,7 @@ class Orchestrator(EntityList):
         # if a cluster
         else:
             try:
-                check_cluster_status(trials=1)
+                check_cluster_status(self._hosts, self.ports, trials=1)
                 return True
             # we expect this to fail if the cluster is not active
             except SSInternalError:

--- a/tests/on_wlm/test_launch_orc_cobalt.py
+++ b/tests/on_wlm/test_launch_orc_cobalt.py
@@ -65,6 +65,10 @@ def test_launch_cobalt_cluster_orc(fileutils, wlmutils):
         exp.stop(orc)
         assert False
 
+    if len(orc.get_address()) < 3:
+        exp.stop(orc)
+        assert False
+
     exp.stop(orc)
     status = exp.get_status(orc)
     assert all([stat == status.STATUS_CANCELLED for stat in status])

--- a/tests/on_wlm/test_launch_orc_pbs.py
+++ b/tests/on_wlm/test_launch_orc_pbs.py
@@ -68,6 +68,10 @@ def test_launch_pbs_cluster_orc(fileutils, wlmutils):
         exp.stop(orc)
         assert False
 
+    if len(orc.get_address()) < 3:
+        exp.stop(orc)
+        assert False
+
     exp.stop(orc)
     status = exp.get_status(orc)
     assert all([stat == status.STATUS_CANCELLED for stat in status])

--- a/tests/on_wlm/test_launch_orc_slurm.py
+++ b/tests/on_wlm/test_launch_orc_slurm.py
@@ -61,6 +61,10 @@ def test_launch_slurm_cluster_orc(fileutils, wlmutils):
         exp.stop(orc)
         assert False
 
+    if len(orc.get_address()) < 3:
+        exp.stop(orc)
+        assert False
+
     exp.stop(orc)
     statuses = exp.get_status(orc)
     assert all([stat == status.STATUS_CANCELLED for stat in statuses])


### PR DESCRIPTION
Orchestrator method is_active() had the incorrect set of parameters for check_cluster_status() call.  This PR fixes that and adds a check in WLM tests to check that get_address() (which calls this method) returns correctly sized result.