### PR TITLE
DataLoader fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ docs:
 docks:
 	@if [ -d "docs" ]; then rm -rf docs; fi
 	@mkdir -p docs
-	@docker compose build docs-dev
+	@docker compose build --progress=plain docs-dev
 	@docker create -ti --name devdocs smartsim-docs:dev-latest
 	@docker cp devdocs:/usr/local/src/SmartSim/doc/_build/html/ ./docs/develop/
 	@docker container rm devdocs

--- a/doc/api/smartsim_api.rst
+++ b/doc/api/smartsim_api.rst
@@ -478,7 +478,7 @@ SmartSim includes built-in utilities for supporting TensorFlow and Keras in trai
     :members:
 
 
-.. currentmodule:: smartsim.ml.tf.data
+.. currentmodule:: smartsim.ml.tf
 
 .. autoclass:: StaticDataGenerator
    :show-inheritance:
@@ -497,7 +497,7 @@ PyTorch
 
 SmartSim includes built-in utilities for supporting PyTorch in training and inference.
 
-.. currentmodule:: smartsim.ml.torch.data
+.. currentmodule:: smartsim.ml.torch
 
 .. autoclass:: StaticDataGenerator
    :members:
@@ -524,8 +524,8 @@ Slurm
 
 .. autosummary::
 
-    slurm.get_allocation
-    slurm.release_allocation
+    get_allocation
+    release_allocation
 
 .. automodule:: smartsim.slurm
     :members:

--- a/doc/api/smartsim_api.rst
+++ b/doc/api/smartsim_api.rst
@@ -485,7 +485,7 @@ SmartSim includes built-in utilities for supporting TensorFlow and Keras in trai
    :inherited-members:
    :members:
 
-.. autoclass:: DataGenerator
+.. autoclass:: DynamicDataGenerator
    :members:
    :show-inheritance:
    :inherited-members:
@@ -504,7 +504,7 @@ SmartSim includes built-in utilities for supporting PyTorch in training and infe
    :show-inheritance:
    :inherited-members:
 
-.. autoclass:: DataGenerator
+.. autoclass:: DynamicDataGenerator
    :members:
    :show-inheritance:
    :inherited-members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,3 +83,5 @@ html_static_path = ['_static']
 
 autoclass_content = 'both'
 add_module_names = False
+
+nbsphinx_execute = 'never'

--- a/doc/tutorials/05_training.rst
+++ b/doc/tutorials/05_training.rst
@@ -8,11 +8,11 @@ train a ML model. A typical example is one in which one simulation produces samp
 each time step and another application needs to download the samples as they are produced 
 to train a Deep Neural Network (e.g. a surrogate model).
 
-In this section, we will use components implemented in ``smartsim.ml.tf.data``, to train a
+In this section, we will use components implemented in ``smartsim.ml.tf``, to train a
 Neural Network implemented in TensorFlow and Keras. In particular, we will be using
 two classes:
 - ``smartsim.ml.data.TrainingUploader`` which streamlines the uploading of samples and corresponding targets to the DB
-- ``smartsim.ml.tf.data.DataGenerator`` which is a Keras ``Generator`` which can be used to train a DNN,
+- ``smartsim.ml.tf.DataGenerator`` which is a Keras ``Generator`` which can be used to train a DNN,
 and will download the samples from the DB updating the training set at the end of each epoch.
 
 The SmartSim ``Experiment`` will consist in one mock simulation (the ``producer``) uploading samples,
@@ -81,7 +81,7 @@ the ``training_service`` would look like
 
 .. code-block:: python
 
-    from smartsim.ml.tf.data import DynamicDataGenerator
+    from smartsim.ml.tf import DynamicDataGenerator
     generator = DynamicDataGenerator(
             sample_prefix="points",
             target_prefix="value",
@@ -101,8 +101,8 @@ the ``training_service`` would look like
 
 
 Again, this is enough for simple simulations. If the simulation uses MPI,
-then the ``DataGenerator`` needs to know about the possible sub-indices. For example,
-if the simulation runs 8 MPI ranks, the ``DataGenerator`` initialization will
+then the ``DynamicDataGenerator`` needs to know about the possible sub-indices. For example,
+if the simulation runs 8 MPI ranks, the ``DynamicDataGenerator`` initialization will
 need to be adapted as follows
 
 .. code-block:: python

--- a/doc/tutorials/05_training.rst
+++ b/doc/tutorials/05_training.rst
@@ -31,12 +31,12 @@ An equivalent example using PyTorch instead of TensorFlow is available in the sa
 The first application in the workflow, the ``producer`` will upload batches of samples at regular intervals,
 mimicking the behavior of an iterative simulation. 
 
-Since the ``training_service`` will use a ``smartsim.ml.tf.DataGenerator`` two download the samples, their
+Since the ``training_service`` will use a ``smartsim.ml.tf.DynamicDataGenerator`` two download the samples, their
 keys need to follow a pre-defined format. Assuming that only one process in the simulation
 uploads the data, this format is ``<sample_prefix>_<iteration>``. And for targets
 (which can also be integer labels), the key format is ``<target_prefix>_<iteration>``. Both ``<sample_prefix>``
 and ``<target_prefix>`` are user-defined, and will need to be used to initialize the
-``smartsim.ml.tf.DataGenerator`` object.
+``smartsim.ml.tf.DynamicDataGenerator`` object.
 
 Assuming the simulation is written in Python, then the code would look like
 
@@ -70,23 +70,23 @@ and download them as they are available. The training data set size thus needs t
 each ``producer`` iteration.
 
 In Keras, a ``Sequence`` represents a data set and can be passed to ``model.fit()``.
-The class ``smartsim.ml.tf.DataGenerator`` is a Keras ``Sequence``, which updates
+The class ``smartsim.ml.tf.DynamicDataGenerator`` is a Keras ``Sequence``, which updates
 its data set at the end of each training epoch, looking for newly produced batches of samples.
 A current limitation of the TensorFlow training algorithm is that it does not take
 into account changes of size in the data sets once the training has started, i.e. it is always
 assumed that the training (and validation) data does not change during the training. To
 overcome this limitation, we need to train one epoch at the time. Thus, 
-following what we defined in the :ref:`producer section <ml_training_produced_code>`,
+following what we defined in the :ref:`producer section <ml_training_producer_code>`,
 the ``training_service`` would look like
 
 .. code-block:: python
 
-    from smartsim.ml.tf.data import DataGenerator
-    generator = DataGenerator(
-        sample_prefix="points",
-        target_prefix="value",
-        batch_size=32,
-        cluster=False)
+    from smartsim.ml.tf.data import DynamicDataGenerator
+    generator = DynamicDataGenerator(
+            sample_prefix="points",
+            target_prefix="value",
+            batch_size=32,
+            cluster=False)
 
     model = # some ML model
     # model initialization
@@ -107,12 +107,12 @@ need to be adapted as follows
 
 .. code-block:: python
 
-    generator = DataGenerator(
-        sample_prefix="points",
-        target_prefix="value",
-        batch_size=32,
-        cluster=False,
-        uploader_ranks=8)
+    generator = DynamicDataGenerator(
+                    sample_prefix="points",
+                    target_prefix="value",
+                    batch_size=32,
+                    cluster=False,
+                    uploader_ranks=8)
 
 
 5.1.3 Launching the experiment

--- a/tests/backends/test_dataloader.py
+++ b/tests/backends/test_dataloader.py
@@ -98,7 +98,7 @@ def test_batch_dataloader_tf(fileutils):
     dataloader = create_uploader(exp, config_path, "tf")
     trainer_tf = create_trainer_tf(exp, config_path)
 
-    orc = Orchestrator()
+    orc = Orchestrator(port=6780)
     exp.generate(orc)
     exp.start(orc)
     exp.start(dataloader, block=False)
@@ -131,7 +131,7 @@ def test_batch_dataloader_torch(fileutils):
     dataloader = create_uploader(exp, config_path, "torch")
     trainer_torch = create_trainer_torch(exp, config_path)
 
-    orc = Orchestrator()
+    orc = Orchestrator(port=6780)
     exp.generate(orc)
     exp.start(orc)
     exp.start(dataloader, block=False)
@@ -157,7 +157,7 @@ def test_batch_dataloader_torch(fileutils):
 def test_wrong_dataloaders(fileutils):
     test_dir = fileutils.make_test_dir("test-wrong-dataloaders")
     exp = Experiment("test-wrong-dataloaders", exp_path=test_dir)
-    orc = Orchestrator()
+    orc = Orchestrator(port=6780)
     exp.generate(orc)
     exp.start(orc)
 

--- a/tutorials/01_getting_started/01_getting_started.ipynb
+++ b/tutorials/01_getting_started/01_getting_started.ipynb
@@ -13,11 +13,12 @@
     " - Running and Communicating with the Orchestrator\n",
     " - Ensembles using SmartRedis\n",
     "\n",
+    "\n",
     "## 1.1 Running Models \n",
     "\n",
     "`Experiment`s are how users define workflows in SmartSim. The `Experiment` is used to create `Model` instances which represent applications, scripts, or largely any program. An experiment can start and stop a `Model` and monitor execution.\n",
     "\n",
-    "We begin by importing the `Experiment` class.\n"
+    "We begin by importing the `Experiment` class."
    ]
   },
   {
@@ -1154,7 +1155,7 @@
   }
  ],
  "metadata": {
-"language_info": {
+  "language_info": {
    "codemirror_mode": {
     "name": "ipython",
     "version": 3

--- a/tutorials/05_ml_training/train_tf.ipynb
+++ b/tutorials/05_ml_training/train_tf.ipynb
@@ -52,7 +52,7 @@
     "    # start the database on interactive allocation\n",
     "    experiment.start(db, block=True)\n",
     "\n",
-    "    return db"
+    "    return db\n"
    ]
   },
   {
@@ -64,6 +64,7 @@
     "The data-producing processes will be started as part of an ensemble of two replicas (this mimics the execution of two copies of the simulation). The actual script producing the data is called `data_uploader.py` and is contained in the `tf` directory. Its content is\n",
     "\n",
     "```python\n",
+    "\n",
     "from smartsim.ml import TrainingDataUploader\n",
     "from os import environ\n",
     "from time import sleep\n",
@@ -85,7 +86,6 @@
     "if environ[\"SSKEYOUT\"] == \"uploader_0\":\n",
     "    data_uploader.publish_info()\n",
     "\n",
-    "\n",
     "# Start \"simulation\", produce data every two minutes, for thirty minutes\n",
     "for _ in range(15):\n",
     "    new_batch = np.random.normal(loc=float(mpi_rank), scale=5.0, size=(32*batches_per_loop, 224, 224, 3)).astype(float)\n",
@@ -94,6 +94,7 @@
     "    data_uploader.put_batch(new_batch, new_labels)\n",
     "    print(f\"{mpi_rank}: New data pushed to DB\")\n",
     "    sleep(120)\n",
+    "\n",
     "\n",
     "```\n",
     "\n",
@@ -117,24 +118,24 @@
    "outputs": [],
    "source": [
     "def create_uploader(experiment, alloc, nodes=1, tasks_per_node=1):\n",
-    "    \"\"\"Start an ensemble of two processes producing sample batches at\n",
-    "       regular intervals.\n",
-    "    \"\"\"\n",
-    "    srun = SrunSettings(exe=\"python\",\n",
-    "                        exe_args=\"data_uploader.py\",\n",
-    "                        env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
-    "                        alloc=alloc)\n",
-    "    srun.set_nodes(nodes)\n",
-    "    srun.set_tasks_per_node(tasks_per_node)\n",
+    "   \"\"\"Start an ensemble of two processes producing sample batches at\n",
+    "      regular intervals.\n",
+    "   \"\"\"\n",
+    "   srun = SrunSettings(exe=\"python\",\n",
+    "                     exe_args=\"data_uploader.py\",\n",
+    "                     env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
+    "                     alloc=alloc)\n",
+    "   srun.set_nodes(nodes)\n",
+    "   srun.set_tasks_per_node(tasks_per_node)\n",
     "\n",
-    "    uploader = experiment.create_ensemble(\"uploader\", replicas=2, run_settings=srun)\n",
+    "   uploader = experiment.create_ensemble(\"uploader\", replicas=2, run_settings=srun)\n",
     "\n",
-    "    # create directories for the output files and copy\n",
-    "    # scripts to execution location inside newly created dir\n",
-    "    # only necessary if its not an executable (python is executable here)\n",
-    "    uploader.attach_generator_files(to_copy=[\"./tf/data_uploader.py\"])\n",
-    "    experiment.generate(uploader, overwrite=True)\n",
-    "    return uploader"
+    "   # create directories for the output files and copy\n",
+    "   # scripts to execution location inside newly created dir\n",
+    "   # only necessary if its not an executable (python is executable here)\n",
+    "   uploader.attach_generator_files(to_copy=[\"./tf/data_uploader.py\"])\n",
+    "   experiment.generate(uploader, overwrite=True)\n",
+    "   return uploader"
    ]
   },
   {
@@ -144,6 +145,7 @@
     "The last component of our workflow is the trainer. This process will keep downloading samples as they are produced, and use them to train a neural network.\n",
     "\n",
     "Here is the content of the `training_service.py` script, stored in the `tf` directory\n",
+    "\n",
     "```python\n",
     "import tensorflow.keras as keras\n",
     "\n",
@@ -481,6 +483,12 @@
    ]
   }
  ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/tutorials/05_ml_training/train_tf.ipynb
+++ b/tutorials/05_ml_training/train_tf.ipynb
@@ -481,28 +481,6 @@
    ]
   }
  ],
- "metadata": {
-  "interpreter": {
-   "hash": "5f96b028d35977f3d62414249e8a4fc42677d517daea4eab9bcc2f5f43a2f69b"
-  },
-  "kernelspec": {
-   "display_name": "smartsim",
-   "language": "python",
-   "name": "smartsim"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.10"
-  }
- },
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/tutorials/05_ml_training/train_torch.ipynb
+++ b/tutorials/05_ml_training/train_torch.ipynb
@@ -53,7 +53,7 @@
     "    # start the database on interactive allocation\n",
     "    experiment.start(db, block=True)\n",
     "\n",
-    "    return db"
+    "    return db\n"
    ]
   },
   {
@@ -64,8 +64,8 @@
     "\n",
     "The data-producing processes will be started as part of an ensemble of two replicas (this mimics the execution of two copies of the simulation). The actual script producing the data is called `data_uploader.py` and is contained in the `torch` directory. Its content is\n",
     "\n",
-    "\n",
     "```python\n",
+    "\n",
     "from smartsim.ml import TrainingDataUploader\n",
     "from os import environ\n",
     "from time import sleep\n",
@@ -104,6 +104,7 @@
     "- `producer_prefixes` is used to identify the SmartSim entity names of the processes producing data: this is useful in the case the training service has several incoming entities (as defined in SmartSim, through the environment variable `SSKEYIN`), but it should expect data only from a subset of them. \n",
     "- `num_ranks` is the number of concurrent data loaders withing this application, in this case it is simply the number of MPI ranks, as each process will upload its own data.\n",
     "\n",
+    "\n",
     "At each iteration, each rank of \"simulation\" calls `put_batch` to upload a batch of samples and the corresponding labels. The batch will be uploaded on the DB and stored under a key composed by a prefix (defaulting to `samples`), the sub-index, and the iteration number, which increases monotonically every time a batch is uploaded.\n",
     "\n",
     "Now that we know the content of `data_uploader.py`, we can create an entity representing the uploader ensemble."
@@ -118,24 +119,25 @@
    "outputs": [],
    "source": [
     "def create_uploader(experiment, alloc, nodes=1, tasks_per_node=1):\n",
-    "    \"\"\"Start an ensemble of two processes producing sample batches at\n",
-    "       regular intervals.\n",
-    "    \"\"\"\n",
-    "    srun = SrunSettings(exe=\"python\",\n",
-    "                        exe_args=\"data_uploader.py\",\n",
-    "                        env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
-    "                        alloc=alloc)\n",
-    "    srun.set_nodes(nodes)\n",
-    "    srun.set_tasks_per_node(tasks_per_node)\n",
+    "   \"\"\"Start an ensemble of two processes producing sample batches at\n",
+    "      regular intervals.\n",
+    "   \"\"\"\n",
+    "   srun = SrunSettings(exe=\"python\",\n",
+    "                     exe_args=\"data_uploader.py\",\n",
+    "                     env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
+    "                     alloc=alloc)\n",
+    "   srun.set_nodes(nodes)\n",
+    "   srun.set_tasks_per_node(tasks_per_node)\n",
     "\n",
-    "    uploader = experiment.create_ensemble(\"uploader\", replicas=2, run_settings=srun)\n",
+    "   uploader = experiment.create_ensemble(\"uploader\", replicas=2, run_settings=srun)\n",
     "\n",
-    "    # create directories for the output files and copy\n",
-    "    # scripts to execution location inside newly created dir\n",
-    "    # only necessary if its not an executable (python is executable here)\n",
-    "    uploader.attach_generator_files(to_copy=[\"./torch/data_uploader.py\"])\n",
-    "    experiment.generate(uploader, overwrite=True)\n",
-    "    return uploader"
+    "   # create directories for the output files and copy\n",
+    "   # scripts to execution location inside newly created dir\n",
+    "   # only necessary if its not an executable (python is executable here)\n",
+    "   uploader.attach_generator_files(to_copy=[\"./torch/data_uploader.py\"])\n",
+    "   experiment.generate(uploader, overwrite=True)\n",
+    "   return uploader\n",
+    "   "
    ]
   },
   {
@@ -147,6 +149,7 @@
     "Here is the content of the `training_service.py` script, stored in the `torch` directory\n",
     "\n",
     "```python\n",
+    "\n",
     "import numpy as np\n",
     "import torchvision.models as models\n",
     "from smartsim.ml.torch import DynamicDataGenerator, DataLoader\n",
@@ -199,6 +202,7 @@
     "        epoch_running_loss = 0.0\n",
     "                \n",
     "    print('Finished Training')\n",
+    "    \n",
     "```\n",
     "\n",
     "The key component is the `DataGenerator` object. Since the DB contains the metadata of the `TrainingDataUploader`, and these are stored under a default key, the `DataGenerator` will retrieve them and use them to know the key of the uploaded batches of samples and labels. We need to specify `init_samples=False`, because initialization of the data set will be performed by the `DataLoader` workers: notice that the `DataLoader` is imported from `smartsim.ml.torch`: it is our custom implementation of a data loader, which will also triger a data update at the beginning of each epoch, to check if there are new samples available.\n",
@@ -231,7 +235,8 @@
     "    # only necessary if its not an executable (python is executable here)\n",
     "    trainer.attach_generator_files(to_copy=\"./torch/training_service.py\")\n",
     "    experiment.generate(trainer, overwrite=True)\n",
-    "    return trainer"
+    "    return trainer\n",
+    "    "
    ]
   },
   {
@@ -353,6 +358,7 @@
     "The only component we change with respect to the previous example, is the training service, which is now defined in `training_service_hvd.py`:\n",
     "\n",
     "```python\n",
+    "\n",
     "import numpy as np\n",
     "import torchvision.models as models\n",
     "\n",
@@ -428,6 +434,7 @@
     "            epoch_running_loss = 0.0\n",
     "                \n",
     "    print('Finished Training')\n",
+    "    \n",
     "```\n",
     "\n",
     "Compared to the previous training service, we notice that the only thing changing for the `DataGenerator` is that we need to specify the total number of replicas, which is equal to the total number of Horovod ranks, and the rank of each replica, which corresponds to the Horovod rank. The rest of the training service script is modified according to the standard Horovod distributed training rules.\n",
@@ -442,25 +449,25 @@
    "outputs": [],
    "source": [
     "def create_trainer_hvd(experiment, alloc, nodes=1, tasks_per_node=1):\n",
-    "    \"\"\"Start a process running a distributed training service which will\n",
-    "       download batches from the DB and use Horovod to distribute\n",
-    "       data and compute global weight updates.\n",
-    "    \"\"\"\n",
-    "    srun = SrunSettings(exe=\"python\",\n",
-    "                        exe_args=\"training_service_hvd.py\",\n",
-    "                        env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
-    "                        alloc=alloc)\n",
-    "    srun.set_nodes(nodes)\n",
-    "    srun.set_tasks_per_node(tasks_per_node)\n",
+    "   \"\"\"Start a process running a distributed training service which will\n",
+    "      download batches from the DB and use Horovod to distribute\n",
+    "      data and compute global weight updates.\n",
+    "   \"\"\"\n",
+    "   srun = SrunSettings(exe=\"python\",\n",
+    "                     exe_args=\"training_service_hvd.py\",\n",
+    "                     env_vars={\"PYTHONUNBUFFERED\": \"1\"},\n",
+    "                     alloc=alloc)\n",
+    "   srun.set_nodes(nodes)\n",
+    "   srun.set_tasks_per_node(tasks_per_node)\n",
     "\n",
-    "    trainer = experiment.create_model(\"trainer\", srun)\n",
+    "   trainer = experiment.create_model(\"trainer\", srun)\n",
     "\n",
-    "    # create directories for the output files and copy\n",
-    "    # scripts to execution location inside newly created dir\n",
-    "    # only necessary if its not an executable (python is executable here)\n",
-    "    trainer.attach_generator_files(to_copy=\"./torch/training_service_hvd.py\")\n",
-    "    experiment.generate(trainer, overwrite=True)\n",
-    "    return trainer"
+    "   # create directories for the output files and copy\n",
+    "   # scripts to execution location inside newly created dir\n",
+    "   # only necessary if its not an executable (python is executable here)\n",
+    "   trainer.attach_generator_files(to_copy=\"./torch/training_service_hvd.py\")\n",
+    "   experiment.generate(trainer, overwrite=True)\n",
+    "   return trainer\n"
    ]
   },
   {
@@ -557,6 +564,12 @@
    ]
   }
  ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/tutorials/05_ml_training/train_torch.ipynb
+++ b/tutorials/05_ml_training/train_torch.ipynb
@@ -557,28 +557,6 @@
    ]
   }
  ],
- "metadata": {
-  "interpreter": {
-   "hash": "5f96b028d35977f3d62414249e8a4fc42677d517daea4eab9bcc2f5f43a2f69b"
-  },
-  "kernelspec": {
-   "display_name": "smartsim",
-   "language": "python",
-   "name": "smartsim"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.10"
-  }
- },
  "nbformat": 4,
  "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR adds fixes for some issues introduced by the DataLoaders, namely:
- DataLoaders were incorrectly linked in docs
- DataLoader notebooks included kernels and that made `make docks` fail
- `test_dataloaders.py` used the standard Redis port for the orchestrators, but that port is already in use on some systems (switched to 6780)