### PR TITLE
High Level Docs Update / Changelog for 0.4.0

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -26,6 +26,11 @@ made to ensure an optimal experience. Here is a
 comprehensive list of changes made in SmartSim 0.4.0.
 
 
+Orchestrator Enhancements:
+
+ - Add Orchestrator Co-location (SmartSim-PR139_)
+ - Add Orchestrator configuration file edit methods (SmartSim-PR109_)
+
 Emphasize Driver Script Portability:
 
  - Add ability to create run settings through an experiment (SmartSim-PR110_)
@@ -35,7 +40,7 @@ Emphasize Driver Script Portability:
 Expand Machine Learning Library Support:
 
  - Add Ray cluster setup and deployment to SmartSim (SmartSim-PR50_)
- - Add machine learning data loaders for Keras/TF and Pytorch (SmartSim-PR115_)
+ - Add machine learning data loaders for Keras/TF and Pytorch (SmartSim-PR115_) (SmartSim-PR140_)
  - Launch Ray internally using ``RunSettings`` (SmartSim-PR118_)
 
 Expand Launcher Setting Options:
@@ -49,6 +54,7 @@ General Improvements and Bug Fixes:
  - Abstract away non-user facing implementation details (SmartSim-PR122_)
  - Add various dimensions to the CI build matrix for SmartSim testing (SmartSim-PR130_)
  - Add missing functions to LSFSettings API (SmartSim-PR113_)
+ - Add RedisAI checker for installed backends (SmartSim-PR137_)
  - Remove heavy and unnecessary dependencies (SmartSim-PR116_) (SmartSim-PR132_)
  - Fix LSFLauncher and LSFOrchestrator (SmartSim-PR86_)
  - Fix over greedy Workload Manager Parsers (SmartSim-PR95_)
@@ -57,8 +63,8 @@ General Improvements and Bug Fixes:
 
 Documentation Updates:
 
- - Updates to documentation build process (SmartSim-PR133_)
- - Updates to documentation content (SmartSim-PR96_) (SmartSim-PR129_)
+ - Updates to documentation build process (SmartSim-PR133_) (SmartSim-PR143_)
+ - Updates to documentation content (SmartSim-PR96_) (SmartSim-PR129_) (SmartSim-PR136_) (SmartSim-PR141_)
  - Update SmartSim Examples (SmartSim-PR68_) (SmartSim-PR100_)
 
 
@@ -72,6 +78,7 @@ Documentation Updates:
 .. _SmartSim-PR104: https://github.com/CrayLabs/SmartSim/pull/104
 .. _SmartSim-PR107: https://github.com/CrayLabs/SmartSim/pull/107
 .. _SmartSim-PR108: https://github.com/CrayLabs/SmartSim/pull/108
+.. _SmartSim-PR109: https://github.com/CrayLabs/SmartSim/pull/109
 .. _SmartSim-PR110: https://github.com/CrayLabs/SmartSim/pull/110
 .. _SmartSim-PR112: https://github.com/CrayLabs/SmartSim/pull/112
 .. _SmartSim-PR113: https://github.com/CrayLabs/SmartSim/pull/113
@@ -85,7 +92,13 @@ Documentation Updates:
 .. _SmartSim-PR130: https://github.com/CrayLabs/SmartSim/pull/130
 .. _SmartSim-PR132: https://github.com/CrayLabs/SmartSim/pull/132
 .. _SmartSim-PR133: https://github.com/CrayLabs/SmartSim/pull/133
+.. _SmartSim-PR136: https://github.com/CrayLabs/SmartSim/pull/136
+.. _SmartSim-PR137: https://github.com/CrayLabs/SmartSim/pull/137
 .. _SmartSim-PR138: https://github.com/CrayLabs/SmartSim/pull/138
+.. _SmartSim-PR139: https://github.com/CrayLabs/SmartSim/pull/139
+.. _SmartSim-PR140: https://github.com/CrayLabs/SmartSim/pull/140
+.. _SmartSim-PR141: https://github.com/CrayLabs/SmartSim/pull/141
+.. _SmartSim-PR143: https://github.com/CrayLabs/SmartSim/pull/143
 
 
 0.3.2

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,7 +14,7 @@ SmartSim
 0.4.0
 -----
 
-Expected release on Feb 11, 2022
+Released on Feb 11, 2022
 
 Description:
 In this release SmartSim continues to promote ease of use.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,22 +17,50 @@ SmartSim
 Expected release on Feb 11, 2022
 
 Description:
+In this release SmartSim continues to promote ease of use.
+To this end SmartSim has introduced new portability features
+that allow users to abstract away their targeted hardware,
+while providing even more compatibility with existing
+libraries. Additional tweaks and upgrades have also been
+made to ensure an optimal experience. Here is a
+comprehensive list of changes made in SmartSim 0.4.0.
+
+
+Emphasize Driver Script Portability:
 
  - Add ability to create run settings through an experiment (SmartSim-PR110_)
  - Add ability to create batch settings through an experiment (SmartSim-PR112_)
- - Add automatic launcher detection to experiment poratability functions (SmartSim-PR120_)
+ - Add automatic launcher detection to experiment portability functions (SmartSim-PR120_)
+
+Expand Machine Learning Library Support:
+
  - Add Ray cluster setup and deployment to SmartSim (SmartSim-PR50_)
  - Add machine learning data loaders for Keras/TF and Pytorch (SmartSim-PR115_)
+ - Launch Ray internally using ``RunSettings`` (SmartSim-PR118_)
+
+Expand Launcher Setting Options:
+
+ - Add ability to use base ``RunSettings`` on a Slurm, PBS, or Cobalt launchers (SmartSim-PR90_) 
+ - Add ability to use base ``RunSettings`` on LFS launcher (SmartSim-PR108_)
+
+General Improvements and Bug Fixes:
+
  - Improve and extend parameter handling (SmartSim-PR107_) (SmartSim-PR119_)
- - Abstract non-user facing implimentation details (SmartSim-PR122_)
- - Add various dimensions to the CI build matrix (SmartSim-PR130_)
+ - Abstract away non-user facing implementation details (SmartSim-PR122_)
+ - Add various dimensions to the CI build matrix for SmartSim testing (SmartSim-PR130_)
+ - Add missing functions to LSFSettings API (SmartSim-PR113_)
  - Remove heavy and unnecessary dependencies (SmartSim-PR116_) (SmartSim-PR132_)
- - Bug fixes (SmartSim-PR95_) (SmartSim-PR104_) (SmartSim-PR138_)
- - Update SmartSim Examples (SmartSim-PR68_) (SmartSim-PR100_)
+ - Fix LSFLauncher and LSFOrchestrator (SmartSim-PR86_)
+ - Fix over greedy Workload Manager Parsers (SmartSim-PR95_)
+ - Fix Slurm handling of comma-separated env vars (SmartSim-PR104_)
+ - Fix internal method calls (SmartSim-PR138_)
+
+Documentation Updates:
+
  - Updates to documentation build process (SmartSim-PR133_)
  - Updates to documentation content (SmartSim-PR96_) (SmartSim-PR129_)
+ - Update SmartSim Examples (SmartSim-PR68_) (SmartSim-PR100_)
 
- - TODO: Not Sure (SmartSim-PR86_) (SmartSim-PR90_) (SmartSim-PR108_) (SmartSim-PR113_) (SmartSim-PR118_)
 
 .. _SmartSim-PR50: https://github.com/CrayLabs/SmartSim/pull/50
 .. _SmartSim-PR68: https://github.com/CrayLabs/SmartSim/pull/68

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,6 +11,55 @@ Jump to :ref:`SmartRedis Changelog <changelog>`
 SmartSim
 ========
 
+0.4.0
+-----
+
+Expected release on Feb 11, 2022
+
+Description:
+
+ - Add ability to create run settings through an experiment (SmartSim-PR110_)
+ - Add ability to create batch settings through an experiment (SmartSim-PR112_)
+ - Add automatic launcher detection to experiment poratability functions (SmartSim-PR120_)
+ - Add Ray cluster setup and deployment to SmartSim (SmartSim-PR50_)
+ - Add machine learning data loaders for Keras/TF and Pytorch (SmartSim-PR115_)
+ - Improve and extend parameter handling (SmartSim-PR107_) (SmartSim-PR119_)
+ - Abstract non-user facing implimentation details (SmartSim-PR122_)
+ - Add various dimensions to the CI build matrix (SmartSim-PR130_)
+ - Remove heavy and unnecessary dependencies (SmartSim-PR116_) (SmartSim-PR132_)
+ - Bug fixes (SmartSim-PR95_) (SmartSim-PR104_) (SmartSim-PR138_)
+ - Update SmartSim Examples (SmartSim-PR68_) (SmartSim-PR100_)
+ - Updates to documentation build process (SmartSim-PR133_)
+ - Updates to documentation content (SmartSim-PR96_) (SmartSim-PR129_)
+
+ - TODO: Not Sure (SmartSim-PR86_) (SmartSim-PR90_) (SmartSim-PR108_) (SmartSim-PR113_) (SmartSim-PR118_)
+
+.. _SmartSim-PR50: https://github.com/CrayLabs/SmartSim/pull/50
+.. _SmartSim-PR68: https://github.com/CrayLabs/SmartSim/pull/68
+.. _SmartSim-PR86: https://github.com/CrayLabs/SmartSim/pull/86
+.. _SmartSim-PR90: https://github.com/CrayLabs/SmartSim/pull/90
+.. _SmartSim-PR95: https://github.com/CrayLabs/SmartSim/pull/95
+.. _SmartSim-PR96: https://github.com/CrayLabs/SmartSim/pull/96
+.. _SmartSim-PR100: https://github.com/CrayLabs/SmartSim/pull/100
+.. _SmartSim-PR104: https://github.com/CrayLabs/SmartSim/pull/104
+.. _SmartSim-PR107: https://github.com/CrayLabs/SmartSim/pull/107
+.. _SmartSim-PR108: https://github.com/CrayLabs/SmartSim/pull/108
+.. _SmartSim-PR110: https://github.com/CrayLabs/SmartSim/pull/110
+.. _SmartSim-PR112: https://github.com/CrayLabs/SmartSim/pull/112
+.. _SmartSim-PR113: https://github.com/CrayLabs/SmartSim/pull/113
+.. _SmartSim-PR115: https://github.com/CrayLabs/SmartSim/pull/115
+.. _SmartSim-PR116: https://github.com/CrayLabs/SmartSim/pull/116
+.. _SmartSim-PR118: https://github.com/CrayLabs/SmartSim/pull/118
+.. _SmartSim-PR119: https://github.com/CrayLabs/SmartSim/pull/119
+.. _SmartSim-PR120: https://github.com/CrayLabs/SmartSim/pull/120
+.. _SmartSim-PR122: https://github.com/CrayLabs/SmartSim/pull/122
+.. _SmartSim-PR129: https://github.com/CrayLabs/SmartSim/pull/129
+.. _SmartSim-PR130: https://github.com/CrayLabs/SmartSim/pull/130
+.. _SmartSim-PR132: https://github.com/CrayLabs/SmartSim/pull/132
+.. _SmartSim-PR133: https://github.com/CrayLabs/SmartSim/pull/133
+.. _SmartSim-PR138: https://github.com/CrayLabs/SmartSim/pull/138
+
+
 0.3.2
 -----
 

--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -98,6 +98,7 @@ Setup
 =====
 
   - Fork the SmartSim (SmartRedis) repository
+  - The origin remote should be set to your fork for pull and push
   - Set upstream as the main repository and set upstream push remote to ``no_push``
   - Follow installation instructions
 
@@ -110,9 +111,9 @@ Please check the following before submitting a pull request to the SmartSim repo
   1) Your feature is on a new branch off master.
   2) You are merging the feature branch from your fork into the main repository.
   3) All unnecessary whitespace has been purged from your code.
-  4) Black and isort have been applied to format code and sort imports
+  4) For Python code changes, Black and isort have been applied to format code and sort imports
   5) Pylint errors have been minimized as much as possible
-  6) All your code as been appropriately documented.
+  6) All your code has been appropriately documented.
   7) The PR description is clear and concise.
   8) You have requested a review.
 
@@ -142,18 +143,34 @@ are a few things to specifically mention.
   - Utilize ``conftest.py`` for creating pytest fixtures
 
 
+SmartSim Python Style Guide Do's and Don'ts:
+
+  - DON'T use global variables or the global keyword unless necessary
+  - DON'T over comment code when it reads like English
+  - DO use underscores on methods that should not be used outside a class
+  - DO use comprehensions
+  - DON'T write functions for more than one purpose
+  - DON'T allow functions to return more than one type
+  - DON'T use protected member variables outside a class
+  - DON'T use single letter variable names
+  - DO use entire words in names (i.e. get_function not get_func)
+  - DON'T use wildcard imports (i.e. ``from package import *``) unless ``__all__`` is defined
+  - DO use snake_case when naming functions, methods, and variables
+  - DO use PascalCase when naming Classes
+  - DO use the logging module
+
 ---------------------------------------------------------
 
 ==================
 Editor Suggestions
 ==================
 
-The editor that we suggest developers to use is VSCode. Below are some extensions that
+The editor that we suggest developers use is VSCode. Below are some extensions that
 could make the process of developing on SmartSim a bit easier.
 
     - GitLens, for viewing changes in the git history
     - Remote SSH, for connecting to clusters and supercomputers
-    - PyLance, Langauge Server
+    - PyLance, Language Server
     - Python indent, for correcting python indents
     - reStructuredText, for writing documentation
     - Strict Whitespace, for ensuring no whitespace left in code

--- a/doc/experiment.rst
+++ b/doc/experiment.rst
@@ -30,17 +30,17 @@ The instances created by an ``Experiment`` fall into two classes:
   1. ``SmartSimEntity``
   2. ``EntityList``
 
-``Model`` instances are ``SmartSimEntity`` objects. ``Ensemble`` instances
-are ``EntityList`` objects. ``EntityList`` instances are containers of
-``SmartSimEntity`` objects.
+``SmartSimEntity`` objects are bundles of information about an executable launched from
+SmartSim, such as its name and settings for how it should be run. ``EntityList`` objects
+are containers of several ``SmartSimEntity`` objects.
 
 Model
 =====
 
-``Model(s)`` are created through the Experiment API. Models represent
-any computational kernel. Models are flexible enough to support many
-different applications, however, to be used with our clients (SmartRedis)
-the application will have to be written in Python, C, C++, or Fortran.
+``Model(s)`` are subclasses of ``SmartSimEntity(s)`` and are created through the
+Experiment API. Models represent any computational kernel. Models are flexible enough
+to support many different applications, however, to be used with our clients
+(SmartRedis) the application will have to be written in Python, C, C++, or Fortran.
 
 Models are given :ref:`RunSettings <rs-api>` objects that specify how a kernel should
 be executed with regard to the workload manager (e.g. Slurm) and the available
@@ -78,14 +78,16 @@ Three strategies are built in:
   3. ``random`` for random selection from predefined parameter spaces.
 
 A callable function can also be supplied for custom permutation strategies.
-The function should take in two lists: parameter names and parameter values.
-The function should return a list of dictionaries that will be supplied as
-model parameters. The length of the list returned will determine how many
-``Model`` instances are created.
+The function should take two arguments: a list of parameter names and a list of lists
+of potential parameter values. The function should return a list of dictionaries that
+will be supplied as model parameters. The length of the list returned will determine
+how many ``Model`` instances are created.
 
 For example, the following the the built-in strategy ``all_perm``.
 
 .. code-block:: python
+
+    from itertools import product
 
     def create_all_permutations(param_names, param_values):
         perms = list(product(*param_values))
@@ -105,7 +107,7 @@ Launching Ensembles
 
 Ensembles can be launched in previously obtained interactive allocations
 and as a batch. Similar to ``RunSettings``, ``BatchSettings`` specify how
-a application(s) in a batch job should be executed with regards to the system
+an application(s) in a batch job should be executed with regards to the system
 workload manager and available compute resources.
 
   - :ref:`SbatchSettings <sbatch_api>` for Slurm

--- a/doc/launchers.rst
+++ b/doc/launchers.rst
@@ -9,7 +9,7 @@ launching them onto a system.
 
 The `launchers` allow SmartSim users to interact with their system
 programmatically through a python interface.
-Because of this, SmartSim users don’t have to leave the Jupyter Notebook,
+Because of this, SmartSim users don't have to leave the Jupyter Notebook,
 Python REPL, or Python script to launch, query, and interact with their jobs.
 
 SmartSim currently supports 5 `launchers`:
@@ -149,7 +149,7 @@ The above code would generate a ``salloc`` command like:
 
 .. code-block:: bash
 
-    salloc -N 5 -C haswell --parition debug --time 10:00:00 --exclusive
+    salloc -N 5 -C haswell --partition debug --time 10:00:00 --exclusive
 
 
 

--- a/doc/orchestrator.rst
+++ b/doc/orchestrator.rst
@@ -5,9 +5,9 @@ Orchestrator
 
 The ``Orchestrator`` is an in-memory database that is launched prior to all other
 entities within an ``Experiment``. The ``Orchestrator`` can be used to store and retrieve
-data during the course of an experiment. In order to stream data into
-or receive data from the ``Orchestrator``, one of the SmartSim clients (SmartRedis) has to be
-used within a Model.
+data during the course of an experiment and across multiple entities. In order to
+stream data into or receive data from the ``Orchestrator``, one of the SmartSim clients
+(SmartRedis) has to be used within a Model.
 
 .. |orchestrator| image:: images/Orchestrator.png
   :width: 700


### PR DESCRIPTION
High Level Docs Update:
- Pass over `experiment`/`launchers`/`orchestrator` docs for spelling/grammar/wording
- Add brief description of overall goals for release
- Compiles a list of PRs made since the last release into a single list
    - Similar PRs grouped together into an overall heading
    - Provides a brief description of the changes made in each
    - Willing to have this be pruned and/or sorted in nicer categories based on maintainers suggestions