### PR TITLE
Fixes to mpirun, mpmd, and aprun

### DIFF
--- a/smartsim/_core/launcher/step/mpirunStep.py
+++ b/smartsim/_core/launcher/step/mpirunStep.py
@@ -128,14 +128,15 @@ class MpirunStep(Step):
         if self.run_settings.mpmd:
             return self._make_mpmd()
         else:
-            cmd = self.run_settings.exe
-            cmd += self.run_settings.exe_args
-            return cmd
+            exe = self.run_settings.exe
+            args = self.run_settings.exe_args
+            return exe + args
 
     def _make_mpmd(self):
         """Build mpirun (MPMD) executable"""
-        cmd = self.run_settings.exe
-        cmd += self.run_settings.exe_args
+        exe = self.run_settings.exe
+        args = self.run_settings.exe_args
+        cmd = exe + args
         for mpmd in self.run_settings.mpmd:
             cmd += [" : "]
             cmd += mpmd.format_run_args()

--- a/smartsim/_core/launcher/taskManager.py
+++ b/smartsim/_core/launcher/taskManager.py
@@ -185,7 +185,7 @@ class TaskManager:
         try:
             task = self[task_id]
             if task.is_alive:
-                task.terminate()
+                task.kill()
                 returncode = task.check_status()
                 out, err = task.get_io()
                 self.add_task_history(task_id, returncode, out, err)

--- a/smartsim/constants.py
+++ b/smartsim/constants.py
@@ -26,13 +26,14 @@
 
 # Constants for SmartSim
 
-from .log import get_logger
+from warnings import warn, simplefilter
 
-logger = get_logger(__name__)
 
 dep_msg = "This is a deprecated module. Please use smartsim.status instead.\n"
 dep_msg += "This module will be removed in the next release."
-logger.warning(dep_msg)
+
+simplefilter("once", DeprecationWarning)
+warn(dep_msg, DeprecationWarning)
 
 
 # Statuses that are applied to jobs

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -131,10 +131,10 @@ class Orchestrator(EntityList):
         if launcher == "local" and batch:
             msg = "Local launcher can not be launched with batch=True"
             raise SmartSimError(msg)
-        if launcher == "pbs" and batch and single_cmd:
-            msg = "PBS Orchestrator can not be launched with batch=True and single_cmd=True. "
+        if run_command == "aprun" and batch and single_cmd:
+            msg = "aprun can launched orchestrator with batch=True and single_cmd=True. "
             msg += "Automatically switching to single_cmd=False."
-            logger.info()
+            logger.info(msg)
             single_cmd = False
 
         self.launcher = launcher

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -879,7 +879,7 @@ class CobaltOrchestrator(Orchestrator):
         :param time: walltime for batch 'HH:MM:SS' format
         :type time: str, optional
         """
-        simplefilter("always", DeprecationWarning)
+        simplefilter("once", DeprecationWarning)
         msg = "CobaltOrchestrator(...) is deprecated and will be removed in a future release.\n"
         msg += "Please update your code to use Orchestrator(launcher='cobalt', ...)."
         warn(msg, DeprecationWarning)
@@ -959,7 +959,7 @@ class LSFOrchestrator(Orchestrator):
         :param interface: network interface to use
         :type interface: str
         """
-        simplefilter("always", DeprecationWarning)
+        simplefilter("once", DeprecationWarning)
         msg = "LSFOrchestrator(...) is deprecated and will be removed in a future release.\n"
         msg += "Please update your code to use Orchestrator(launcher='lsf', ...)."
         warn(msg, DeprecationWarning)
@@ -1036,7 +1036,7 @@ class SlurmOrchestrator(Orchestrator):
         :param single_cmd: run all shards with one (MPMD) command, defaults to True
         :type single_cmd: bool
         """
-        simplefilter("always", DeprecationWarning)
+        simplefilter("once", DeprecationWarning)
         msg = "SlurmOrchestrator(...) is deprecated and will be removed in a future release.\n"
         msg += "Please update your code to use Orchestrator(launcher='slurm', ...)."
         warn(msg, DeprecationWarning)
@@ -1102,7 +1102,7 @@ class PBSOrchestrator(Orchestrator):
         :param queue: queue to launch batch in
         :type queue: str, optional
         """
-        simplefilter("always", DeprecationWarning)
+        simplefilter("once", DeprecationWarning)
         msg = "PBSOrchestrator(...) is deprecated and will be removed in a future release.\n"
         msg += "Please update your code to use Orchestrator(launcher='pbs', ...)."
         warn(msg, DeprecationWarning)

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -131,6 +131,11 @@ class Orchestrator(EntityList):
         if launcher == "local" and batch:
             msg = "Local launcher can not be launched with batch=True"
             raise SmartSimError(msg)
+        if launcher == "pbs" and batch and single_cmd:
+            msg = "PBS Orchestrator can not be launched with batch=True and single_cmd=True. "
+            msg += "Automatically switching to single_cmd=False."
+            logger.info()
+            single_cmd = False
 
         self.launcher = launcher
         self.run_command = run_command

--- a/tests/full_wlm/test_generic_orc_launch_batch.py
+++ b/tests/full_wlm/test_generic_orc_launch_batch.py
@@ -121,7 +121,7 @@ def test_launch_cluster_orc_batch_multi(fileutils, wlmutils):
     assert all([stat == status.STATUS_CANCELLED for stat in statuses])
 
     
-def test_launch_slurm_cluster_orc_reconnect(fileutils, wlmutils):
+def test_launch_cluster_orc_reconnect(fileutils, wlmutils):
     """test reconnecting to clustered 3-node orchestrator"""
     launcher = wlmutils.get_test_launcher()
     exp_name = "test-launch-cluster-orc-batch-reconect"
@@ -152,7 +152,7 @@ def test_launch_slurm_cluster_orc_reconnect(fileutils, wlmutils):
 
     exp.stop(orc)
 
-    exp_name = "test-orc-slurm-cluster-orc-batch-reconnect-2nd"
+    exp_name = "test-orc-cluster-orc-batch-reconnect-2nd"
     exp_2 = Experiment(exp_name, launcher=launcher)
 
     checkpoint = osp.join(test_dir, "smartsim_db.dat")

--- a/tests/full_wlm/test_mpmd.py
+++ b/tests/full_wlm/test_mpmd.py
@@ -53,7 +53,7 @@ def test_slurm_mpmd(fileutils, wlmutils):
     test_dir = fileutils.make_test_dir(exp_name)
     for run_command in run_commands:
         script = fileutils.get_test_conf_path("sleep.py")
-        settings = exp.create_run_settings("python", f"{script} --time=15", run_command=run_command)
+        settings = exp.create_run_settings("python", f"{script} --time=5", run_command=run_command)
         settings.set_tasks(1)
 
         settings.make_mpmd(deepcopy(settings))

--- a/tests/full_wlm/test_mpmd.py
+++ b/tests/full_wlm/test_mpmd.py
@@ -53,14 +53,14 @@ def test_slurm_mpmd(fileutils, wlmutils):
     test_dir = fileutils.make_test_dir(exp_name)
     for run_command in run_commands:
         script = fileutils.get_test_conf_path("sleep.py")
-        settings = exp.create_run_settings("python", f"{script} --time=5", run_command=run_command)
+        settings = exp.create_run_settings("python", f"{script} --time=15", run_command=run_command)
         settings.set_tasks(1)
 
         settings.make_mpmd(deepcopy(settings))
         settings.make_mpmd(deepcopy(settings))
 
         mpmd_model = exp.create_model("mmpd", path=test_dir, run_settings=settings)
-
+        exp.generate(mpmd_model, overwrite=True)
         exp.start(mpmd_model, block=True)
         statuses = exp.get_status(mpmd_model)
         assert all([stat == status.STATUS_COMPLETED for stat in statuses])

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -8,20 +8,24 @@ try:
 except ImportError:
     tf_available = False
 
-def test_deprecated_orchestrators():
+def test_deprecated_orchestrators(wlmutils):
     with pytest.deprecated_call():
-        _ = SlurmOrchestrator()
+        _ = SlurmOrchestrator(interface=wlmutils.get_test_interface())
 
     with pytest.deprecated_call():
-        _ = LSFOrchestrator()
+        _ = LSFOrchestrator(interface=wlmutils.get_test_interface())
 
     with pytest.deprecated_call():
-        _ = CobaltOrchestrator()
+        _ = CobaltOrchestrator(interface=wlmutils.get_test_interface())
 
     with pytest.deprecated_call():
-        _ = PBSOrchestrator()
+        _ = PBSOrchestrator(interface=wlmutils.get_test_interface())
 
 @pytest.mark.skipif(not tf_available, reason="Requires TF to run")
 def test_deprecated_tf():
     with pytest.deprecated_call():
         from smartsim.tf import freeze_model
+
+def test_deprecated_constants():
+    with pytest.deprecated_call():
+        from smartsim import constants


### PR DESCRIPTION
This PR adds fixes to issues encountered while testing on specific systems. Specifically:
- mpirun mpmd behavior which concatenated more commands than needed was fixed
- prevent aprun batch launch of orchestrator with single_cmd
- terminate processes with kill to prevent issues with mpirun on slurm-based systems
- update deprecations and tests thereof
- fix names of some generic tests