### PR TITLE
Run github action test suite in PRs only

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,6 +1,6 @@
 name: run-tests
 
-on: [push, pull_request]
+on: pull_request
 
 env:
   HOMEBREW_NO_ANALYTICS: "ON" # Make Homebrew installation a little quicker


### PR DESCRIPTION
Run github action test suite in pull requests only, instead of on any push to any branch on any fork.

Note that the `pull request` trigger includes open, reopen, and sync, where sync includes pushing commits to a branch with an open PR.