### PR TITLE
Move docker pip install to requirements-doc.txt

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -3,5 +3,6 @@ breathe==4.31.0
 sphinx-book-theme==0.2.0
 sphinx-fortran==1.1.1
 nbsphinx>=0.8.2
+docutils==0.17
 torch==1.7.1
 tensorflow==2.5.2

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -3,3 +3,5 @@ breathe==4.31.0
 sphinx-book-theme==0.2.0
 sphinx-fortran==1.1.1
 nbsphinx>=0.8.2
+torch==1.7.1
+tensorflow==2.5.2

--- a/docker/docs/dev/Dockerfile
+++ b/docker/docs/dev/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone https://github.com/CrayLabs/SmartRedis.git --branch develop --dept
     && python -m pip install . \
     && rm -rf ~/.cache/pip
 
-
 RUN cd doc/tutorials/ && \
     ln -s ../../tutorials/* .
+
 RUN make docs

--- a/docker/docs/dev/Dockerfile
+++ b/docker/docs/dev/Dockerfile
@@ -19,8 +19,14 @@ RUN python -m pip install ipython ipykernel torch==1.7.1 tensorflow==2.5.2
 
 COPY . /usr/local/src/SmartSim/
 WORKDIR /usr/local/src/SmartSim/
-RUN NO_CHECKS=1 SMARTSIM_SUFFIX=dev python -m pip install .[doc]
 
+# Install docs dependencies
+RUN python -m pip install -r doc/requirements-doc.txt
+
+# Install smartsim
+RUN NO_CHECKS=1 SMARTSIM_SUFFIX=dev python -m pip install .
+
+# Install smartredis
 RUN git clone https://github.com/CrayLabs/SmartRedis.git --branch develop --depth=1 smartredis \
     && cd smartredis \
     && python -m pip install . \


### PR DESCRIPTION
Moved the additional python package dependencies from the docker file to the documentation requirements file.

This resolves a `make docks` bug that showed up on MacOS with python 3.8+ where the dependency resolution resulted in an error (specifically, when trying to resolve version for `appnope`).

Also removed `ipykernel` and `ipython` from requirements, since they are included as dependencies to `nbsphinx`.
