### PR TITLE
Update CMake version from 3.10 to 3.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          python -m pip install cmake>=3.10
+          python -m pip install cmake>=3.13
           python setup.py sdist
 
       - uses: actions/upload-artifact@v2

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -15,7 +15,7 @@ The base prerequisites to install SmartSim and SmartRedis are:
 
   - Python 3.7-3.9
   - Pip
-  - Cmake 3.10.x (or later)
+  - Cmake 3.13.x (or later)
   - C compiler
   - C++ compiler
   - GNU Make > 4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 
 [build-system]
-requires = ["setuptools", "wheel", "cmake>=3.10"]
+requires = ["setuptools", "wheel", "cmake>=3.13"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 packages = find:
 setup_requires =
     setuptools>=39.2
-    cmake>=3.10
+    cmake>=3.13
 include_package_data = True
 python_requires = >=3.7
 


### PR DESCRIPTION
The SmartSim documentation lists CMake version 3.10 as a requirement for SmartSim and SmartRedis.  SmartRedis was upgraded to a minimum CMake version of 3.13.  This PR updates the documentation.  Also, to maintain a consistent build and test environment, the CMake minimum version has also been upgrade in SmartSim.   The current version of CMake is 3.23, so users are unlikely to notice a change unless they are using a very old version of CMake, and newer versions of CMake are easily installed in a conda environment.