### PR TITLE
Add ipython dep to doc build

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -6,3 +6,4 @@ nbsphinx>=0.8.2
 docutils==0.17
 torch==1.7.1
 tensorflow==2.5.2
+ipython


### PR DESCRIPTION
One liner, forgot to add ipython back into the build. it's needed separately from nbsphinx as detail in this issue

https://github.com/spatialaudio/nbsphinx/issues/24

