### PR TITLE
Fix wrong handling of LSF gpus_per_shard option

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -187,7 +187,7 @@ class WLMUtils:
         elif test_launcher == "cobalt":
             db = CobaltOrchestrator(db_nodes=nodes, port=port, batch=batch, interface=test_nic)
         elif test_launcher == "lsf":
-            db = LSFOrchestrator(db_nodes=nodes, port=port, batch=batch, gpus_per_shard=1 if test_device=="GPU" else 0, project=get_account(), interface=test_nic)
+            db = LSFOrchestrator(db_nodes=nodes, port=port, batch=batch, cpus_per_shard=4, gpus_per_shard=2 if test_device=="GPU" else 0, project=get_account(), interface=test_nic)
         else:
             db = Orchestrator(port=port, interface="lo")
         return db

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -491,10 +491,7 @@ from which these instructions are executed.
                                     tensorflow=2.6.2 \
                                     libtensorflow=2.6.2 \
                                     pytorch=1.9.0 \
-                                    torchvision=0.10.0 \
-                                    onnx \
-                                    onnxruntime \
-                                    skl2onnx
+                                    torchvision=0.10.0 
   conda activate $ENV_NAME
   export CC=$(which gcc)
   export CXX=$(which g++)

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -602,7 +602,7 @@ class Orchestrator(EntityList):
             assigned_smts += cpus_per_shard
             if gpus_per_shard > 1:  # pragma: no-cover
                 erf_sets["gpu"] = (
-                    "{" + f"{assigned_gpus}-{assigned_gpus+self.gpus_per_shard-1}" + "}"
+                    "{" + f"{assigned_gpus}-{assigned_gpus+gpus_per_shard-1}" + "}"
                 )
             elif gpus_per_shard > 0:
                 erf_sets["gpu"] = "{" + f"{assigned_gpus}" + "}"


### PR DESCRIPTION
This is a hotfix PR, a mishandled option is preventing LSF orchestrators from using more than one GPU per shard.