### PR TITLE
Fix re-run smart build bug

### DIFF
--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -320,7 +320,7 @@ class Build:
         if os.environ.get("RAI_PATH"):
             if installed_redisai_backends():
                 logger.error(
-                    f"Backends are already built and loaded at {CONFIG.redisai}. There is no need to build."
+                    f"There is no need to build. Backends are already built and specified in the environment at 'RAI_PATH': {CONFIG.redisai}"
                 )
             else:
                 logger.error(

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -311,7 +311,6 @@ class Build:
         except SetupError as e:
             logger.warning(str(e))
 
-
     def check_backends_install(self):
         """Checks if backends have already been installed.
         Logs details on how to proceed forward
@@ -320,9 +319,13 @@ class Build:
         """
         if os.environ.get("RAI_PATH"):
             if installed_redisai_backends():
-                logger.error(f"Backends are already built and loaded at {CONFIG.redisai}. There is no need to build.")
+                logger.error(
+                    f"Backends are already built and loaded at {CONFIG.redisai}. There is no need to build."
+                )
             else:
-                logger.error(f"Before running 'smart build', unset your RAI_PATH environment variable with 'unset RAI_PATH'.")
+                logger.error(
+                    f"Before running 'smart build', unset your RAI_PATH environment variable with 'unset RAI_PATH'."
+                )
             exit(1)
         else:
             if installed_redisai_backends():

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -154,11 +154,7 @@ class Build:
         print(f"    ONNX {self.versions.ONNX}: {color_bool(onnx)}\n")
         print(f"Building for GPU support: {color_bool(device == 'gpu')}\n")
 
-        if os.path.isdir(CONFIG.lib_path) and os.listdir(CONFIG.lib_path):
-            logger.error(
-                "If you wish to re-run `smart build`, you must first run `smart clean`."
-            )
-            exit(1)
+        self.check_backends_install()
 
         # Check for onnx and tf in user python environemnt and prompt user
         # to download them if they are not installed. this should not break
@@ -314,3 +310,23 @@ class Build:
                 )
         except SetupError as e:
             logger.warning(str(e))
+
+
+    def check_backends_install(self):
+        """Checks if backends have already been installed.
+        Logs details on how to proceed forward
+        if the RAI_PATH environment variable is set or if
+        backends have already been installed.
+        """
+        if os.environ.get("RAI_PATH"):
+            if installed_redisai_backends():
+                logger.error(f"Backends are already built and loaded at {CONFIG.redisai}. There is no need to build.")
+            else:
+                logger.error(f"Before running 'smart build', unset your RAI_PATH environment variable with 'unset RAI_PATH'.")
+            exit(1)
+        else:
+            if installed_redisai_backends():
+                logger.error(
+                    "If you wish to re-run `smart build`, you must first run `smart clean`."
+                )
+                exit(1)


### PR DESCRIPTION
This PR fixes #162. 
There are four cases that this PR accounts for which have been confirmed to work on local machine and Horizon.
1. User attempts to run `smart build` when `RAI_PATH` is set and backends are installed
   - Inform user that backends are already built, tell them where they are built, and notify the user that there is no reason to build.
2. User attempts to run `smart build` when `RAI_PATH` is set, but backends are not installed
   - Inform user that before running `smart build`, they should unset `RAI_PATH`
3. User attempts to run `smart build` when `RAI_PATH` is not set and backends are installed
   - Inform user that they need to run `smart clean` before running `smart build`
4. User attempts to run `smart build` when `RAI_PATH` is not set and backends are not installed
   - Allow `smart build` to continue