### PR TITLE
Fix run_args issue in create_database

### DIFF
--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -534,16 +534,13 @@ class Orchestrator(EntityList):
         return batch_settings
 
     def _build_run_settings(self, exe, exe_args, **kwargs):
-        run_command = kwargs.get("run_command")
         run_args = kwargs.pop("run_args", {})
         db_nodes = kwargs.get("db_nodes", 1)
         single_cmd = kwargs.get("single_cmd", True)
         mpmd_nodes = single_cmd and db_nodes > 1
 
         if mpmd_nodes:
-            # Slurm MPMD needs total number of nodes
-            if self.launcher == "slurm":
-                run_args["nodes"] = db_nodes
+            
             run_settings = create_run_settings(
                 exe=exe, exe_args=exe_args[0], run_args=run_args.copy(), **kwargs
             )

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -540,10 +540,10 @@ class Orchestrator(EntityList):
         single_cmd = kwargs.get("single_cmd", True)
         mpmd_nodes = single_cmd and db_nodes > 1
 
-        if self.launcher == "slurm":
-            run_args["nodes"] = 1 if not mpmd_nodes else db_nodes
-
         if mpmd_nodes:
+            # Slurm MPMD needs total number of nodes
+            if self.launcher == "slurm":
+                run_args["nodes"] = db_nodes
             run_settings = create_run_settings(
                 exe=exe, exe_args=exe_args[0], run_args=run_args.copy(), **kwargs
             )

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -560,7 +560,7 @@ class Orchestrator(EntityList):
                 run_settings.make_mpmd(mpmd_run_settings)
         else:
             run_settings = create_run_settings(
-                exe=exe, exe_args=exe_args, run_args=run_args, **kwargs
+                exe=exe, exe_args=exe_args, run_args=run_args.copy(), **kwargs
             )
 
             if self.launcher != "local":

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -535,10 +535,13 @@ class Orchestrator(EntityList):
 
     def _build_run_settings(self, exe, exe_args, **kwargs):
         run_command = kwargs.get("run_command")
-        run_args = kwargs.get("run_args", {})
+        run_args = kwargs.pop("run_args", {})
         db_nodes = kwargs.get("db_nodes", 1)
         single_cmd = kwargs.get("single_cmd", True)
         mpmd_nodes = single_cmd and db_nodes > 1
+
+        if self.launcher == "slurm":
+            run_args["nodes"] = 1 if not mpmd_nodes else db_nodes
 
         if mpmd_nodes:
             run_settings = create_run_settings(
@@ -566,13 +569,13 @@ class Orchestrator(EntityList):
         if self.launcher != "local":
             run_settings.set_tasks_per_node(1)
 
-        if isinstance(run_settings, SrunSettings):
-            run_args["nodes"] = 1 if not mpmd_nodes else db_nodes
+        # Put it back in case it is needed again
+        kwargs["run_args"] = run_args
 
         return run_settings
 
     def _build_run_settings_lsf(self, exe, exe_args, **kwargs):
-        run_args = kwargs.get("run_args", {}).copy()
+        run_args = kwargs.pop("run_args", {})
         cpus_per_shard = kwargs.get("cpus_per_shard", None)
         gpus_per_shard = kwargs.get("gpus_per_shard", None)
         old_host = None
@@ -581,7 +584,7 @@ class Orchestrator(EntityList):
             host = shard_id
             run_args["launch_distribution"] = "packed"
 
-            run_settings = JsrunSettings(exe, args, run_args=run_args)
+            run_settings = JsrunSettings(exe, args, run_args=run_args.copy())
             run_settings.set_binding("none")
 
             # This makes sure output is written to orchestrator_0.out, orchestrator_1.out, and so on
@@ -616,6 +619,7 @@ class Orchestrator(EntityList):
                 run_settings.make_mpmd()
                 erf_rs = run_settings
 
+        kwargs["run_args"] = run_args
         return erf_rs
 
     def _initialize_entities(self, **kwargs):


### PR DESCRIPTION
This PR fixes an incorrect usage of `kwargs` in `Orchestrator._build_run_settings`.
Since `run_args` is not popped from `kwargs`, when we use it as argument in `create_run_settings`, two copies are passed, causing an error.

We also eliminated an unused Slurm option setting, which was redundant.