### PR TITLE
Set test hostlist to None when aprun is available

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -102,6 +102,9 @@ def get_hostlist():
             except:
                 return None
         elif "PBS_NODEFILE" in os.environ:
+            # On Cray systems, PBS_NODEFILE can contain the MOM node name
+            if shutil.which("aprun"):
+                return None
             try:
                 with open(os.environ["PBS_NODEFILE"], 'r') as nodefile:
                     lines = nodefile.readlines()


### PR DESCRIPTION
On certain Cray systems, PBS_NODEFILE does not contain the list of allocated nodes (it actually contains the name MOM node from which it was launched). This breaks some tests where the hostlist is used to launch the orchestrator on PBS. This PR prevents PBS_NODEFILE to be parsed when `aprun` is available (i.e. if the system is a Cray).