### PR TITLE
Keydb support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ smartredis
 # written upon install
 smartsim/version.py
 
-smartsim/_core/bin/redis-server
-smartsim/_core/bin/redis-cli
+smartsim/_core/bin/*-server
+smartsim/_core/bin/*-cli
 
 # created upon install
 smartsim/_core/lib

--- a/setup.py
+++ b/setup.py
@@ -108,14 +108,14 @@ class InstallPlatlib(install):
 class SmartSimBuild(build_py):
 
     def run(self):
-        redis_builder = builder.RedisBuilder(build_env(),
+        database_builder = builder.DatabaseBuilder(build_env(),
                                              build_env.MALLOC,
                                              build_env.JOBS)
-        if not redis_builder.is_built:
-            redis_builder.build_from_git(versions.REDIS_URL,
+        if not database_builder.is_built:
+            database_builder.build_from_git(versions.REDIS_URL,
                                          versions.REDIS)
 
-            redis_builder.cleanup()
+            database_builder.cleanup()
 
         # run original build_py command
         build_py.run(self)

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -121,6 +121,8 @@ class Build:
         logger.info("SmartSim build complete!")
 
     def build_database(self):
+        if self.keydb:
+            CONFIG.conf_path = Path(CONFIG.core_path, "config", "keydb.conf")
         # check database installation
         database_name = "KeyDB" if self.keydb else "Redis"
         database_builder = builder.DatabaseBuilder(

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -123,16 +123,22 @@ class Build:
     def build_database(self):
         # check database installation
         database_name = "KeyDB" if self.keydb else "Redis"
-        database_builder = builder.DatabaseBuilder(self.build_env(), self.build_env.MALLOC, self.build_env.JOBS, self.verbose)
+        database_builder = builder.DatabaseBuilder(
+            self.build_env(), self.build_env.MALLOC, self.build_env.JOBS, self.verbose
+        )
 
         if not database_builder.is_built:
+            version = Version_("6.2.0") if self.keydb else self.versions.REDIS
             logger.info(
-                f"Building {database_name} version {self.versions.REDIS} from {self.versions.REDIS_URL}"
+                f"Building {database_name} version {version} from {self.versions.REDIS_URL}"
             )
-
-            database_builder.build_from_git(
-                self.versions.REDIS_URL, self.versions.REDIS_BRANCH
+            database_url = (
+                "https://github.com/EQ-Alpha/KeyDB"
+                if self.keydb
+                else self.versions.REDIS_URL
             )
+            database_branch = "v6.2.0" if self.keydb else self.versions.REDIS_BRANCH
+            database_builder.build_from_git(database_url, database_branch)
             database_builder.cleanup()
         logger.info(f"{database_name} build complete!")
 

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -88,9 +88,8 @@ class Build:
             self.build_env = BuildEnv()
 
             if self.verbose:
-                db_name = "KEYDB" if self.keydb else "REDIS"
                 logger.info("Build Environment:")
-                env = self.build_env.as_dict(db_name=db_name)
+                env = self.build_env.as_dict()
                 print(tabulate(env, headers=env.keys(), tablefmt="github"), "\n")
 
             logger.info("Checking requested versions...")
@@ -107,8 +106,9 @@ class Build:
                     )
 
             if self.verbose:
+                db_name = "KEYDB" if self.keydb else "REDIS"
                 logger.info("Version Information:")
-                vers = self.versions.as_dict()
+                vers = self.versions.as_dict(db_name=db_name)
                 print(tabulate(vers, headers=vers.keys(), tablefmt="github"), "\n")
 
             # REDIS/KeyDB

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -94,6 +94,12 @@ class Build:
             logger.info("Checking requested versions...")
             self.versions = Versioner()
 
+            if self.keydb:
+                self.versions.REDIS = Version_("6.2.0")
+                self.versions.REDIS_URL = "https://github.com/EQ-Alpha/KeyDB"
+                self.versions.REDIS_BRANCH = "v6.2.0"
+                CONFIG.conf_path = Path(CONFIG.core_path, "config", "keydb.conf")
+
             if self.verbose:
                 logger.info("Version Information:")
                 vers = self.versions.as_dict()
@@ -121,26 +127,16 @@ class Build:
         logger.info("SmartSim build complete!")
 
     def build_database(self):
-        if self.keydb:
-            CONFIG.conf_path = Path(CONFIG.core_path, "config", "keydb.conf")
         # check database installation
         database_name = "KeyDB" if self.keydb else "Redis"
         database_builder = builder.DatabaseBuilder(
             self.build_env(), self.build_env.MALLOC, self.build_env.JOBS, self.verbose
         )
-
         if not database_builder.is_built:
-            version = Version_("6.2.0") if self.keydb else self.versions.REDIS
             logger.info(
-                f"Building {database_name} version {version} from {self.versions.REDIS_URL}"
+                f"Building {database_name} version {self.versions.REDIS} from {self.versions.REDIS_URL}"
             )
-            database_url = (
-                "https://github.com/EQ-Alpha/KeyDB"
-                if self.keydb
-                else self.versions.REDIS_URL
-            )
-            database_branch = "v6.2.0" if self.keydb else self.versions.REDIS_BRANCH
-            database_builder.build_from_git(database_url, database_branch)
+            database_builder.build_from_git(self.versions.REDIS_URL, self.versions.REDIS_BRANCH)
             database_builder.cleanup()
         logger.info(f"{database_name} build complete!")
 

--- a/smartsim/_core/_cli/clean.py
+++ b/smartsim/_core/_cli/clean.py
@@ -53,7 +53,7 @@ class Clean:
 
         bin_path = self._core_path / "bin"
         if bin_path.is_dir() and _all:
-            files_to_remove = ["redis-server", "redis-cli"]
+            files_to_remove = ["redis-server", "redis-cli", "keydb-server", "keydb-cli"]
             removed = False
             for _file in files_to_remove:
                 file_path = bin_path.joinpath(_file)
@@ -62,4 +62,4 @@ class Clean:
                     removed = True
                     file_path.unlink()
             if removed:
-                logger.info("Successfully removed SmartSim Redis installation")
+                logger.info("Successfully removed SmartSim database installation")

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -58,14 +58,13 @@ class SmartCli:
         exit(0)
 
     def dbcli(self):
-        install_path = get_install_path()
-        script_path = next((install_path / "_core" / "bin").glob("*-cli")).resolve()
-        if script_path.is_file():
-            print(script_path)
-            exit(0)
-        else:
-            print("Database (Redis or KeyDB) dependencies not found")
-            exit(1)
+        bin_path = get_install_path() / "_core" / "bin"
+        for option in bin_path.iterdir():
+            if option.name in ("redis-cli", "keydb-cli"):
+                print(option)
+                exit(0)
+        print("Database (Redis or KeyDB) dependencies not found")
+        exit(1)
 
 
 def main():

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import argparse
-import glob
 import sys
 
 from smartsim._core._cli.build import Build
@@ -60,7 +59,7 @@ class SmartCli:
 
     def dbcli(self):
         install_path = get_install_path()
-        script_path = install_path.joinpath(glob.glob("_core/bin/*-cli")).resolve()
+        script_path = next((install_path / "_core" / "bin").glob("*-cli")).resolve()
         if script_path.is_file():
             print(script_path)
             exit(0)

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import glob
 import sys
 
 from smartsim._core._cli.build import Build
@@ -59,12 +60,12 @@ class SmartCli:
 
     def dbcli(self):
         install_path = get_install_path()
-        script_path = install_path.joinpath("_core/bin/redis-cli").resolve()
+        script_path = install_path.joinpath(glob.glob("_core/bin/*-cli")).resolve()
         if script_path.is_file():
             print(script_path)
             exit(0)
         else:
-            print("Redis dependencies not found")
+            print("Database (Redis or KeyDB) dependencies not found")
             exit(1)
 
 

--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -210,12 +210,11 @@ class Versioner:
     TENSORFLOW = Version_(REDISAI.tensorflow)
     ONNX = Version_(REDISAI.onnx)
 
-    def as_dict(self):
-        database_name = "REDIS" if "redis" in self.REDIS_URL else "KEYDB"
+    def as_dict(self, db_name="REDIS"):
         packages = [
             "SMARTSIM",
             "SMARTREDIS",
-            database_name,
+            db_name,
             "REDISAI",
             "TORCH",
             "TENSORFLOW",

--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -211,10 +211,11 @@ class Versioner:
     ONNX = Version_(REDISAI.onnx)
 
     def as_dict(self):
+        database_name = "REDIS" if "redis" in self.REDIS_URL else "KEYDB"
         packages = [
             "SMARTSIM",
             "SMARTREDIS",
-            "REDIS",
+            database_name,
             "REDISAI",
             "TORCH",
             "TENSORFLOW",

--- a/smartsim/_core/_install/builder.py
+++ b/smartsim/_core/_install/builder.py
@@ -186,12 +186,9 @@ class DatabaseBuilder(Builder):
         server_destination = self.bin_path / (database_name.lower() + "-server")
         cli_source = database_src_dir / (database_name.lower() + "-cli")
         cli_destination = self.bin_path / (database_name.lower() + "-cli")
-        # server_source = glob.glob(database_src_dir / "*-server")[0]
-        # server_destination = glob.glob(self.bin_path / "*-server")[0]
-        # cli_source = glob.glob(database_src_dir / "*-cli")[0]
-        # cli_destination = glob.glob(self.bin_path / "*-cli")[0]
         self.copy_file(server_source, server_destination, set_exe=True)
         self.copy_file(cli_source, cli_destination, set_exe=True)
+
 
 class RedisAIBuilder(Builder):
     """Class to build RedisAI from Source
@@ -249,9 +246,9 @@ class RedisAIBuilder(Builder):
         :param device: cpu or gpu
         :type device: str
         """
-        rai_deps_path = sorted(self.rai_build_path.glob(
-            os.path.join("deps", f"*{device}*")
-        ))
+        rai_deps_path = sorted(
+            self.rai_build_path.glob(os.path.join("deps", f"*{device}*"))
+        )
         if not rai_deps_path:
             raise FileNotFoundError("Could not find RedisAI 'deps' directory")
 
@@ -283,11 +280,15 @@ class RedisAIBuilder(Builder):
         if src_libtf_lib_dir.is_dir():
             library_files = sorted(src_libtf_lib_dir.glob("*"))
             if not library_files:
-                raise FileNotFoundError(f"Could not find libtensorflow library files in {src_libtf_lib_dir}")
+                raise FileNotFoundError(
+                    f"Could not find libtensorflow library files in {src_libtf_lib_dir}"
+                )
         else:
             library_files = sorted(libtf_path.glob("lib*.so*"))
             if not library_files:
-                raise FileNotFoundError(f"Could not find libtensorflow library files in {libtf_path}")
+                raise FileNotFoundError(
+                    f"Could not find libtensorflow library files in {libtf_path}"
+                )
 
         for src_file in library_files:
             dst_file = rai_libtf_lib_dir / src_file.name

--- a/smartsim/_core/_install/builder.py
+++ b/smartsim/_core/_install/builder.py
@@ -130,10 +130,11 @@ class DatabaseBuilder(Builder):
 
     @property
     def is_built(self):
-        """Check if Redis is built"""
-        server = next(self.bin_path.glob("*-server"), None) is not None
-        cli = next(self.bin_path.glob("*-cli"), None) is not None
-        return server and cli
+        """Check if Redis or KeyDB is built"""
+        bin_files = {file.name for file in self.bin_path.iterdir()}
+        redis_files = {"redis-server", "redis-cli"}
+        keydb_files = {"keydb-server", "keydb-cli"}
+        return redis_files.issubset(bin_files) or keydb_files.issubset(bin_files)
 
     def build_from_git(self, git_url, branch):
         """Build Redis from git
@@ -142,7 +143,7 @@ class DatabaseBuilder(Builder):
         :param branch: branch to checkout
         :type branch: str
         """
-        database_name = "redis" if "redis" in git_url else "KeyDB"
+        database_name = "KeyDB" if "KeyDB" in git_url else "redis"
         database_build_path = Path(self.build_dir, database_name.lower())
 
         # remove git directory if it exists as it should

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -102,30 +102,30 @@ class Config:
         return str(redisai)
 
     @property
-    def redis_conf(self) -> str:
+    def database_conf(self) -> str:
         conf = Path(os.environ.get("REDIS_CONF", self.conf_path)).resolve()
         if not conf.is_file():
             raise SSConfigError(
-                "Redis configuration file at REDIS_CONF could not be found"
+                "Database configuration file at REDIS_CONF could not be found"
             )
         return str(conf)
 
     @property
-    def redis_exe(self) -> str:
+    def database_exe(self) -> str:
         try:
-            redis_exe = self.bin_path / "redis-server"
-            redis = Path(os.environ.get("REDIS_PATH", redis_exe)).resolve()
-            exe = expand_exe_path(str(redis))
+            database_exe = next(self.bin_path.glob("*-server"))
+            database = Path(os.environ.get("REDIS_PATH", database_exe)).resolve()
+            exe = expand_exe_path(str(database))
             return exe
         except (TypeError, FileNotFoundError) as e:
             raise SSConfigError(
-                "Specified Redis binary at REDIS_PATH could not be used"
+                "Specified database binary at REDIS_PATH could not be used"
             ) from e
 
     @property
-    def redis_cli(self) -> str:
+    def database_cli(self) -> str:
         try:
-            redis_cli_exe = self.bin_path / "redis-cli"
+            redis_cli_exe = next(self.bin_path.glob("*-cli"))
             redis_cli = Path(os.environ.get("REDIS_CLI_PATH", redis_cli_exe)).resolve()
             exe = expand_exe_path(str(redis_cli))
             return exe

--- a/smartsim/_core/launcher/colocated.py
+++ b/smartsim/_core/launcher/colocated.py
@@ -121,8 +121,8 @@ def _build_colocated_wrapper_cmd(port=6780,
 
     # collect DB binaries and libraries from the config
     db_cmd = [
-        CONFIG.redis_exe,
-        CONFIG.redis_conf,
+        CONFIG.database_exe,
+        CONFIG.database_conf,
         "--loadmodule",
         CONFIG.redisai
     ]

--- a/smartsim/_core/utils/redis.py
+++ b/smartsim/_core/utils/redis.py
@@ -62,7 +62,7 @@ def create_cluster(hosts, ports):  # cov-wlm
             ip_list.append(address)
 
     # call cluster command
-    redis_cli = CONFIG.redis_cli
+    redis_cli = CONFIG.database_cli
     cmd = [redis_cli, "--cluster", "create"]
     cmd += ip_list
     cmd += ["--cluster-replicas", "0"]

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -179,7 +179,7 @@ class Orchestrator(EntityList):
             # will raise SSConfigError if not found
             self._redis_exe
             self._redis_conf
-            CONFIG.redis_cli
+            CONFIG.database_cli
         except SSConfigError as e:
             msg = "SmartSim not installed with pre-built extensions (Redis)\n"
             msg += "Use the `smart` cli tool to install needed extensions\n"
@@ -299,11 +299,11 @@ class Orchestrator(EntityList):
 
     @property
     def _redis_exe(self):
-        return CONFIG.redis_exe
+        return CONFIG.database_exe
 
     @property
     def _redis_conf(self):
-        return CONFIG.redis_conf
+        return CONFIG.database_conf
 
     def set_cpus(self, num_cpus):
         """Set the number of CPUs available to each database shard

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,9 +10,9 @@ from smartsim.error import SSConfigError
 def test_all_config_defaults():
     config = Config()
     assert Path(config.redisai).is_file()
-    assert Path(config.redis_exe).is_file()
-    assert Path(config.redis_cli).is_file()
-    assert Path(config.redis_conf).is_file()
+    assert Path(config.database_exe).is_file()
+    assert Path(config.database_cli).is_file()
+    assert Path(config.database_conf).is_file()
 
     # these will be changed so we will just run them
     assert config.log_level
@@ -38,25 +38,25 @@ def test_redisai():
 
 def test_redis_conf():
     config = Config()
-    assert Path(config.redis_conf).is_file()
-    assert isinstance(config.redis_conf, str)
+    assert Path(config.database_conf).is_file()
+    assert isinstance(config.database_conf, str)
 
     os.environ["REDIS_CONF"] = "not/a/path"
     config = Config()
     with pytest.raises(SSConfigError):
-        config.redis_conf
+        config.database_conf
     os.environ.pop("REDIS_CONF")
 
 
 def test_redis_exe():
     config = Config()
-    assert Path(config.redis_exe).is_file()
-    assert isinstance(config.redis_exe, str)
+    assert Path(config.database_exe).is_file()
+    assert isinstance(config.database_exe, str)
 
     os.environ["REDIS_PATH"] = "not/a/path"
     config = Config()
     with pytest.raises(SSConfigError):
-        config.redis_exe
+        config.database_exe
     os.environ.pop("REDIS_PATH")
 
 
@@ -68,5 +68,5 @@ def test_redis_cli():
     os.environ["REDIS_CLI_PATH"] = "not/a/path"
     config = Config()
     with pytest.raises(SSConfigError):
-        config.redis_cli
+        config.database_cli
     os.environ.pop("REDIS_CLI_PATH")


### PR DESCRIPTION
This PR adds the ability to use `KeyDB` in place of `Redis` as the database through a new `--keydb` flag for `smart build`. This flexibility enables users to maximize their throughput if they desire.