### PR TITLE
Remove preset environment variables from slurmSettings and mpirunSettings

### DIFF
--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -138,7 +138,9 @@ class SrunStep(Step):
                 env_var_str,
                 comma_separated_env_vars,
             ) = self.run_settings.format_comma_sep_env_vars()
-            srun_cmd += ["--export", env_var_str]
+
+            if len(env_var_str) > 0:
+                srun_cmd += ["--export", env_var_str]
 
             if comma_separated_env_vars:
                 srun_cmd = ["env"] + comma_separated_env_vars + srun_cmd
@@ -199,7 +201,8 @@ class SrunStep(Step):
             cmd += mpmd.format_run_args()
             cmd += ["--job-name", self.name]
             (env_var_str, _) = mpmd.format_comma_sep_env_vars()
-            cmd += ["--export", env_var_str]
+            if len(env_var_str) > 0:
+                cmd += ["--export", env_var_str]
             cmd += mpmd.exe
             cmd += mpmd.exe_args
 

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -368,7 +368,7 @@ class RunSettings:
         val_types = typing.get_args(val_types_union)
         # Coerce env_vars values to str as a convenience to user
         for (env, val) in env_vars.items():
-            if not isinstance(val, value_types):
+            if not isinstance(val, val_types):
                 raise TypeError(f"env_vars[{env}] was of type {type(val)}, not {val_types_union}")
             else:
                 self.env_vars[env] = str(val)

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -359,10 +359,12 @@ class RunSettings:
     def update_env(self, env_vars):
         """Update the job environment variables
 
-        To fully inherit the current user environment, add the
-        workload-manager-specific flag to the launch command through the
-        :meth:`add_exe_args` method. For example, ``--export=ALL`` for slurm,
-        or ``-V`` for PBS/aprun.
+        .. note:
+
+            To fully inherit the current user environment, add the
+            workload-manager-specific flag to the launch command through the
+            :meth:`add_exe_args` method. For example, ``--export=ALL`` for
+            slurm, or ``-V`` for PBS/aprun.
 
 
         :param env_vars: environment variables to update or add

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -24,6 +24,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import typing
+
 from .._core.utils.helpers import expand_exe_path, fmt_dict, init_default, is_valid_cmd
 from ..log import get_logger
 
@@ -358,9 +360,18 @@ class RunSettings:
         """Update the job environment variables
 
         :param env_vars: environment variables to update or add
-        :type env_vars: dict[str, str]
+        :type env_vars: dict[str, Union[str, int, float, bool]]
+        :raises TypeError: if env_vars values cannot be coerced to strings
         """
-        self.env_vars.update(env_vars)
+        val_types_union = typing.Union[str, int, float, bool]
+        # Expand union type so it can be used in isinstance()
+        val_types = typing.get_args(val_types_union)
+        # Coerce env_vars values to str as a convenience to user
+        for (env, val) in env_vars.items():
+            if not isinstance(val, value_types):
+                raise TypeError(f"env_vars[{env}] was of type {type(val)}, not {val_types_union}")
+            else:
+                self.env_vars[env] = str(val)
 
     def add_exe_args(self, args):
         """Add executable arguments to executable

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -357,12 +357,10 @@ class RunSettings:
     def update_env(self, env_vars):
         """Update the job environment variables
 
-        .. note:
-
-            To fully inherit the current user environment, add the
-            workload-manager-specific flag to the launch command through the
-            :meth:`add_exe_args` method. For example, ``--export=ALL`` for
-            slurm, or ``-V`` for PBS/aprun.
+        To fully inherit the current user environment, add the
+        workload-manager-specific flag to the launch command through the
+        :meth:`add_exe_args` method. For example, ``--export=ALL`` for
+        slurm, or ``-V`` for PBS/aprun.
 
 
         :param env_vars: environment variables to update or add

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -377,7 +377,7 @@ class RunSettings:
             if not isinstance(val, val_types):
                 raise TypeError(f"env_vars[{env}] was of type {type(val)}, not {val_types_union}")
             else:
-                self.env_vars[env] = str(val)
+                self.env_vars[env] = val
 
     def add_exe_args(self, args):
         """Add executable arguments to executable

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -24,8 +24,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import typing
-
 from .._core.utils.helpers import expand_exe_path, fmt_dict, init_default, is_valid_cmd
 from ..log import get_logger
 
@@ -371,12 +369,10 @@ class RunSettings:
         :type env_vars: dict[str, Union[str, int, float, bool]]
         :raises TypeError: if env_vars values cannot be coerced to strings
         """
-        val_types_union = typing.Union[str, int, float, bool]
-        # Expand union type so it can be used in isinstance()
-        val_types = typing.get_args(val_types_union)
+        val_types = (str, int, float, bool)
         # Coerce env_vars values to str as a convenience to user
         for (env, val) in env_vars.items():
-            if not isinstance(val, val_types):
+            if type(val) not in val_types:
                 raise TypeError(f"env_vars[{env}] was of type {type(val)}, not {val_types_union}")
             else:
                 self.env_vars[env] = val

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -359,6 +359,12 @@ class RunSettings:
     def update_env(self, env_vars):
         """Update the job environment variables
 
+        To fully inherit the current user environment, add the
+        workload-manager-specific flag to the launch command through the
+        :meth:`add_exe_args` method. For example, ``--export=ALL`` for slurm,
+        or ``-V`` for PBS/aprun.
+
+
         :param env_vars: environment variables to update or add
         :type env_vars: dict[str, Union[str, int, float, bool]]
         :raises TypeError: if env_vars values cannot be coerced to strings

--- a/smartsim/settings/mpirunSettings.py
+++ b/smartsim/settings/mpirunSettings.py
@@ -224,16 +224,10 @@ class MpirunSettings(RunSettings):
     def format_env_vars(self):
         """Format the environment variables for mpirun
 
-        Automatically exports ``PYTHONPATH``, ``LD_LIBRARY_PATH``
-        and ``PATH``
-
         :return: list of env vars
         :rtype: list[str]
         """
         formatted = []
-        presets = ["PATH", "LD_LIBRARY_PATH", "PYTHONPATH"]
-        for preset in presets:
-            formatted.extend(["-x", preset])
 
         if self.env_vars:
             for name, value in self.env_vars.items():

--- a/smartsim/settings/slurmSettings.py
+++ b/smartsim/settings/slurmSettings.py
@@ -291,24 +291,9 @@ class SrunSettings(RunSettings):
         :returns: the formatted string of environment variables
         :rtype: tuple[str, list[str]]
         """
-        # TODO make these overridable by user
-        presets = ["PATH", "LD_LIBRARY_PATH", "PYTHONPATH"]
 
         comma_separated_format_str = []
-
-        def add_env_var(var, format_str):
-            try:
-                value = os.environ[var]
-                format_str += "=".join((var, value)) + ","
-                return format_str
-            except KeyError:
-                return format_str
-
         format_str = ""
-
-        # add env var presets due to slurm weirdness
-        for preset in presets:
-            format_str = add_env_var(preset, format_str)
 
         # add user supplied variables
         for k, v in self.env_vars.items():

--- a/tests/test_openmpi_settings.py
+++ b/tests/test_openmpi_settings.py
@@ -52,12 +52,6 @@ def test_format_env():
     formatted = settings.format_env_vars()
     result = [
         "-x",
-        "PATH",
-        "-x",
-        "LD_LIBRARY_PATH",
-        "-x",
-        "PYTHONPATH",
-        "-x",
         "OMP_NUM_THREADS=10",
         "-x",
         "LOGGING=verbose",


### PR DESCRIPTION
Remove preset environment variables from slurmSettings and mpirunSettings since they are no longer needed.

Some other clean-ups:

- Check env var value types earlier in the process to ensure types are correct before launching any jobs
- Added a note to the `update_env` docs to inform users on how to have smartsim inherit the user environment
- Only throw `--export` flag if env_vars is not empty, otherwise we get an argument parsing error

Verified full testing passes on an HPC system with `SMARTSIM_TEST_LAUNCHER=slurm`.

Resolves #128