### PR TITLE
Add GitHub button to docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -76,6 +76,12 @@ fortran_src = [
 # a list of builtin themes.
 html_theme = "sphinx_book_theme"
 
+html_theme_options = {
+    "repository_url": "https://github.com/CrayLabs/SmartSim",
+    "use_repository_button": True,
+    "use_issues_button": True,
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
This PR adds a GitHub button to the documentation. The button provides an easy way for viewers of the documentation to jump straight to the source code, and also to jump straight to creating an issue in the SmartSim repo.