### PR TITLE
Kill jobs on KeyboardInterrupt

### DIFF
--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -26,6 +26,7 @@
 
 import os.path as osp
 import pickle
+import signal
 import threading
 import time
 
@@ -69,16 +70,13 @@ class Controller:
         The controller will start the job-manager thread upon
         execution of all jobs.
         """
-        try:
-            self._launch(manifest)
+        self._jobs.kill_on_interrupt = kill_on_interrupt
+        signal.signal(signal.SIGINT, self._jobs.signal_interrupt)
+        self._launch(manifest)
 
-            # start the job manager thread if not already started
-            if not self._jobs.actively_monitoring:
-                self._jobs.start()
-
-        except KeyboardInterrupt:
-            self._jobs.signal_interrupt(kill_on_interrupt=kill_on_interrupt)
-            raise
+        # start the job manager thread if not already started
+        if not self._jobs.actively_monitoring:
+            self._jobs.start()
 
         # block until all non-database jobs are complete
         if block:
@@ -104,24 +102,20 @@ class Controller:
         :param verbose: set verbosity
         :type verbose: bool
         """
-        try:
-            to_monitor = self._jobs.jobs
-            while len(to_monitor) > 0:
-                time.sleep(interval)
+        self._jobs.kill_on_interrupt = kill_on_interrupt
+        to_monitor = self._jobs.jobs
+        while len(to_monitor) > 0:
+            time.sleep(interval)
 
-                # acquire lock to avoid "dictionary changed during iteration" error
-                # without having to copy dictionary each time.
-                if verbose:
-                    JM_LOCK.acquire()
-                    try:
-                        for job in to_monitor.values():
-                            logger.info(job)
-                    finally:
-                        JM_LOCK.release()
-
-        except KeyboardInterrupt:
-            self._jobs.signal_interrupt(kill_on_interrupt=kill_on_interrupt)
-            raise
+            # acquire lock to avoid "dictionary changed during iteration" error
+            # without having to copy dictionary each time.
+            if verbose:
+                JM_LOCK.acquire()
+                try:
+                    for job in to_monitor.values():
+                        logger.info(job)
+                finally:
+                    JM_LOCK.release()
 
     def finished(self, entity):
         """Return a boolean indicating wether a job has finished or not
@@ -588,3 +582,4 @@ class Controller:
             return orc
         finally:
             JM_LOCK.release()
+

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -125,7 +125,7 @@ class Experiment:
         self._control = Controller(launcher=launcher)
         self._launcher = launcher.lower()
 
-    def start(self, *args, block=True, summary=False):
+    def start(self, *args, block=True, summary=False, kill_on_interrupt=True):
         """Start passed instances using Experiment launcher
 
         Any instance ``Model``, ``Ensemble`` or ``Orchestrator``
@@ -171,7 +171,11 @@ class Experiment:
         try:
             if summary:
                 self._launch_summary(start_manifest)
-            self._control.start(manifest=start_manifest, block=block)
+            self._control.start(
+                manifest=start_manifest,
+                block=block,
+                kill_on_interrupt=kill_on_interrupt,
+            )
         except SmartSimError as e:
             logger.error(e)
             raise
@@ -238,7 +242,7 @@ class Experiment:
             logger.error(e)
             raise
 
-    def poll(self, interval=10, verbose=True):
+    def poll(self, interval=10, verbose=True, kill_on_interrupt=True):
         """Monitor jobs through logging to stdout.
 
         This method should only be used if jobs were launched
@@ -266,7 +270,7 @@ class Experiment:
         :raises SmartSimError:
         """
         try:
-            self._control.poll(interval, verbose)
+            self._control.poll(interval, verbose, kill_on_interrupt=kill_on_interrupt)
         except SmartSimError as e:
             logger.error(e)
             raise

--- a/tests/test_interrupt.py
+++ b/tests/test_interrupt.py
@@ -1,0 +1,44 @@
+import os
+import signal
+import time
+from threading import Thread
+
+from smartsim import Experiment
+from smartsim.settings import RunSettings
+
+
+# def signal_handler(sig, frame):
+#     print('You pressed Ctrl+C!')
+def keyboard_interrupt(pid):
+    """Interrupt main thread"""
+    time.sleep(8)  # allow time for jobs to start before interrupting
+    os.kill(pid, signal.SIGINT)
+
+
+def test_interrupt_jobs(fileutils):
+    # signal.signal(signal.SIGINT, signal_handler)
+    test_dir = fileutils.make_test_dir()
+    exp_name = "test_interrupt_jobs"
+    exp = Experiment(exp_name, exp_path=test_dir)
+    model = exp.create_model(
+        "interrupt_model", path=test_dir, run_settings=RunSettings("sleep", "100")
+    )
+    ensemble = exp.create_ensemble(
+        "interrupt_ensemble", replicas=2, run_settings=RunSettings("sleep", "100")
+    )
+    ensemble.set_path(test_dir)
+    num_jobs = 1 + len(ensemble)
+    try:
+        pid = os.getpid()
+        keyboard_interrupt_thread = Thread(
+            name="sigint_thread", target=keyboard_interrupt, args=(pid,)
+        )
+        keyboard_interrupt_thread.start()
+        exp.start(model, ensemble, block=True, kill_on_interrupt=True)
+    except KeyboardInterrupt:
+        time.sleep(2)  # allow time for jobs to be stopped
+        active_jobs = exp._control._jobs.jobs
+        active_db_jobs = exp._control._jobs.db_jobs
+        completed_jobs = exp._control._jobs.completed
+        assert len(active_jobs) + len(active_db_jobs) == 0
+        assert len(completed_jobs) == num_jobs

--- a/tests/test_interrupt.py
+++ b/tests/test_interrupt.py
@@ -7,24 +7,30 @@ from smartsim import Experiment
 from smartsim.settings import RunSettings
 
 
-# def signal_handler(sig, frame):
-#     print('You pressed Ctrl+C!')
 def keyboard_interrupt(pid):
     """Interrupt main thread"""
     time.sleep(8)  # allow time for jobs to start before interrupting
     os.kill(pid, signal.SIGINT)
 
 
-def test_interrupt_jobs(fileutils):
-    # signal.signal(signal.SIGINT, signal_handler)
+def test_interrupt_blocked_jobs(fileutils):
+    """
+    Launches and polls a model and an ensemble with two more models.
+    Once polling starts, the SIGINT signal is sent to the main thread,
+    and consequently, all running jobs are killed.
+    """
     test_dir = fileutils.make_test_dir()
-    exp_name = "test_interrupt_jobs"
+    exp_name = "test_interrupt_blocked_jobs"
     exp = Experiment(exp_name, exp_path=test_dir)
     model = exp.create_model(
-        "interrupt_model", path=test_dir, run_settings=RunSettings("sleep", "100")
+        "interrupt_blocked_model",
+        path=test_dir,
+        run_settings=RunSettings("sleep", "100"),
     )
     ensemble = exp.create_ensemble(
-        "interrupt_ensemble", replicas=2, run_settings=RunSettings("sleep", "100")
+        "interrupt_blocked_ensemble",
+        replicas=2,
+        run_settings=RunSettings("sleep", "100"),
     )
     ensemble.set_path(test_dir)
     num_jobs = 1 + len(ensemble)
@@ -42,3 +48,48 @@ def test_interrupt_jobs(fileutils):
         completed_jobs = exp._control._jobs.completed
         assert len(active_jobs) + len(active_db_jobs) == 0
         assert len(completed_jobs) == num_jobs
+
+
+def test_interrupt_multi_experiment_unblocked_jobs(fileutils):
+    """
+    Starts two Experiments, each having one model
+    and an ensemble with two more models. Since
+    blocking is False, the main thread sleeps until
+    the SIGINT signal is sent, resulting in both
+    Experiment's running jobs to be killed.
+    """
+    test_dir = fileutils.make_test_dir()
+    exp_names = ["test_interrupt_jobs_0", "test_interrupt_jobs_1"]
+    experiments = [Experiment(exp_names[i], exp_path=test_dir) for i in range(2)]
+    jobs_per_experiment = [0] * len(experiments)
+    for i, experiment in enumerate(experiments):
+        model = experiment.create_model(
+            "interrupt_model_" + str(i),
+            path=test_dir,
+            run_settings=RunSettings("sleep", "100"),
+        )
+        ensemble = experiment.create_ensemble(
+            "interrupt_ensemble_" + str(i),
+            replicas=2,
+            run_settings=RunSettings("sleep", "100"),
+        )
+        ensemble.set_path(test_dir)
+        jobs_per_experiment[i] = 1 + len(ensemble)
+    try:
+        pid = os.getpid()
+        keyboard_interrupt_thread = Thread(
+            name="sigint_thread", target=keyboard_interrupt, args=(pid,)
+        )
+        keyboard_interrupt_thread.start()
+        for experiment in experiments:
+            experiment.start(model, ensemble, block=False, kill_on_interrupt=True)
+        time.sleep(9)  # since jobs aren't blocked, wait for SIGINT
+    except KeyboardInterrupt:
+        time.sleep(2)  # allow time for jobs to be stopped
+        for i, experiment in enumerate(experiments):
+            active_jobs = experiment._control._jobs.jobs
+            active_db_jobs = experiment._control._jobs.db_jobs
+            completed_jobs = experiment._control._jobs.completed
+            assert len(active_jobs) + len(active_db_jobs) == 0
+            assert len(completed_jobs) == jobs_per_experiment[i]
+


### PR DESCRIPTION
This PR resolves #48 by killing all running jobs whenever a `KeyboardInterrupt` is received. Previously, `KeyboardInterrupt` was handled when launching and polling by warning the user that some jobs may need to be manually cleaned up. This PR extends this behavior by automatically killing all running jobs, regardless of whether they are being polled. This means that when `block=False`, the jobs are still killed. The user still has the option to revert back to the previous behavior by passing `kill_on_interrupt=False` to `Experiment.start` and `Experiment.poll`.