### PR TITLE
Introduce multiversioned docs

### DIFF
--- a/doc/_static/version_names.txt
+++ b/doc/_static/version_names.txt
@@ -1,0 +1,11 @@
+let version_names = `
+develop (unstable),
+0.4.0 (stable),
+0.3.2
+`;
+
+let version_urls = `
+https://www.craylabs.org/develop/overview.html,
+https://www.craylabs.org/docs/overview.html,
+https://www.craylabs.org/docs/versions/0.3.2/overview.html
+`;

--- a/doc/_templates/versions.html
+++ b/doc/_templates/versions.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <h3>SmartSim Documentation Versions</h3>
+        <p>The following versions of the SmartSim docs are currently available:</p>
+        <ul id="versions-list">
+            <!--
+                Get each version name and their urls.
+                version_names.txt should be updated for each release
+            -->
+            <script src="_static/version_names.txt"></script>
+            <script>
+                var versions = version_names.split(",")
+                var urls = version_urls.split(",")
+                var ul = document.getElementById("versions-list")
+                for (var i = 0; i < versions.length; i++) {
+                    var li = document.createElement("li");
+                    var a = document.createElement("a");
+                    a.setAttribute("href", urls[i]);
+                    a.appendChild(document.createTextNode(versions[i]));
+                    li.appendChild(a);
+                    ul.appendChild(li);
+                }
+            </script>
+        </ul>
+    </body>
+</html>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -76,16 +76,20 @@ fortran_src = [
 # a list of builtin themes.
 html_theme = "sphinx_book_theme"
 
-html_theme_options = {
-    "repository_url": "https://github.com/CrayLabs/SmartSim",
-    "use_repository_button": True,
-    "use_issues_button": True,
-}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+html_theme_options = {
+    "repository_url": "https://github.com/CrayLabs/SmartSim",
+    "use_repository_button": True,
+    "use_issues_button": True,
+}
+# html_sidebars = {
+#     "**": [""] # apply to all pages of the docs
+# }
 
 autoclass_content = 'both'
 add_module_names = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -87,9 +87,6 @@ html_theme_options = {
     "use_repository_button": True,
     "use_issues_button": True,
 }
-# html_sidebars = {
-#     "**": [""] # apply to all pages of the docs
-# }
 
 autoclass_content = 'both'
 add_module_names = False

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,6 +2,11 @@
    sphinx-quickstart on Sat Sep 14 15:07:14 2019.
 
 .. toctree::
+   :maxdepth: 1
+
+   versions
+
+.. toctree::
    :maxdepth: 2
    :caption: Getting Started
 

--- a/doc/versions.rst
+++ b/doc/versions.rst
@@ -1,0 +1,6 @@
+********
+Versions
+********
+
+.. raw:: html
+    :file: _templates/versions.html


### PR DESCRIPTION
This PR adds a "Versions" section to the documentation's navigation bar so that users who many need to reference older versions of SmartSim will be able to do so. `doc/_static/version_names.txt` will need minor additions for each release. On each new release, the new version's name and documentation url will need to be added to `doc/_static/version_names.txt`.

To view this new feature do
`make docks`
`open docs/develop/index.html`