### PR TITLE
Mpiexec Patch

### DIFF
--- a/smartsim/settings/mpirunSettings.py
+++ b/smartsim/settings/mpirunSettings.py
@@ -268,7 +268,9 @@ class MpirunSettings(_OpenMPISettings):
         """
         super().__init__(exe, exe_args, "mpirun", run_args, env_vars, **kwargs)
 
-        c_proc = sp.run([self.run_command, "-V"], capture_output=True)  # type: sp.CompletedProcess
+        c_proc = sp.run(
+            [self.run_command, "-V"], capture_output=True
+        )  # type: sp.CompletedProcess
         version_stmt = c_proc.stdout.decode()
 
         if not re.match(r"mpirun\s\(Open MPI\)\s4.\d+.\d+", version_stmt):
@@ -297,10 +299,12 @@ class MpiexecSettings(_OpenMPISettings):
         :type env_vars: dict[str, str], optional
         """
         super().__init__(exe, exe_args, "mpiexec", run_args, env_vars, **kwargs)
-        
-        c_proc = sp.run([self.run_command, "-V"], capture_output=True)  # type: sp.CompletedProcess
+
+        c_proc = sp.run(
+            [self.run_command, "-V"], capture_output=True
+        )  # type: sp.CompletedProcess
         version_stmt = c_proc.stdout.decode()
-        
+
         if not re.match(r"mpiexec\s\(OpenRTE\)\s4.\d+.\d+", version_stmt):
             logger.warning("Non-OpenMPI implementation of `mpiexec` detected")
 
@@ -328,8 +332,10 @@ class OrterunSettings(_OpenMPISettings):
         """
         super().__init__(exe, exe_args, "orterun", run_args, env_vars, **kwargs)
 
-        c_proc = sp.run([self.run_command, "-V"], capture_output=True)  # type: sp.CompletedProcess
+        c_proc = sp.run(
+            [self.run_command, "-V"], capture_output=True
+        )  # type: sp.CompletedProcess
         version_stmt = c_proc.stdout.decode()
-        
+
         if not re.match(r"orterun\s\(OpenRTE\)\s4.\d+.\d+", version_stmt):
             logger.warning("Non-OpenMPI implementation of `orterun` detected")

--- a/smartsim/settings/mpirunSettings.py
+++ b/smartsim/settings/mpirunSettings.py
@@ -24,7 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import subprocess as sp
+import subprocess
 import re
 
 from ..error import SSUnsupportedError
@@ -268,12 +268,12 @@ class MpirunSettings(_OpenMPISettings):
         """
         super().__init__(exe, exe_args, "mpirun", run_args, env_vars, **kwargs)
 
-        c_proc = sp.run(
+        completed_process = subprocess.run(
             [self.run_command, "-V"], capture_output=True
-        )  # type: sp.CompletedProcess
-        version_stmt = c_proc.stdout.decode()
+        )  # type: subprocess.CompletedProcess
+        version_statement = completed_process.stdout.decode()
 
-        if not re.match(r"mpirun\s\(Open MPI\)\s4.\d+.\d+", version_stmt):
+        if not re.match(r"mpirun\s\(Open MPI\)\s4.\d+.\d+", version_statement):
             logger.warning("Non-OpenMPI implementation of `mpirun` detected")
 
 
@@ -300,12 +300,12 @@ class MpiexecSettings(_OpenMPISettings):
         """
         super().__init__(exe, exe_args, "mpiexec", run_args, env_vars, **kwargs)
 
-        c_proc = sp.run(
+        completed_process = subprocess.run(
             [self.run_command, "-V"], capture_output=True
-        )  # type: sp.CompletedProcess
-        version_stmt = c_proc.stdout.decode()
+        )  # type: subprocess.CompletedProcess
+        version_statement = completed_process.stdout.decode()
 
-        if not re.match(r"mpiexec\s\(OpenRTE\)\s4.\d+.\d+", version_stmt):
+        if not re.match(r"mpiexec\s\(OpenRTE\)\s4.\d+.\d+", version_statement):
             logger.warning("Non-OpenMPI implementation of `mpiexec` detected")
 
 
@@ -332,10 +332,10 @@ class OrterunSettings(_OpenMPISettings):
         """
         super().__init__(exe, exe_args, "orterun", run_args, env_vars, **kwargs)
 
-        c_proc = sp.run(
+        completed_process = subprocess.run(
             [self.run_command, "-V"], capture_output=True
-        )  # type: sp.CompletedProcess
-        version_stmt = c_proc.stdout.decode()
+        )  # type: subprocess.CompletedProcess
+        version_statement = completed_process.stdout.decode()
 
-        if not re.match(r"orterun\s\(OpenRTE\)\s4.\d+.\d+", version_stmt):
+        if not re.match(r"orterun\s\(OpenRTE\)\s4.\d+.\d+", version_statement):
             logger.warning("Non-OpenMPI implementation of `orterun` detected")

--- a/smartsim/settings/mpirunSettings.py
+++ b/smartsim/settings/mpirunSettings.py
@@ -268,7 +268,9 @@ class MpirunSettings(_OpenMPISettings):
         """
         super().__init__(exe, exe_args, "mpirun", run_args, env_vars, **kwargs)
 
-        version_stmt = sp.check_output([self.run_command, "-V"]).decode()
+        c_proc = sp.run([self.run_command, "-V"], capture_output=True)  # type: sp.CompletedProcess
+        version_stmt = c_proc.stdout.decode()
+
         if not re.match(r"mpirun\s\(Open MPI\)\s4.\d+.\d+", version_stmt):
             logger.warning("Non-OpenMPI implementation of `mpirun` detected")
 
@@ -295,8 +297,10 @@ class MpiexecSettings(_OpenMPISettings):
         :type env_vars: dict[str, str], optional
         """
         super().__init__(exe, exe_args, "mpiexec", run_args, env_vars, **kwargs)
-
-        version_stmt = sp.check_output([self.run_command, "-V"]).decode()
+        
+        c_proc = sp.run([self.run_command, "-V"], capture_output=True)  # type: sp.CompletedProcess
+        version_stmt = c_proc.stdout.decode()
+        
         if not re.match(r"mpiexec\s\(OpenRTE\)\s4.\d+.\d+", version_stmt):
             logger.warning("Non-OpenMPI implementation of `mpiexec` detected")
 
@@ -324,6 +328,8 @@ class OrterunSettings(_OpenMPISettings):
         """
         super().__init__(exe, exe_args, "orterun", run_args, env_vars, **kwargs)
 
-        version_stmt = sp.check_output([self.run_command, "-V"]).decode()
+        c_proc = sp.run([self.run_command, "-V"], capture_output=True)  # type: sp.CompletedProcess
+        version_stmt = c_proc.stdout.decode()
+        
         if not re.match(r"orterun\s\(OpenRTE\)\s4.\d+.\d+", version_stmt):
             logger.warning("Non-OpenMPI implementation of `orterun` detected")


### PR DESCRIPTION
Updates the  `MpiexecSettings` (and all other OpenMPI settings classes) to use `subprocess.run` as opposed to `subprocess.check_output` when checking version statements so that it can handle a non-zero status return code.