### PR TITLE
Fix keydb directory name during build

### DIFF
--- a/smartsim/_core/_install/builder.py
+++ b/smartsim/_core/_install/builder.py
@@ -150,7 +150,7 @@ class DatabaseBuilder(Builder):
         :param branch: branch to checkout
         :type branch: str
         """
-        database_name = "KeyDB" if "KeyDB" in git_url else "redis"
+        database_name = "keydb" if "KeyDB" in git_url else "redis"
         database_build_path = Path(self.build_dir, database_name.lower())
 
         # remove git directory if it exists as it should


### PR DESCRIPTION
Currently ``database_name`` is set to ``KeyDB``, but when the command ``smart build --keydb`` is executed the following error is encountered:

```bash
[SmartSim] ERROR [Errno 2] No such file or directory: 'SmartSim/smartsim/_core/.third-party/keydb'
```

This PR changes the ``database_name`` to ``keydb``.