### PR TITLE
Updated version of Black

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,4 +11,5 @@ isort>=5.6.4
 pylint>=2.6.0
 pytest>=6.0.0
 pytest-cov>=2.10.1
+click==8.0.2
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ redis-py-cluster==2.1.3
 tqdm>=4.50.2
 psutil>=5.7.2
 tabulate>=0.8.9
-black>=22.3.0
+black>=20.8b1
 isort>=5.6.4
 pylint>=2.6.0
 pytest>=6.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ redis-py-cluster==2.1.3
 tqdm>=4.50.2
 psutil>=5.7.2
 tabulate>=0.8.9
-black>=20.8b1
+black>=22.3.0
 isort>=5.6.4
 pylint>=2.6.0
 pytest>=6.0.0

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,8 @@ deps = [
     "redis-py-cluster==2.1.3",
     "redis==3.5.3",
     "tqdm>=4.50.2",
-    "filelock>=3.4.2"
+    "filelock>=3.4.2",
+    "click==8.0.2"
 ]
 
 # Add SmartRedis at specific version


### PR DESCRIPTION
Added version of Click in set-up.py

Now when users install SmartSim in a new virtual environment and run `pip install -e .\[ml,dev\] `, then `make style`, the updated version of Click will now work with the existing version of Black

`make style` will pass