### PR TITLE
RunSettings Typo

### DIFF
--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -369,9 +369,11 @@ class RunSettings:
         """
         val_types = (str, int, float, bool)
         # Coerce env_vars values to str as a convenience to user
-        for (env, val) in env_vars.items():
-            if type(val) not in val_types:
-                raise TypeError(f"env_vars[{env}] was of type {type(val)}, not {val_types_union}")
+        for env, val in env_vars.items():
+            if not isinstance(val, val_types):
+                raise TypeError(
+                    f"env_vars[{env}] was of type {type(val)}, not {val_types}"
+                )
             else:
                 self.env_vars[env] = val
 
@@ -512,7 +514,6 @@ class RunSettings:
             else:
                 formatted.append(f"{key}={val}")
         return formatted
-                
 
     def __str__(self):  # pragma: no-cover
         string = f"Executable: {self.exe[0]}\n"


### PR DESCRIPTION
Stumbled into a typo in RunSettings. Quick fix implemented:

- Fix typo in `RunSettings.update_env`: `val_types_union` -> `val_types`
- black