### PR TITLE
Avoid checking for alloc_specs if it is not defined

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ redis==3.5.3
 redis-py-cluster==2.1.3
 tqdm>=4.50.2
 filelock>=3.4.2
+protobuf==3.20

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ deps = [
     "redis==3.5.3",
     "tqdm>=4.50.2",
     "filelock>=3.4.2",
-    "click==8.0.2"
+    "protobuf==3.20"
 ]
 
 # Add SmartRedis at specific version
@@ -154,6 +154,7 @@ extras_require = {
         "pylint>=2.6.0",
         "pytest>=6.0.0",
         "pytest-cov>=2.10.1"
+        "click==8.0.2",
     ],
     # see smartsim/_core/_install/buildenv.py for more details
     "ml": versions.ml_extras_required(),

--- a/tests/full_wlm/test_wlm_helper_functions.py
+++ b/tests/full_wlm/test_wlm_helper_functions.py
@@ -8,6 +8,8 @@ from smartsim.error.errors import LauncherError, SmartSimError, SSUnsupportedErr
 
 
 def test_get_hosts(alloc_specs):
+    if not alloc_specs:
+        pytest.skip("alloc_specs not defined")
     def verify_output(output):
         assert isinstance(output, list)
         assert all(isinstance(host, str) for host in output)
@@ -34,6 +36,8 @@ def test_get_hosts(alloc_specs):
 
 
 def test_get_queue(alloc_specs):
+    if not alloc_specs:
+        pytest.skip("alloc_specs not defined")
     def verify_output(output):
         assert isinstance(output, str)
         if "queue" in alloc_specs:
@@ -59,6 +63,8 @@ def test_get_queue(alloc_specs):
 
 
 def test_get_tasks(alloc_specs):
+    if not alloc_specs:
+        pytest.skip("alloc_specs not defined")
     def verify_output(output):
         assert isinstance(output, int)
         if "num_tasks" in alloc_specs:
@@ -87,6 +93,8 @@ def test_get_tasks(alloc_specs):
 
 
 def test_get_tasks_per_node(alloc_specs):
+    if not alloc_specs:
+        pytest.skip("alloc_specs not defined")
     def verify_output(output):
         assert isinstance(output, dict)
         assert all(

--- a/tests/full_wlm/test_wlm_helper_functions.py
+++ b/tests/full_wlm/test_wlm_helper_functions.py
@@ -6,6 +6,9 @@ import pytest
 import smartsim.wlm as wlm
 from smartsim.error.errors import LauncherError, SmartSimError, SSUnsupportedError
 
+# alloc_specs can be specified by the user when testing, but it will
+# require all WLM env variables to be populated. If alloc_specs is not
+# defined, the tests in this file are skipped.
 
 def test_get_hosts(alloc_specs):
     if not alloc_specs:


### PR DESCRIPTION
This PR mitigates issues when a Slurm or PBS system is set up so that not all environment variables are populated. 
If the `alloc_specs` fixture is not defined (see commit 4bd5e23), the functions using it won't be testsd.