### PR TITLE
Singularity API documentations

### DIFF
--- a/doc/api/smartsim_api.rst
+++ b/doc/api/smartsim_api.rst
@@ -62,6 +62,16 @@ Types of Settings:
     CobaltBatchSettings
     BsubBatchSettings
 
+Settings objects can accept a container object that defines a container
+runtime, image, and arguments to use for the workload. Below is a list of
+supported container runtimes.
+
+Types of Containers:
+
+.. autosummary::
+
+    Singularity
+
 
 RunSettings
 -----------
@@ -372,6 +382,21 @@ be launched as a batch on LSF systems.
 
 
 .. autoclass:: BsubBatchSettings
+    :inherited-members:
+    :undoc-members:
+    :members:
+
+
+Singularity
+-----------
+
+.. _singularity_api:
+
+``Singularity`` is a type of ``Container`` that can be passed to a
+``RunSettings`` class or child class to enable running the workload in a
+container.
+
+.. autoclass:: Singularity
     :inherited-members:
     :undoc-members:
     :members:

--- a/smartsim/settings/containers.py
+++ b/smartsim/settings/containers.py
@@ -40,7 +40,8 @@ class Container():
 
 
 class Singularity(Container):
-    '''Singularity (apptainer) container type.
+    '''Singularity (apptainer) container type. To be passed into a
+    ``RunSettings`` class initializer or ``Experiment.create_run_settings``.
 
     .. note::
 
@@ -53,7 +54,7 @@ class Singularity(Container):
         `system administrator <https://apptainer.org/docs/admin/1.0/configfiles.html#bind-mount-management>`_
 
 
-    :param image: local or remote path to container image, e.g. 'docker://sylabsio/lolcow'
+    :param image: local or remote path to container image, e.g. ``docker://sylabsio/lolcow``
     :type image: str
     :param args: arguments to 'singularity exec' command
     :type args: str | list[str], optional


### PR DESCRIPTION
Add Singularity docs to SmartSim API docs.

I was on the fence about exposing the base class, `Container`. It has no use for a user, but it is the  type referenced in arguments, e.g. 

```python
  def create_run_settings(self, ..., container: Container, ...):
    ...
```

I opted for leaving `Container` docs out in this PR, but am open to changing that if the reviewer disagrees. This decision can also be revisited in the future, if users are finding the current form confusing.