### PR TITLE
Fix ONNX test

### DIFF
--- a/tests/backends/run_sklearn_onnx.py
+++ b/tests/backends/run_sklearn_onnx.py
@@ -59,6 +59,7 @@ def run(device):
     linreg = build_lin_reg()
     outputs = run_model(client, device, linreg, X, "X", ["Y"])
     assert len(outputs[0]) == 5
+    print("Linear regression successful")
     print(outputs)
 
     # Kmeans test
@@ -70,6 +71,7 @@ def run(device):
     assert len(outputs) == 2
     assert len(outputs[0]) == 10
     assert outputs[1].shape == (10, 2)
+    print("K-means successful")
     print(outputs)
 
     # test random Forest regressor
@@ -77,6 +79,7 @@ def run(device):
     model = build_random_forest()
     outputs = run_model(client, device, model, sample, "rf_in", ["rf_label"])
     assert len(outputs[0]) == 1
+    print("Random forest successful")
     print(outputs)
 
 

--- a/tests/backends/run_sklearn_onnx.py
+++ b/tests/backends/run_sklearn_onnx.py
@@ -39,10 +39,10 @@ def build_random_forest():
     return rf_model.SerializeToString()
 
 
-def run_model(client: Client, device, model, model_input, in_name, out_names):
+def run_model(client, model_name, device, model, model_input, in_name, out_names):
     client.put_tensor(in_name, model_input)
-    client.set_model("onnx_model", model, "ONNX", device=device)
-    client.run_model("onnx_model", inputs=[in_name], outputs=out_names)
+    client.set_model(model_name, model, "ONNX", device=device)
+    client.run_model(model_name, inputs=[in_name], outputs=out_names)
     outputs = []
     for o in out_names:
         outputs.append(client.get_tensor(o))
@@ -57,7 +57,7 @@ def run(device):
     # linreg test
     X = np.array([[1.0], [2.0], [3.0], [4.0], [5.0]]).astype(np.float32)
     linreg = build_lin_reg()
-    outputs = run_model(client, device, linreg, X, "X", ["Y"])
+    outputs = run_model(client, "linreg", device, linreg, X, "X", ["Y"])
     assert len(outputs[0]) == 5
     print("Linear regression successful")
     print(outputs)
@@ -66,7 +66,7 @@ def run(device):
     X = np.arange(20, dtype=np.float32).reshape(10, 2)
     kmeans = build_kmeans()
     outputs = run_model(
-        client, device, kmeans, X, "kmeans_in", ["kmeans_labels", "kmeans_transform"]
+        client, "kmeans", device, kmeans, X, "kmeans_in", ["kmeans_labels", "kmeans_transform"]
     )
     assert len(outputs) == 2
     assert len(outputs[0]) == 10
@@ -77,7 +77,7 @@ def run(device):
     # test random Forest regressor
     sample = np.array([[6.4, 2.8, 5.6, 2.2]]).astype(np.float32)
     model = build_random_forest()
-    outputs = run_model(client, device, model, sample, "rf_in", ["rf_label"])
+    outputs = run_model(client, "random_forest", device, model, sample, "rf_in", ["rf_label"])
     assert len(outputs[0]) == 1
     print("Random forest successful")
     print(outputs)

--- a/tests/backends/run_sklearn_onnx.py
+++ b/tests/backends/run_sklearn_onnx.py
@@ -39,10 +39,10 @@ def build_random_forest():
     return rf_model.SerializeToString()
 
 
-def run_model(client, device, model, model_input, in_name, out_names):
+def run_model(client: Client, device, model, model_input, in_name, out_names):
     client.put_tensor(in_name, model_input)
     client.set_model("onnx_model", model, "ONNX", device=device)
-    client.run_model("onnx_model", inputs=in_name, outputs=out_names)
+    client.run_model("onnx_model", inputs=[in_name], outputs=out_names)
     outputs = []
     for o in out_names:
         outputs.append(client.get_tensor(o))


### PR DESCRIPTION
This PR aims at fixing the ONNX test, which has been erratically failing in CI/CD pipelines. 

I identified one possible source of errors in the fact that we overwrite the ONNX model several times, and - possibly - the model stored in the DB is not updated correctly (thus resulting in the error `Number of keys given as OUTPUTS here does not match model definition`). This hints at a bug in one of the used libraries (possibly RedisAI), thus we can not fix it completely: we can just avoid triggering it, by not overwriting models.

I also updated one function to use list of strings for inputs, instead of just a string (which is anyhow accepted by SmartRedis).

While I can not be sure that this fixes the problem, I have run the test 80 times in a row and it never failed.