### PR TITLE
Update version_names.json

### DIFF
--- a/doc/_static/version_names.json
+++ b/doc/_static/version_names.json
@@ -1,4 +1,4 @@
 {
-    "version_names":["develop (unstable)", "0.4.1 (stable)", "0.3.2"],
-    "version_urls": ["https://www.craylabs.org/develop/overview.html", "https://www.craylabs.org/docs/overview.html", "https://www.craylabs.org/docs/versions/0.3.2/overview.html"]
+    "version_names":["develop (unstable)", "0.4.1 (stable)", "0.4.0", "0.3.2"],
+    "version_urls": ["https://www.craylabs.org/develop/overview.html", "https://www.craylabs.org/docs/overview.html", "https://www.craylabs.org/docs/versions/0.4.0/overview.html", "https://www.craylabs.org/docs/versions/0.3.2/overview.html"]
 }


### PR DESCRIPTION
The version_names.json file needs to be updated with the new release so that future invocations of the github action ``deploy_dev_docs`` do not corrupt the doc version history.