### PR TITLE
Domain Socket Support for co-located databases

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -72,8 +72,12 @@ jobs:
         if: contains( matrix.os, 'ubuntu' ) && matrix.py_v == 3.9 && matrix.rai == '1.2.5'
         run: singularity pull docker://alrigazzi/smartsim-testing
 
+      # Note: The develop branch of smartredis is installed first to ensure that any tests that depend
+      # on developments of the client are brought in.
       - name: Install SmartSim (with ML backends)
-        run: python -m pip install .[dev,ml,ray]
+        run: |
+          python -m pip install git+https://github.com/CrayLabs/SmartRedis.git@develop#egg=smartredis
+          python -m pip install .[dev,ml,ray]
 
       - name: Install ML Runtimes with Smart
         if: contains( matrix.os, 'macos' )

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -462,8 +462,20 @@ class Controller:
         # Set address to local if it's a colocated model
         if hasattr(entity, "colocated"):
             if entity.colocated:
-                port = entity.run_settings.colocated_db_settings["port"]
-                client_env["SSDB"] = f"127.0.0.1:{str(port)}"
+                port = entity.run_settings.colocated_db_settings.get("port",None)
+                socket = entity.run_settings.colocated_db_settings.get("unix_socket",None)
+                if socket and port:
+                    raise SSInternalError(
+                        "Co-located was configured for both TCP/IP and UDS"
+                    )
+                if port:
+                    client_env["SSDB"] = f"127.0.0.1:{str(port)}"
+                elif socket:
+                    client_env["SSDB"] = f"unix://{socket}"
+                else:
+                    raise SSInternalError(
+                        "Colocated database was not configured for either TCP or UDS"
+                    )
         entity.run_settings.update_env(client_env)
 
     def _save_orchestrator(self, orchestrator):

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -460,8 +460,7 @@ class Controller:
                 client_env["SSKEYOUT"] = entity.name
 
         # Set address to local if it's a colocated model
-        if hasattr(entity, "colocated"):
-            if entity.colocated:
+        if hasattr(entity, "colocated") and entity.colocated:
                 port = entity.run_settings.colocated_db_settings.get("port",None)
                 socket = entity.run_settings.colocated_db_settings.get("unix_socket",None)
                 if socket and port:

--- a/smartsim/_core/entrypoints/colocated.py
+++ b/smartsim/_core/entrypoints/colocated.py
@@ -166,7 +166,9 @@ def main(
     global DBPID
 
     try:
-        ip_address = current_ip(network_interface)
+        ip_address = None
+        if network_interface:
+            ip_address = current_ip(network_interface)
         lo_address = current_ip("lo")
     except ValueError as e:
         logger.warning(e)
@@ -269,7 +271,7 @@ if __name__ == "__main__":
             prefix_chars="+", description="SmartSim Process Launcher"
         )
         parser.add_argument(
-            "+ifname", type=str, help="Network Interface name", default="lo"
+            "+ifname", type=str, help="Network Interface name", default=""
         )
         parser.add_argument(
             "+lockfile", type=str, help="Filename to create for single proc per host"

--- a/smartsim/_core/launcher/colocated.py
+++ b/smartsim/_core/launcher/colocated.py
@@ -111,15 +111,15 @@ def _build_colocated_wrapper_cmd(
         lockfile,
         "+db_cpus",
         str(cpus),
-        "+command",
     ]
     # Add in the interface if using TCP/IP
-    interface = kwargs.get("ifname",None):
+    interface = kwargs.get("ifname",None)
     if interface:
-        cmd += ["+ifname", interface]
-
+        cmd.extend(["+ifname", interface])
+    cmd.append("+command")
     # collect DB binaries and libraries from the config
     db_cmd = [CONFIG.database_exe, CONFIG.database_conf, "--loadmodule", CONFIG.redisai]
+
     # add extra redisAI configurations
     for arg, value in rai_args.items():
         if value:
@@ -137,13 +137,18 @@ def _build_colocated_wrapper_cmd(
     socket_permissions = kwargs.get("socket_permissions", None)
 
     if unix_socket and socket_permissions:
-        db_cmd.extend(["--unixsocket", str(unix_socket), "--unixsocketperm", socket_permissions])
+        db_cmd.extend(
+            [
+                "--unixsocket", str(unix_socket),
+                "--unixsocketperm", str(socket_permissions)
+            ]
+        )
     elif bool(unix_socket) ^ bool(socket_permissions):
         raise SSInternalError(
             "`unix_socket` and `socket_permissions` must both be defined or undefined."
             )
 
-    db_cmd.extend([, "--logfile", db_log])  # usually /dev/null
+    db_cmd.extend(["--logfile", db_log])  # usually /dev/null
     for db_arg, value in extra_db_args.items():
         # replace "_" with "-" in the db_arg because we use kwargs
         # for the extra configurations and Python doesn't allow a hyphen
@@ -167,7 +172,6 @@ def _build_colocated_wrapper_cmd(
 
     cmd.extend(db_cmd)
     return " ".join(cmd)
-
 
 def _build_db_model_cmd(db_models):
     cmd = []

--- a/smartsim/_core/launcher/colocated.py
+++ b/smartsim/_core/launcher/colocated.py
@@ -127,10 +127,7 @@ def _build_colocated_wrapper_cmd(
             # ex. THREADS_PER_QUEUE=1
             db_cmd.append(f"{arg.upper()} {str(value)}")
 
-    # Add port and log information for TCP/IP
-    port = kwargs.get("port",None)
-    if port:
-        db_cmd.extend(["--port", str(port)])
+    db_cmd.extend(["--port", str(kwargs["port"])])
 
     # Add socket and permissions for UDS
     unix_socket = kwargs.get("unix_socket", None)

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -160,12 +160,12 @@ class Model(SmartSimEntity):
         .. highlight:: python
         .. code-block:: python
 
-            ex. kwargs = {
-                maxclients: 100000,
-                threads_per_queue: 1,
-                inter_op_threads: 1,
-                intra_op_threads: 1,
-                server_threads: 2 # keydb only
+            example_kwargs = {
+                "maxclients": 100000,
+                "threads_per_queue": 1,
+                "inter_op_threads": 1,
+                "intra_op_threads": 1,
+                "server_threads": 2 # keydb only
             }
 
         Generally these don't need to be changed.
@@ -182,7 +182,6 @@ class Model(SmartSimEntity):
         :type debug: bool, optional
         :param kwargs: additional keyword arguments to pass to the orchestrator database
         :type kwargs: dict, optional
-
         """
 
         uds_options = {

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -269,7 +269,8 @@ class Model(SmartSimEntity):
 
         # TODO list which db settings can be extras
         colo_db_config = {}
-        colo_db_config.update(connection_options, common_options)
+        colo_db_config.update(connection_options)
+        colo_db_config.update(common_options)
         # redisai arguments for inference settings
         colo_db_config['rai_args'] = {
             "threads_per_queue": kwargs.get("threads_per_queue", None),

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -187,7 +187,8 @@ class Model(SmartSimEntity):
 
         uds_options = {
             "unix_socket":unix_socket,
-            "socket_permissions":socket_permissions
+            "socket_permissions":socket_permissions,
+            "port":0 # This is hardcoded to 0 as recommended by redis for UDS
         }
         common_options = {
             "cpus":db_cpus,

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -31,6 +31,7 @@ from .dbobject import DBModel, DBScript
 from .entity import SmartSimEntity
 from .files import EntityFiles
 
+import warnings
 
 class Model(SmartSimEntity):
     def __init__(self, name, params, path, run_settings, params_as_args=None):
@@ -128,21 +129,87 @@ class Model(SmartSimEntity):
         to_configure = init_default([], to_configure, (list, str))
         self.files = EntityFiles(to_configure, to_copy, to_symlink)
 
-    def colocate_db(
+    def colocate_db(self, **kwargs):
+        warnings.warn(
+            (
+                "`colocate_db` has been deprecated and will be removed in a \n"
+                "future release. Please use `colocate_db_tcp` or `colocate_db_uds`."
+            ),
+            category=DeprecationWarning
+        )
+        self.colocate_db_tcp(**kwargs)
+
+    def colocate_db_uds(
         self,
-        port=6379,
+        unix_socket="/tmp/redis.socket",
+        socket_permissions=755,
         db_cpus=1,
         limit_app_cpus=True,
-        ifname="lo",
         debug=False,
         **kwargs,
     ):
-        """Colocate an Orchestrator instance with this Model at runtime.
+        """Colocate an Orchestrator instance with this Model over UDS.
 
-        This method will initialize settings which add an unsharded (not connected)
+        This method will initialize settings which add an unsharded
         database to this Model instance. Only this Model will be able to communicate
-        with this colocated database by using the loopback TCP interface or Unix
-        Domain sockets (UDS coming soon).
+        with this colocated database by using Unix Domain sockets.
+
+        Extra parameters for the db can be passed through kwargs. This includes
+        many performance, caching and inference settings.
+
+        .. highlight:: python
+        .. code-block:: python
+
+            ex. kwargs = {
+                maxclients: 100000,
+                threads_per_queue: 1,
+                inter_op_threads: 1,
+                intra_op_threads: 1,
+                server_threads: 2 # keydb only
+            }
+
+        Generally these don't need to be changed.
+
+        :param unix_socket: path to where the socket file will be created
+        :type unix_socket: str, optional
+        :param socket_permissions: permissions for the socketfile
+        :type socket_permissions: int, optional
+        :param db_cpus: number of cpus to use for orchestrator, defaults to 1
+        :type db_cpus: int, optional
+        :param limit_app_cpus: whether to limit the number of cpus used by the app, defaults to True
+        :type limit_app_cpus: bool, optional
+        :param debug: launch Model with extra debug information about the co-located db
+        :type debug: bool, optional
+        :param kwargs: additional keyword arguments to pass to the orchestrator database
+        :type kwargs: dict, optional
+
+        """
+
+        uds_options = {
+            "unix_socket":unix_socket,
+            "socket_permissions":socket_permissions
+        }
+        common_options = {
+            "cpus":db_cpus,
+            "limit_app_cpus":limit_app_cpus,
+            "debug":debug
+        }
+        self._set_colocated_db_settings( uds_options, common_options, **kwargs)
+
+    def colocate_db_tcp(
+        self,
+        port=6379,
+        ifname="lo",
+        db_cpus=1,
+        limit_app_cpus=True,
+        debug=False,
+        **kwargs,
+    ):
+        """Colocate an Orchestrator instance with this Model over TCP/IP.
+
+        This method will initialize settings which add an unsharded
+        database to this Model instance. Only this Model will be able to communicate
+        with this colocated database by using the loopback TCP interface.
 
         Extra parameters for the db can be passed through kwargs. This includes
         many performance, caching and inference settings.
@@ -162,18 +229,36 @@ class Model(SmartSimEntity):
 
         :param port: port to use for orchestrator database, defaults to 6379
         :type port: int, optional
+        :param ifname: interface to use for orchestrator, defaults to "lo"
+        :type ifname: str, optional
         :param db_cpus: number of cpus to use for orchestrator, defaults to 1
         :type db_cpus: int, optional
         :param limit_app_cpus: whether to limit the number of cpus used by the app, defaults to True
         :type limit_app_cpus: bool, optional
-        :param ifname: interface to use for orchestrator, defaults to "lo"
-        :type ifname: str, optional
         :param debug: launch Model with extra debug information about the co-located db
         :type debug: bool, optional
         :param kwargs: additional keyword arguments to pass to the orchestrator database
         :type kwargs: dict, optional
 
         """
+
+        tcp_options = {
+            "port":port,
+            "ifname":ifname
+        }
+        common_options = {
+            "cpus":db_cpus,
+            "limit_app_cpus":limit_app_cpus,
+            "debug":debug
+        }
+        self._set_colocated_db_settings( tcp_options, common_options, **kwargs)
+
+    def _set_colocated_db_settings(self, connection_options, common_options, **kwargs):
+        """
+        Ingest the connection-specific options (UDS/TCP) and set the final settings
+        for the co-located database
+        """
+
         if hasattr(self.run_settings, "mpmd") and len(self.run_settings.mpmd) > 0:
             raise SSUnsupportedError(
                 "Models co-located with databases cannot be run as a mpmd workload"
@@ -183,18 +268,13 @@ class Model(SmartSimEntity):
             self.run_settings._prep_colocated_db(db_cpus)
 
         # TODO list which db settings can be extras
-        colo_db_config = {
-            "port": int(port),
-            "cpus": int(db_cpus),
-            "interface": ifname,
-            "limit_app_cpus": limit_app_cpus,
-            "debug": debug,
-            # redisai arguments for inference settings
-            "rai_args": {
-                "threads_per_queue": kwargs.get("threads_per_queue", None),
-                "inter_op_parallelism": kwargs.get("inter_op_parallelism", None),
-                "intra_op_parallelism": kwargs.get("intra_op_parallelism", None),
-            },
+        colo_db_config = {}
+        colo_db_config.update(connection_options, common_options)
+        # redisai arguments for inference settings
+        colo_db_config['rai_args'] = {
+            "threads_per_queue": kwargs.get("threads_per_queue", None),
+            "inter_op_parallelism": kwargs.get("inter_op_parallelism", None),
+            "intra_op_parallelism": kwargs.get("intra_op_parallelism", None),
         }
         colo_db_config["extra_db_args"] = dict(
             [

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -129,7 +129,7 @@ class Model(SmartSimEntity):
         to_configure = init_default([], to_configure, (list, str))
         self.files = EntityFiles(to_configure, to_copy, to_symlink)
 
-    def colocate_db(self, **kwargs):
+    def colocate_db(self, *args, **kwargs):
         warnings.warn(
             (
                 "`colocate_db` has been deprecated and will be removed in a \n"
@@ -137,7 +137,7 @@ class Model(SmartSimEntity):
             ),
             category=DeprecationWarning
         )
-        self.colocate_db_tcp(**kwargs)
+        self.colocate_db_tcp(*args, **kwargs)
 
     def colocate_db_uds(
         self,
@@ -265,7 +265,7 @@ class Model(SmartSimEntity):
             )
 
         if hasattr(self.run_settings, "_prep_colocated_db"):
-            self.run_settings._prep_colocated_db(db_cpus)
+            self.run_settings._prep_colocated_db(common_options['db_cpus'])
 
         # TODO list which db settings can be extras
         colo_db_config = {}

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -447,7 +447,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils):
 
     for i, entity in enumerate(colo_ensemble):
         entity.colocate_db(
-            port = wlmutils.get_test_port() + i, db_cpus=1, limit_app_cpus=False, debug=True, ifname="lo"
+            wlmutils.get_test_port() + i, db_cpus=1, limit_app_cpus=False, debug=True, ifname="lo"
         )
         # Test that models added individually do not conflict with enemble ones
         entity.add_ml_model(

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -447,7 +447,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils):
 
     for i, entity in enumerate(colo_ensemble):
         entity.colocate_db(
-            wlmutils.get_test_port() + i, db_cpus=1, limit_app_cpus=False, debug=True, ifname="lo"
+            port = wlmutils.get_test_port() + i, db_cpus=1, limit_app_cpus=False, debug=True, ifname="lo"
         )
         # Test that models added individually do not conflict with enemble ones
         entity.add_ml_model(

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+import warnings
 
 from smartsim import Experiment, status
 
@@ -8,8 +9,8 @@ from smartsim import Experiment, status
 if pytest.test_launcher not in pytest.wlm_options:
     pytestmark = pytest.mark.skip(reason="Not testing WLM integrations")
 
-
-def test_launch_colocated_model(fileutils, wlmutils):
+@pytest.mark.parametrize("db_type", ["uds","tcp","deprecated"])
+def test_launch_colocated_model(fileutils, wlmutils, db_type):
     """Test the launch of a model with a colocated database"""
 
     launcher = wlmutils.get_test_launcher()
@@ -27,9 +28,25 @@ def test_launch_colocated_model(fileutils, wlmutils):
 
     colo_model = exp.create_model("colocated_model", colo_settings)
     colo_model.set_path(test_dir)
-    colo_model.colocate_db(
-        port=6780, db_cpus=1, limit_app_cpus=False, debug=True, ifname=network_interface
-    )
+    db_args = {
+        "db_cpus":1,
+        "limit_app_cpus":False,
+        "debug":True,
+    }
+
+    if db_type in ["tcp", "deprecated"]:
+        colocate_fun = {
+            "tcp":colo_model.colocate_db_tcp,
+            "deprecated":colo_model.colocate_db
+        }
+        with warnings.catch_warnings(record=True) as w:
+            colocate_fun[db_type](port=6780, ifname="lo", **db_args)
+            if db_type == "deprecated":
+                assert len(w) == 1
+                assert issubclass(w[-1].category, DeprecationWarning)
+                assert "Please use `colocate_db_tcp` or `colocate_db_uds`" in str(w[-1].message)
+    elif db_type == "uds":
+        colo_model.colocate_db_uds(**db_args)
 
     # assert model will launch with colocated db
     assert colo_model.colocated

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -1,9 +1,12 @@
 import sys
 
+import pytest
+import warnings
 from smartsim import Experiment, status
 
 
-def test_launch_colocated_model(fileutils):
+@pytest.mark.parametrize("db_type", ["uds","tcp","deprecated"])
+def test_launch_colocated_model(fileutils, db_type):
     """Test the launch of a model with a colocated database and local launcher"""
 
     exp_name = "test-launch-colocated-model-with-restart"
@@ -18,9 +21,26 @@ def test_launch_colocated_model(fileutils):
 
     colo_model = exp.create_model("colocated_model", colo_settings)
     colo_model.set_path(test_dir)
-    colo_model.colocate_db(
-        port=6780, db_cpus=1, limit_app_cpus=False, debug=True, ifname="lo"
-    )
+
+    db_args = {
+        "db_cpus":1,
+        "limit_app_cpus":False,
+        "debug":True,
+    }
+
+    if db_type in ["tcp", "deprecated"]:
+        colocate_fun = {
+            "tcp":colo_model.colocate_db_tcp,
+            "deprecated":colo_model.colocate_db
+        }
+        with warnings.catch_warnings(record=True) as w:
+            colocate_fun[db_type](port=6780, ifname="lo", **db_args)
+            if db_type == "deprecated":
+                assert len(w) == 1
+                assert issubclass(w[-1].category, DeprecationWarning)
+                assert "Please use `colocate_db_tcp` or `colocate_db_uds`" in str(w[-1].message)
+    elif db_type == "uds":
+        colo_model.colocate_db_uds(**db_args)
 
     # assert model will launch with colocated db
     assert colo_model.colocated

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -5,7 +5,12 @@ import warnings
 from smartsim import Experiment, status
 
 
-@pytest.mark.parametrize("db_type", ["uds","tcp","deprecated"])
+if sys.platform == "darwin":
+    supported_dbs = ["tcp","deprecated"]
+else:
+    supported_dbs = ["uds","tcp","deprecated"]
+
+@pytest.mark.parametrize("db_type", supported_dbs)
 def test_launch_colocated_model(fileutils, db_type):
     """Test the launch of a model with a colocated database and local launcher"""
 


### PR DESCRIPTION
`Models` can now connect to a co-located database using a
Unix Domain Socket (UDS). In synthetic benchmarks, this can
lead to significant improvements over using the loopback
interface over TCP/IP. To ensure compatibility with previous
scripts we now provide the following interfaces:

- `colocate_db` (original): Will throw a `DeprecationWarning`
  but otherwise just wraps `colocate_db_tcp`
- `colocate_db_tcp`: Listens for connections over the loopback
- `colocate_db_uds`: Listens for connections over UDS