### PR TITLE
Support for multi-step jobs; i.e. run_settings as a list

### DIFF
--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -405,7 +405,7 @@ class Controller:
             msg += "Check error and output files for details.\n"
             msg += f"{entity}"
             logger.error(msg)
-            raise SmartSimError(f"Job step {entity.name} failed to launch") from e
+            raise SmartSimError(f"Job step {job_step.name} failed to launch") from e
 
         # a job step is a task if it is not managed by a workload manager (i.e. Slurm)
         # but is rather started, monitored, and exited through the Popen interface

--- a/smartsim/_core/launcher/local/local.py
+++ b/smartsim/_core/launcher/local/local.py
@@ -42,7 +42,7 @@ class LocalLauncher:
         self.task_manager = TaskManager()
         self.step_mapping = StepMapping()
 
-    def create_step(self, name, cwd, step_settings):
+    def create_step(self, name, cwd, step_settings, wait_on_task):
         """Create a job step to launch an entity locally
 
         :return: Step object
@@ -52,6 +52,7 @@ class LocalLauncher:
                 f"Local Launcher only supports entities with RunSettings, not {type(step_settings)}"
             )
         step = LocalStep(name, cwd, step_settings)
+        step.wait_on_task = wait_on_task
         return step
 
     def get_step_update(self, step_names):
@@ -97,7 +98,7 @@ class LocalLauncher:
         error = open(err, "w+")
         cmd = step.get_launch_cmd()
         task_id = self.task_manager.start_task(
-            cmd, step.cwd, env=step.env, out=output, err=error
+            cmd, step.cwd, env=step.env, out=output, err=error, wait_on_task=step.wait_on_task
         )
         self.step_mapping.add(step.name, task_id=task_id, managed=False)
         return task_id

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -40,6 +40,7 @@ class Step:
         self.entity_name = name
         self.cwd = cwd
         self.managed = False
+        self.wait_on_task = False
 
     def get_launch_cmd(self):
         raise NotImplementedError

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -50,8 +50,9 @@ class Step:
 
     def get_output_files(self):
         """Return two paths to error and output files based on cwd"""
-        output = self.get_step_file(ending=".out")
-        error = self.get_step_file(ending=".err")
+        s_name = self.entity_name if self.entity_name.startswith("orchestrator") else self.name
+        output = self.get_step_file(ending=".out", script_name=s_name)
+        error = self.get_step_file(ending=".err", script_name=s_name)
         return output, error
 
     def get_step_file(self, ending=".sh", script_name=None):

--- a/smartsim/_core/launcher/taskManager.py
+++ b/smartsim/_core/launcher/taskManager.py
@@ -97,7 +97,7 @@ class TaskManager:
                 if verbose_tm:
                     logger.debug("Sleeping, no tasks to monitor")
 
-    def start_task(self, cmd_list, cwd, env=None, out=PIPE, err=PIPE):
+    def start_task(self, cmd_list, cwd, env=None, out=PIPE, err=PIPE, wait_on_task=False):
         """Start a task managed by the TaskManager
 
         This is an "unmanaged" task, meaning it is NOT managed
@@ -124,6 +124,8 @@ class TaskManager:
                 logger.debug(f"Starting Task {task.pid}")
             self.tasks.append(task)
             self.task_history[task.pid] = (None, None, None)
+            if (wait_on_task):
+                proc.wait()
             return task.pid
 
         finally:

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -90,7 +90,7 @@ class Ensemble(EntityList):
         self.params_as_args = init_default({}, params_as_args, (list, str))
         self._key_prefixing_enabled = True
         self.batch_settings = init_default({}, batch_settings, BatchSettings)
-        self.run_settings = init_default({}, run_settings, RunSettings)
+        self.run_settings = init_default({}, run_settings, None)
         self._db_models = []
         self._db_scripts = []
         super().__init__(name, getcwd(), perm_strat=perm_strat, **kwargs)


### PR DESCRIPTION
Long term goal: Support for this
```python
rb = exp.create_run_settings(exe="bin1")
rs = exp.create_run_settings(exe="bin2")

# Study parameters
params = {
    "nu": [1e-3, 1e-5, 1e-6],
}

ensemble = exp.create_ensemble("study", 
                               params=params, 
                               run_settings=[rb, rs],
                               perm_strategy="all_perm")
```

which runs bin1 and bin2 consecutively on each study case

**Current state**:
- Implemented only for local runners (but not on batch scripts)
- Some unit tests are on the way