### PR TITLE
Better Exit Usage

### DIFF
--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -176,7 +176,7 @@ class Build:
 
         except (SetupError, BuildError) as e:
             logger.error(str(e))
-            exit(1)
+            sys.exit(1)
 
         logger.info("SmartSim build complete!")
 
@@ -204,13 +204,13 @@ class Build:
         if self.build_env.PLATFORM == "darwin":
             if device == "gpu":
                 logger.error("SmartSim does not support GPU on MacOS")
-                exit(1)
+                sys.exit(1)
             if onnx and self.versions.REDISAI < "1.2.6":
                 logger.error("RedisAI < 1.2.6 does not support ONNX on MacOS")
-                exit(1)
+                sys.exit(1)
             if self.versions.REDISAI == "1.2.4" or self.versions.REDISAI == "1.2.5":
                 logger.error("RedisAI support for MacOS is broken in 1.2.4 and 1.2.5")
-                exit(1)
+                sys.exit(1)
 
         # decide which runtimes to build
         print("\nML Backends Requested")
@@ -241,7 +241,7 @@ class Build:
                     # pip so if we can't find it we know the user suggested a torch
                     # installation path that doesn't exist
                     logger.error("Could not find requested user Torch installation")
-                    exit(1)
+                    sys.exit(1)
             else:
                 # install pytorch wheel, and get the path to the cmake dir
                 # we will use in the RAI build
@@ -389,10 +389,10 @@ class Build:
                 logger.error(
                     f"Before running 'smart build', unset your RAI_PATH environment variable with 'unset RAI_PATH'."
                 )
-            exit(1)
+            sys.exit(1)
         else:
             if installed_redisai_backends():
                 logger.error(
                     "If you wish to re-run `smart build`, you must first run `smart clean`."
                 )
-                exit(1)
+                sys.exit(1)

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -34,38 +34,38 @@ class SmartCli:
         # smart
         if len(sys.argv) < 2:
             parser.print_help()
-            exit(0)
+            sys.exit(0)
 
         args = parser.parse_args(sys.argv[1:2])
         if not hasattr(self, args.command):
             parser.print_help()
-            exit(0)
+            sys.exit(0)
         getattr(self, args.command)()
 
     def build(self):
         Build()
-        exit(0)
+        sys.exit(0)
 
     def clean(self):
         Clean()
-        exit(0)
+        sys.exit(0)
 
     def clobber(self):
         Clean(clean_all=True)
-        exit(0)
+        sys.exit(0)
 
     def site(self):
         print(get_install_path())
-        exit(0)
+        sys.exit(0)
 
     def dbcli(self):
         bin_path = get_install_path() / "_core" / "bin"
         for option in bin_path.iterdir():
             if option.name in ("redis-cli", "keydb-cli"):
                 print(option)
-                exit(0)
+                sys.exit(0)
         print("Database (Redis or KeyDB) dependencies not found")
-        exit(1)
+        sys.exit(1)
 
 
 def main():

--- a/smartsim/_core/entrypoints/colocated.py
+++ b/smartsim/_core/entrypoints/colocated.py
@@ -316,4 +316,4 @@ if __name__ == "__main__":
     # we do not want to have start a colocated process. Only one process
     # per node should be running.
     except filelock.Timeout:
-        exit(0)
+        sys.exit(0)


### PR DESCRIPTION
Removes use of `exit` and replaces with `sys.exit` to handle the unlikely case where users (foolishly) try to use the `smart` cli without fully initializing `site` module