### PR TITLE
Dependency Updates

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,13 +23,16 @@ jobs:
       matrix:
         os: [macos-10.15, ubuntu-20.04] # Operating systems
         compiler: [8] # GNU compiler version
-        rai: [1.2.3, 1.2.5, 1.2.7] # Redis AI versions
-        py_v: [3.7, 3.8, 3.9] # Python versions
+        rai: [1.2.5, 1.2.7] # Redis AI versions
+        py_v: [3.8, 3.9, 3.10] # Python versions
         exclude:
-          - os: macos-10.15 # Do not build with Redis AI 1.2.5 on MacOS
+          # Do not build with Redis AI 1.2.5 on MacOS
+          - os: macos-10.15
             rai: 1.2.5
-          - py_v: 3.7 # ONNX requires python >= 3.8
-            rai: 1.2.7
+          # Do not build Redis AI 1.2.5 with py3.10
+          # as wheels for dependecies are not availble
+          - py_v: 3.10
+            rai: 1.2.5
 
     env:
       SMARTSIM_REDISAI: ${{ matrix.rai }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -82,17 +82,13 @@ jobs:
           python -m pip install git+https://github.com/CrayLabs/SmartRedis.git@develop#egg=smartredis
           python -m pip install .[dev,ml,ray]
 
-      - name: Install ML Runtimes with Smart
-        if: contains( matrix.os, 'macos' )
-        run: smart build --device cpu -v
-
       - name: Install ML Runtimes with Smart (with pt, tf, and onnx support)
-        if: contains( matrix.os, 'ubuntu' ) && (matrix.py_v != 3.9 || matrix.rai != '1.2.3')
+        if: (matrix.py_v != 3.10)
         run: smart build --device cpu --onnx -v
 
-      - name: Install ML Runtimes with Smart excluding PyTorch for Ubuntu/Python3.9/RAI1.2.3 combo
-        if: contains( matrix.os, 'ubuntu' ) && matrix.py_v == 3.9 && matrix.rai == '1.2.3'
-        run: smart build --device cpu --no_pt --onnx -v
+      - name: Install ML Runtimes with Smart (with pt and tf support)
+        if: (matrix.py_v == 3.10)
+        run: smart build --device cpu -v
 
       - name: Run Pytest
         run: |

--- a/README.md
+++ b/README.md
@@ -683,17 +683,17 @@ from C, C++, Fortran and Python with the SmartRedis Clients:
   </thead>
   <tbody style="text-align:center">
     <tr>
-      <td rowspan="3">1.2.3-1.2.4</td>
+      <td rowspan="3">1.2.7</td>
       <td>PyTorch</td>
-      <td>1.7.x</td>
+      <td>1.11.x</td>
     </tr>
     <tr>
       <td>TensorFlow\Keras</td>
-      <td>2.4.x-2.5.x</td>
+      <td>2.8.x</td>
     </tr>
     <tr>
       <td>ONNX</td>
-      <td>1.9.x</td>
+      <td>1.11.x</td>
     </tr>
       <td rowspan="3">1.2.5</td>
       <td>PyTorch</td>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 </div>
 
 
+<div align="center">
+
 [![License](https://img.shields.io/github/license/CrayLabs/SmartSim)](https://github.com/CrayLabs/SmartSim/blob/master/LICENSE.md)
 ![GitHub last commit](https://img.shields.io/github/last-commit/CrayLabs/SmartSim)
 ![GitHub deployments](https://img.shields.io/github/deployments/CrayLabs/SmartSim/github-pages?label=doc%20build)
@@ -26,6 +28,8 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![codecov](https://codecov.io/gh/CrayLabs/SmartSim/branch/develop/graph/badge.svg?token=96HFI2F45E)](https://codecov.io/gh/CrayLabs/SmartSim)
 [![Downloads](https://static.pepy.tech/personalized-badge/smartsim?period=total&units=international_system&left_color=grey&right_color=orange&left_text=Downloads)](https://pepy.tech/project/smartsim)
+
+</div>
 
 ------------
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -10,7 +10,7 @@ Prerequisites
 
 The base prerequisites to install SmartSim and SmartRedis are:
 
-  - Python 3.7-3.9
+  - Python 3.8-3.10
   - Pip
   - Cmake 3.13.x (or later)
   - C compiler
@@ -46,11 +46,11 @@ Supported Versions
    * - MacOS
      - x86_64
      - Not supported
-     - 3.7 - 3.9
+     - 3.8 - 3.10
    * - Linux
      - x86_64
      - Nvidia
-     - 3.7 - 3.9
+     - 3.8 - 3.10
 
 
 .. note::
@@ -69,7 +69,6 @@ the version of the ML libraries).
 +==================+==========+=============+===============+
 | 1.2.7 (default)  | 1.11.0   | 2.8.0       | 1.11.1        |
 | 1.2.5            | 1.9.0    | 2.6.0       | 1.9.0         |
-| 1.2.3            | 1.7.0    | 2.5.2       | 1.9.0         |
 +------------------+----------+-------------+---------------+
 
 TensorFlow_ 2.0 and Keras_ are supported through graph freezing_.
@@ -243,9 +242,9 @@ pre-built wheels that SmartSim does.
    * - Platform
      - Python Versions
    * - MacOS
-     - 3.7 - 3.9
+     - 3.8 - 3.10
    * - Linux
-     - 3.7 - 3.9
+     - 3.8 - 3.10
 
 
 The Python client for SmartRedis is installed through

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,9 @@ contact_email = craylabs@hpe.com
 license = BSD 2-Clause License
 keywords = scientific, ai, workflow, hpc, analysis
 classifiers =
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     License :: OSI Approved :: BSD License
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering
@@ -29,7 +29,7 @@ setup_requires =
     setuptools>=39.2
     cmake>=3.13
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8,<3.11
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ class BuildError(Exception):
 # see https://github.com/google/or-tools/issues/616
 class InstallPlatlib(install):
     def finalize_options(self):
-        install.finalize_options(self)
+        super().finalize_options()
         if self.distribution.has_ext_modules():
             self.install_lib = self.install_platlib
 
@@ -118,7 +118,7 @@ class SmartSimBuild(build_py):
             database_builder.cleanup()
 
         # run original build_py command
-        build_py.run(self)
+        super().run()
 
 
 # Tested with wheel v0.29.0

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,7 @@ extras_require = {
     # see smartsim/_core/_install/buildenv.py for more details
     "ml": versions.ml_extras_required(),
     "ray": [
-        "ray==1.6",
+        "ray~=1.6",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ deps = [
     "redis==3.5.3",
     "tqdm>=4.50.2",
     "filelock>=3.4.2",
-    "protobuf==3.20",
+    "protobuf~=3.20",
 ]
 
 # Add SmartRedis at specific version

--- a/smartsim/__init__.py
+++ b/smartsim/__init__.py
@@ -29,8 +29,8 @@ import sys
 # -*- coding: utf-8 -*-
 from .version import __version__ as __version__
 
-if sys.version_info < (3, 7):  # pragma: no cover
-    sys.exit("Python 3.7 or greater must be used with SmartSim.")
+if sys.version_info < (3, 8):  # pragma: no cover
+    sys.exit("Python 3.8 or greater must be used with SmartSim.")
 
 # Main API module
 from .experiment import Experiment

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -196,16 +196,8 @@ class Build:
     ):
 
         # make sure user isn't trying to do something silly on MacOS
-        if self.build_env.PLATFORM == "darwin":
-            if device == "gpu":
-                logger.error("SmartSim does not support GPU on MacOS")
-                sys.exit(1)
-            if onnx and self.versions.REDISAI < "1.2.6":
-                logger.error("RedisAI < 1.2.6 does not support ONNX on MacOS")
-                sys.exit(1)
-            if self.versions.REDISAI == "1.2.4" or self.versions.REDISAI == "1.2.5":
-                logger.error("RedisAI support for MacOS is broken in 1.2.4 and 1.2.5")
-                sys.exit(1)
+        if self.build_env.PLATFORM == "darwin" and device == "gpu":
+            raise BuildError("SmartSim does not support GPU on MacOS")
 
         # decide which runtimes to build
         print("\nML Backends Requested")

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -231,7 +231,6 @@ class Build:
         if tf:
             self.check_tf_install()
 
-        cmd = []
         # TORCH
         if torch:
             if torch_dir:
@@ -341,6 +340,8 @@ class Build:
 
     def check_onnx_install(self):
         """Check Python environment for ONNX installation"""
+        if sys.version_info >= (3,10):
+            raise SetupError("ONNX 1.11.0 wheel is not available for python>=3.10")
         try:
             if not self.build_env.check_installed("onnx", self.versions.ONNX):
                 msg = (

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -6,7 +6,6 @@ import sys
 from smartsim._core._cli.build import Build
 from smartsim._core._cli.clean import Clean
 from smartsim._core._cli.utils import get_install_path
-from smartsim._core._install.buildenv import Versioner
 
 
 def _usage():

--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -482,7 +482,7 @@ class BuildEnv:
     def check_build_dependency(self, command):
         # TODO expand this to parse and check versions.
         try:
-            out = subprocess.check_call(
+            subprocess.check_call(
                 [command, "--version"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,

--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -122,17 +122,6 @@ class RedisAIVersion(Version_):
     """
 
     defaults = {
-        "1.2.3": {
-            "tensorflow": "2.5.2",
-            "onnx": "1.9.0",
-            "skl2onnx": "1.10.3",
-            "onnxmltools": "1.10.0",
-            "scikit-learn": "1.0.2",
-            "torch": "1.7.1",
-            "torch_cpu_suffix": "+cpu",
-            "torch_cuda_suffix": "+cu110",
-            "torchvision": "0.8.2",
-        },
         "1.2.5": {
             "tensorflow": "2.6.2",
             "onnx": "1.9.0",
@@ -156,8 +145,6 @@ class RedisAIVersion(Version_):
             "torchvision": "0.12.0",
         },
     }
-    # deps are the same between the following versions
-    defaults["1.2.4"] = defaults["1.2.3"]
 
     def __init__(self, vers):
         if vers not in self.defaults:
@@ -173,10 +160,15 @@ class RedisAIVersion(Version_):
             self.version = vers
 
     def __getattr__(self, name):
-        return self.defaults[self.version][name]
+        try:
+            return self.defaults[self.version][name]
+        except KeyError:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            ) from None
 
     def get_defaults(self):
-        return self.defaults[self.version]
+        return self.defaults[self.version].copy()
 
 
 class Versioner:
@@ -203,7 +195,7 @@ class Versioner:
     """
 
     # compatible Python version
-    PYTHON_MIN = Version_("3.7.0")
+    PYTHON_MIN = Version_("3.8.0")
 
     # Versions
     SMARTSIM = Version_(get_env("SMARTSIM_VERSION", "0.4.1"))

--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -238,7 +238,10 @@ class Versioner:
     # TensorFlow and ONNX only use the defaults, but these are not built into
     # the RedisAI package and therefore the user is free to pick other versions.
     TENSORFLOW = Version_(REDISAI.tensorflow)
-    ONNX = Version_(REDISAI.onnx)
+    try:
+        ONNX = Version_(REDISAI.onnx)
+    except AttributeError:
+        ONNX = None
 
     def as_dict(self, db_name="REDIS"):
         packages = [
@@ -248,7 +251,6 @@ class Versioner:
             "REDISAI",
             "TORCH",
             "TENSORFLOW",
-            "ONNX",
         ]
         versions = [
             self.SMARTSIM,
@@ -257,8 +259,10 @@ class Versioner:
             self.REDISAI,
             self.TORCH,
             self.TENSORFLOW,
-            self.ONNX,
         ]
+        if self.ONNX:
+            packages.append("ONNX")
+            versions.append(self.ONNX)
         vers = {"Packages": packages, "Versions": versions}
         return vers
 

--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -145,8 +145,20 @@ class RedisAIVersion(Version_):
             "torchvision": "0.12.0",
         },
     }
+    # Remove options with unsported wheels for python>=3.10
+    if sys.version_info >= (3, 10):
+        defaults.pop("1.2.5")
+        defaults["1.2.7"].pop("onnx")
+        defaults["1.2.7"].pop("skl2onnx")
+        defaults["1.2.7"].pop("onnxmltools")
+        defaults["1.2.7"].pop("scikit-learn")
 
     def __init__(self, vers):
+        min_rai_version = min(Version_(ver) for ver in self.defaults)
+        if min_rai_version > vers:
+            raise SetupError(
+                f"RedisAI version must be greater than or equal to {min_rai_version}"
+            )
         if vers not in self.defaults:
             if vers.startswith("1.2"):
                 # resolve to latest version for 1.2.x

--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -152,6 +152,9 @@ class RedisAIVersion(Version_):
         defaults["1.2.7"].pop("skl2onnx")
         defaults["1.2.7"].pop("onnxmltools")
         defaults["1.2.7"].pop("scikit-learn")
+    # Remove incompatible RAI versions for OSX
+    if sys.platform == "darwin":
+        defaults.pop("1.2.5", None)
 
     def __init__(self, vers):
         min_rai_version = min(Version_(ver) for ver in self.defaults)

--- a/smartsim/_core/_install/builder.py
+++ b/smartsim/_core/_install/builder.py
@@ -227,7 +227,7 @@ class DatabaseBuilder(Builder):
             database = Path(os.environ.get("REDIS_PATH", database_exe)).resolve()
             _ = expand_exe_path(str(database))
         except (TypeError, FileNotFoundError) as e:
-            raise SSConfigError("Installation of redis-server failed!") from e
+            raise BuildError("Installation of redis-server failed!") from e
 
         # validate install -- redis-cli
         try:
@@ -235,7 +235,7 @@ class DatabaseBuilder(Builder):
             redis_cli = Path(os.environ.get("REDIS_CLI_PATH", redis_cli_exe)).resolve()
             _ = expand_exe_path(str(redis_cli))
         except (TypeError, FileNotFoundError) as e:
-            raise SSConfigError("Installation of redis-cli failed!") from e
+            raise BuildError("Installation of redis-cli failed!") from e
 
 
 class RedisAIBuilder(Builder):

--- a/smartsim/_core/_install/builder.py
+++ b/smartsim/_core/_install/builder.py
@@ -258,7 +258,6 @@ class RedisAIBuilder(Builder):
         verbose=False,
     ):
         super().__init__(build_env, jobs=jobs, verbose=verbose)
-        self.rai_build_path = Path(self.build_dir, "RedisAI")
 
         # convert to int for RAI build script
         self.torch = 1 if build_torch else 0
@@ -266,6 +265,10 @@ class RedisAIBuilder(Builder):
         self.onnx = 1 if build_onnx else 0
         self.libtf_dir = libtf_dir
         self.torch_dir = torch_dir
+
+    @property
+    def rai_build_path(self):
+        return Path(self.build_dir, "RedisAI")
 
     @property
     def is_built(self):
@@ -352,7 +355,6 @@ class RedisAIBuilder(Builder):
         :param device: cpu or gpu
         :type device: str
         """
-
         # delete previous build dir (should never be there)
         if self.rai_build_path.is_dir():
             shutil.rmtree(self.rai_build_path)
@@ -369,12 +371,32 @@ class RedisAIBuilder(Builder):
             "clone",
             "--recursive",
             git_url,
-            "--branch",
-            branch,
-            "--depth=1",
-            "RedisAI",
         ]
+        # Circumvent a bad `get_deps.sh` script from RAI on 1.2.7 with ONNX
+        # TODO: Look for a better way to do this or wait for RAI patch
+        if sys.platform == "darwin" and branch == "v1.2.7" and self.onnx:
+            # Clone RAI in an insane way
+            clone_cmd += ["RedisAI"]
+            checkout_osx_fix = [
+                "git",
+                "checkout",
+                "634916c722e718cc6ea3fad46e63f7d798f9adc2",
+            ]
+        else:
+            # Clone RAI in a sane way
+            clone_cmd += [
+                "--branch",
+                branch,
+                "--depth=1",
+                "RedisAI",
+            ]
+            checkout_osx_fix = []
+
         self.run_command(clone_cmd, out=subprocess.DEVNULL, cwd=self.build_dir)
+        if checkout_osx_fix:
+            self.run_command(
+                checkout_osx_fix, out=subprocess.DEVNULL, cwd=self.rai_build_path
+            )
 
         # copy FindTensorFlow.cmake to RAI cmake dir
         self.copy_tf_cmake()


### PR DESCRIPTION
Makes the following changes to SmartSim dependencies:
 - RedisAI 1.2.3 is now deprecated
 - Add support for RedisAI 1.2.7 on MacOS
 - Support Python 3.10 (w/o RAI - ONNX backend)