### PR TITLE
Fix Mpiexec Test on Slurm Based Machines

### DIFF
--- a/tests/test_run_settings.py
+++ b/tests/test_run_settings.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 from shutil import which
 
@@ -10,6 +11,8 @@ from smartsim.settings import (
     RunSettings,
 )
 from smartsim.settings.settings import create_run_settings
+from smartsim.error.errors import SSUnsupportedError
+from smartsim.wlm import detect_launcher
 
 
 def test_create_run_settings_local():
@@ -38,7 +41,6 @@ def test_create_run_settings_local():
     "run_cmd,Settings",
     [
         pytest.param("mpiun", MpirunSettings, id="mpirun"),
-        pytest.param("mpiexec", MpiexecSettings, id="mpiexec"),
         pytest.param("orterun", OrterunSettings, id="orterun"),
     ],
 )
@@ -47,7 +49,23 @@ def test_create_run_settings_returns_settings_subclasses(run_cmd, Settings):
     if _run_cmd:
         settings = create_run_settings("local", "echo", "hello", run_command=run_cmd)
         assert settings.run_command == _run_cmd
-        assert type(settings) == Settings
+        assert isinstance(settings, Settings)
+
+
+def test_create_run_settings_handles_mpiexec_settings_correctly():
+    with contextlib.ExitStack() as ctx:
+        # naively assume that if slurm is present, then the mpiexec.slurm
+        # wrapper is being used
+        if detect_launcher() == "slurm":
+            ctx.enter_context(pytest.raises(SSUnsupportedError))
+        _run_command = which("mpiexec")
+        if _run_command:
+            with ctx:
+                settings = create_run_settings(
+                    "local", "echo", "hello", run_command="mpiexec"
+                )
+                assert settings.run_command == _run_command
+                assert isinstance(settings, MpiexecSettings)
 
 
 ####### Base Run Settings tests #######


### PR DESCRIPTION
Adds new test for testing mpiexec settings that is able to handle slurm's `mpiexec.slurm` wrapper.