### PR TITLE
fix key error for colo lsf

### DIFF
--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -269,7 +269,7 @@ class Model(SmartSimEntity):
             )
 
         if hasattr(self.run_settings, "_prep_colocated_db"):
-            self.run_settings._prep_colocated_db(common_options["db_cpus"])
+            self.run_settings._prep_colocated_db(common_options["cpus"])
 
         # TODO list which db settings can be extras
         colo_db_config = {}


### PR DESCRIPTION
When trying to run a model colo on lsf, a key error will be raised when setting the number of db cpus