### PR TITLE
Fix Unreachable Block on Colo Lsf Settings

### DIFF
--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -70,9 +70,7 @@ class Model(SmartSimEntity):
     @property
     def colocated(self):
         """Return True if this Model will run with a colocated Orchestrator"""
-        if self.run_settings.colocated_db_settings:
-            return True
-        return False
+        return bool(self.run_settings.colocated_db_settings)
 
     def register_incoming_entity(self, incoming_entity):
         """Register future communication between entities.

--- a/smartsim/settings/lsfSettings.py
+++ b/smartsim/settings/lsfSettings.py
@@ -85,7 +85,7 @@ class JsrunSettings(RunSettings):
         :param cpus_per_rs: number of cpus to use per resource set or ALL_CPUS
         :type cpus_per_rs: int or str
         """
-        if self.colocated_db_settings == True:
+        if self.colocated_db_settings:
             db_cpus = self.colocated_db_settings["db_cpus"]
             if cpus_per_rs < db_cpus:
                 raise ValueError(


### PR DESCRIPTION
An object of type `dict[str, Any] | None` is never equivalent to `True`. This needs to be cast to a bool or make a container-is-not-empty check. This PR does the later.