### PR TITLE
Fix job id format, enforce time format

### DIFF
--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -767,14 +767,14 @@ class Experiment:
                         job.entity.type,
                         job.history.jids[run],
                         run,
-                        job.history.job_times[run],
+                        f"{job.history.job_times[run]:.4f}",
                         job.history.statuses[run],
                         job.history.returns[run],
                     ]
                 )
         else:
             return tabulate(
-                values, headers, showindex=True, tablefmt=format, missingval="None"
+                values, headers, showindex=True, tablefmt=format, missingval="None", disable_numparse=True
             )
 
     def _launch_summary(self, manifest):


### PR DESCRIPTION
The current `summary` function lets `tabulate` auto-format numbers (even when they are strings). On Slurm, task ids take the form `<job_id>.<task_id>` and `tabulate` will interpret them as floating point numbers, displaying them incorrectly. 

For example:

```bash
|    | Name           | Entity-Type   |       JobID |   RunID |    Time | Status    |   Returncode |
|----|----------------|---------------|-------------|---------|---------|-----------|--------------|
|  0 | producer_0     | Model         | 3.50355e+06 |       0 | 16.7805 | Completed |            0 |
|  1 | producer_1     | Model         | 3.50355e+06 |       0 | 13.5526 | Completed |            0 |
|  2 | orchestrator_0 | DBNode        | 3.50355e+06 |       0 | 41.6172 | Cancelled |            0 |
```

this PR disable auto-formatting and enforces formatting for time, allowing us to decide how to display numbers, with the following result:

```bash
|    | Name           | Entity-Type   | JobID      | RunID   | Time    | Status    | Returncode   |
|----|----------------|---------------|------------|---------|---------|-----------|--------------|
| 0  | producer_0     | Model         | 3503549.28 | 0       | 16.7840 | Completed | 0            |
| 1  | producer_1     | Model         | 3503549.29 | 0       | 13.5571 | Completed | 0            |
| 2  | orchestrator_0 | DBNode        | 3503549.27 | 0       | 41.6117 | Cancelled | 0            |
```