### PR TITLE
exclude csv-valued env values from --export, enable csv-valued in mpmd

### DIFF
--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -141,7 +141,7 @@ class SrunStep(Step):
             ) = self.run_settings.format_comma_sep_env_vars()
 
             if len(env_var_str) > 0:
-                srun_cmd += ["--export", env_var_str]
+                srun_cmd += ["--export", f"ALL,{env_var_str}"]
 
             if comma_separated_env_vars:
                 compound_env = compound_env.union(comma_separated_env_vars)
@@ -213,7 +213,7 @@ class SrunStep(Step):
 
             (env_var_str, csv_env_vars) = mpmd.format_comma_sep_env_vars()
             if len(env_var_str) > 0:
-                cmd += ["--export", env_var_str]
+                cmd += ["--export", f"ALL,{env_var_str}"]
             if csv_env_vars:
                 compound_env_vars.extend(csv_env_vars)
             cmd += mpmd.exe

--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -219,8 +219,5 @@ class SrunStep(Step):
             cmd += mpmd.exe
             cmd += mpmd.exe_args
 
-        # if compound_env_vars:
-        #     cmd = ["env"] + compound_env_vars + cmd
-
         cmd = sh_split(" ".join(cmd))
         return cmd

--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -199,15 +199,23 @@ class SrunStep(Step):
         exe = self.run_settings.exe
         args = self.run_settings.exe_args
         cmd = exe + args
+
+        compound_env_vars = []
         for mpmd in self.run_settings.mpmd:
             cmd += [" : "]
             cmd += mpmd.format_run_args()
             cmd += ["--job-name", self.name]
-            (env_var_str, _) = mpmd.format_comma_sep_env_vars()
+            
+            (env_var_str, csv_env_vars) = mpmd.format_comma_sep_env_vars()
             if len(env_var_str) > 0:
                 cmd += ["--export", env_var_str]
+            if csv_env_vars:
+                compound_env_vars.extend(csv_env_vars)
             cmd += mpmd.exe
             cmd += mpmd.exe_args
+
+        if compound_env_vars:
+            cmd = ["env"] + compound_env_vars + cmd
 
         cmd = sh_split(" ".join(cmd))
         return cmd

--- a/smartsim/settings/slurmSettings.py
+++ b/smartsim/settings/slurmSettings.py
@@ -24,7 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Tuple
+from typing import List, Tuple
 import datetime
 
 from ..error import SSUnsupportedError
@@ -285,7 +285,7 @@ class SrunSettings(RunSettings):
         """
         return [f"{k}={v}" for k, v in self.env_vars.items() if "," not in str(v)]
 
-    def format_comma_sep_env_vars(self) -> Tuple[str, list[str]]:
+    def format_comma_sep_env_vars(self) -> Tuple[str, List[str]]:
         """Build environment variable string for Slurm
 
         Slurm takes exports in comma separated lists

--- a/smartsim/settings/slurmSettings.py
+++ b/smartsim/settings/slurmSettings.py
@@ -24,8 +24,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import List, Tuple
 import datetime
+from typing import List, Tuple
 
 from ..error import SSUnsupportedError
 from .base import BatchSettings, RunSettings
@@ -298,7 +298,7 @@ class SrunSettings(RunSettings):
 
         exportable_env, compound_env, key_only = [], [], []
 
-        for (k, v) in self.env_vars.items():    
+        for k, v in self.env_vars.items():
             kvp = f"{k}={v}"
 
             if "," in str(v):
@@ -306,12 +306,16 @@ class SrunSettings(RunSettings):
                 compound_env.append(kvp)
             else:
                 exportable_env.append(kvp)
-        
+
         # Append keys to exportable KVPs, e.g. `--export x1=v1,KO1,KO2`
         fmt_exported_env = ",".join(v for v in exportable_env + key_only)
 
-        return fmt_exported_env, compound_env
+        for mpmd in self.mpmd:
+            compound_mpmd_env = {k: v for k, v in mpmd.env_vars.items() if "," in v}
+            compound_mpmd_fmt = {f"{k}={v}" for k, v in compound_mpmd_env.items()}
+            compound_env.extend(compound_mpmd_fmt)
 
+        return fmt_exported_env, compound_env
 
 
 class SbatchSettings(BatchSettings):

--- a/tests/test_slurm_settings.py
+++ b/tests/test_slurm_settings.py
@@ -82,7 +82,7 @@ def test_catch_colo_mpmd():
         srun.make_mpmd(srun_2)
 
 
-def test_catch_colo_mpmd_compound_env():
+def test_mpmd_compound_env_exports():
     """
     Test that compound env vars are added to root env and exported
     to the correct sub-command in mpmd cmd

--- a/tests/test_slurm_settings.py
+++ b/tests/test_slurm_settings.py
@@ -142,6 +142,94 @@ def test_mpmd_compound_env_exports():
     assert "cmp2=222,333" in env_area
 
 
+def test_mpmd_non_compound_env_exports():
+    """
+    Test that without compound env vars, no `env <k=v>...` is prepended to cmd
+    """
+    srun = SrunSettings("python")
+    srun.in_batch = True
+    srun.alloc = 12345
+    srun.env_vars = {"cmp1": "123", "norm1": "xyz"}
+    srun_2 = SrunSettings("python")
+    srun_2.env_vars = {"cmp2": "222", "norm2": "pqr"}
+    srun.make_mpmd(srun_2)
+
+    from smartsim._core.launcher.step.slurmStep import SbatchStep, SrunStep
+    from smartsim.settings.slurmSettings import SbatchSettings
+
+    step = SrunStep("teststep", "./", srun)
+
+    launch_cmd = step.get_launch_cmd()
+    env_cmds = [v for v in launch_cmd if v == "env"]
+    assert "env" not in launch_cmd and len(env_cmds) == 0
+
+    # ensure mpmd command is concatenated
+    mpmd_delimiter_idx = launch_cmd.index(":")
+    assert mpmd_delimiter_idx > -1
+
+    # ensure root cmd exports env
+    root_cmd = launch_cmd[:mpmd_delimiter_idx]
+    exp_idx = root_cmd.index("--export")
+    assert exp_idx
+
+    # ensure correct exports
+    env_vars = root_cmd[exp_idx + 1]
+    assert "cmp1" in env_vars
+    assert "norm1=xyz" in env_vars
+    assert "cmp2" not in env_vars
+    assert "norm2" not in env_vars
+
+    # ensure mpmd cmd exports env
+    mpmd_cmd = launch_cmd[mpmd_delimiter_idx:]
+    exp_idx = mpmd_cmd.index("--export")
+    assert exp_idx
+
+    # ensure correct exports
+    env_vars = mpmd_cmd[exp_idx + 1]
+    assert "cmp2" in env_vars
+    assert "norm2=pqr" in env_vars
+    assert "cmp1" not in env_vars
+    assert "norm1" not in env_vars
+
+    srun_idx = launch_cmd.index("srun")
+    assert srun_idx > -1
+
+    # ensure correct vars loaded in parent shell
+    env_area = launch_cmd[:srun_idx]
+    assert "env" not in env_area
+    assert "cmp1=123" not in env_area
+    assert "cmp2=222" not in env_area
+
+
+def test_mpmd_non_compound_no_exports():
+    """
+    Test that no --export is added if no env vars are supplied
+    """
+    srun = SrunSettings("python")
+    srun.in_batch = True
+    srun.alloc = 12345
+    srun.env_vars = {} 
+    srun_2 = SrunSettings("python")
+    srun_2.env_vars = {}
+    srun.make_mpmd(srun_2)
+
+    from smartsim._core.launcher.step.slurmStep import SbatchStep, SrunStep
+    from smartsim.settings.slurmSettings import SbatchSettings
+
+    step = SrunStep("teststep", "./", srun)
+
+    launch_cmd = step.get_launch_cmd()
+    env_cmds = [v for v in launch_cmd if v == "env"]
+    assert "env" not in launch_cmd and len(env_cmds) == 0
+
+    # ensure mpmd command is concatenated
+    mpmd_delimiter_idx = launch_cmd.index(":")
+    assert mpmd_delimiter_idx > -1
+
+    # ensure no --export exists in either command
+    assert "--export" not in launch_cmd
+
+
 def test_format_env_vars():
     rs = SrunSettings(
         "python",

--- a/tests/test_slurm_settings.py
+++ b/tests/test_slurm_settings.py
@@ -104,6 +104,7 @@ def test_format_comma_sep_env_vars():
     assert "OMP_NUM_THREADS" in formatted
     assert "LOGGING" in formatted
     assert "SSKEYIN" in formatted
+    assert "name_0,name_1" not in formatted
     assert "SSKEYIN=name_0,name_1" in comma_separated_formatted
 
 

--- a/tests/test_slurm_settings.py
+++ b/tests/test_slurm_settings.py
@@ -132,7 +132,7 @@ def test_mpmd_compound_env_exports():
     assert "cmp1" not in env_vars
     assert "norm1" not in env_vars
 
-    srun_idx = launch_cmd.index("srun")
+    srun_idx = " ".join(launch_cmd).index("srun")
     assert srun_idx > -1
 
     # ensure correct vars loaded in parent shell
@@ -191,7 +191,7 @@ def test_mpmd_non_compound_env_exports():
     assert "cmp1" not in env_vars
     assert "norm1" not in env_vars
 
-    srun_idx = launch_cmd.index("srun")
+    srun_idx = " ".join(launch_cmd).index("srun")
     assert srun_idx > -1
 
     # ensure correct vars loaded in parent shell

--- a/tests/test_slurm_settings.py
+++ b/tests/test_slurm_settings.py
@@ -87,11 +87,11 @@ def test_mpmd_compound_env_exports():
     Test that compound env vars are added to root env and exported
     to the correct sub-command in mpmd cmd
     """
-    srun = SrunSettings("python")
+    srun = SrunSettings("printenv")
     srun.in_batch = True
     srun.alloc = 12345
     srun.env_vars = {"cmp1": "123,456", "norm1": "xyz"}
-    srun_2 = SrunSettings("python")
+    srun_2 = SrunSettings("printenv")
     srun_2.env_vars = {"cmp2": "222,333", "norm2": "pqr"}
     srun.make_mpmd(srun_2)
 
@@ -146,11 +146,11 @@ def test_mpmd_non_compound_env_exports():
     """
     Test that without compound env vars, no `env <k=v>...` is prepended to cmd
     """
-    srun = SrunSettings("python")
+    srun = SrunSettings("printenv")
     srun.in_batch = True
     srun.alloc = 12345
     srun.env_vars = {"cmp1": "123", "norm1": "xyz"}
-    srun_2 = SrunSettings("python")
+    srun_2 = SrunSettings("printenv")
     srun_2.env_vars = {"cmp2": "222", "norm2": "pqr"}
     srun.make_mpmd(srun_2)
 
@@ -205,11 +205,11 @@ def test_mpmd_non_compound_no_exports():
     """
     Test that no --export is added if no env vars are supplied
     """
-    srun = SrunSettings("python")
+    srun = SrunSettings("printenv")
     srun.in_batch = True
     srun.alloc = 12345
     srun.env_vars = {} 
-    srun_2 = SrunSettings("python")
+    srun_2 = SrunSettings("printenv")
     srun_2.env_vars = {}
     srun.make_mpmd(srun_2)
 

--- a/tests/test_slurm_settings.py
+++ b/tests/test_slurm_settings.py
@@ -82,6 +82,66 @@ def test_catch_colo_mpmd():
         srun.make_mpmd(srun_2)
 
 
+def test_catch_colo_mpmd_compound_env():
+    """
+    Test that compound env vars are added to root env and exported
+    to the correct sub-command in mpmd cmd
+    """
+    srun = SrunSettings("python")
+    srun.in_batch = True
+    srun.alloc = 12345
+    srun.env_vars = {"cmp1": "123,456", "norm1": "xyz"}
+    srun_2 = SrunSettings("python")
+    srun_2.env_vars = {"cmp2": "222,333", "norm2": "pqr"}
+    srun.make_mpmd(srun_2)
+
+    from smartsim._core.launcher.step.slurmStep import SbatchStep, SrunStep
+    from smartsim.settings.slurmSettings import SbatchSettings
+
+    step = SrunStep("teststep", "./", srun)
+
+    launch_cmd = step.get_launch_cmd()
+    env_cmds = [v for v in launch_cmd if v == "env"]
+    assert "env" in launch_cmd and len(env_cmds) == 1
+
+    # ensure mpmd command is concatenated
+    mpmd_delimiter_idx = launch_cmd.index(":")
+    assert mpmd_delimiter_idx > -1
+
+    # ensure root cmd exports env
+    root_cmd = launch_cmd[:mpmd_delimiter_idx]
+    exp_idx = root_cmd.index("--export")
+    assert exp_idx
+
+    # ensure correct exports
+    env_vars = root_cmd[exp_idx + 1]
+    assert "cmp1" in env_vars
+    assert "norm1=xyz" in env_vars
+    assert "cmp2" not in env_vars
+    assert "norm2" not in env_vars
+
+    # ensure mpmd cmd exports env
+    mpmd_cmd = launch_cmd[mpmd_delimiter_idx:]
+    exp_idx = mpmd_cmd.index("--export")
+    assert exp_idx
+
+    # ensure correct exports
+    env_vars = mpmd_cmd[exp_idx + 1]
+    assert "cmp2" in env_vars
+    assert "norm2=pqr" in env_vars
+    assert "cmp1" not in env_vars
+    assert "norm1" not in env_vars
+
+    srun_idx = launch_cmd.index("srun")
+    assert srun_idx > -1
+
+    # ensure correct vars loaded in parent shell
+    env_area = launch_cmd[:srun_idx]
+    assert "env" in env_area
+    assert "cmp1=123,456" in env_area
+    assert "cmp2=222,333" in env_area
+
+
 def test_format_env_vars():
     rs = SrunSettings(
         "python",


### PR DESCRIPTION
This PR fixes two defects related to passing environment variables to slurm jobs.

1. CSV-valued environment variables are not passed to MPMD executions
2. CSV-valued environment variables are passed twice

For (1), add populating source env with `env k1=v1,v2 {srun} --export k1`

For (2), perform key-only export of csv-valued vars:
- old: `env k1=v1,v2 srun --export k1=v1,v2`
- new: `env k1=v1,v2 srun --export k1`

Sample demonstrating "double export" overwrite & solution in non-mpmd:

```
mcb@h:~> env abc=123,456 def=234,345 srun --output /home/users/mcbridch/outsolo.txt --export=abc=123,456 /usr/bin/printenv
mcb@h:~> cat ./outsolo.txt | grep abc                                                                                    
abc=123
mcb@h:~> env abc=123,456 def=234,345 srun --output /home/users/mcbridch/outsolo.txt --export=abc /usr/bin/printenv 
mcb@h:~> cat ./outsolo.txt | grep abc                                                                             
abc=123,456
```

Sample mpmd launch_cmd with no env:

![image](https://user-images.githubusercontent.com/3595025/224429695-9bcf77c9-ac65-4495-9de6-82f57f510a7c.png)

Sample mpmd launch_cmd with env:

![image](https://user-images.githubusercontent.com/3595025/224430020-5b783960-d42a-43e7-b3fd-f37697ce95ab.png)

