### PR TITLE
Relax codecov threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,16 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
-  threshold: 1% # Account for some variability in codecov
+
+  status:
+    patch:
+      default:
+       # Account for some variability in codecov
+       threshold: 0.5% 
+    project:
+      default:
+       # Account for some variability in codecov
+       threshold: 0.5% 
 
 parsers:
   gcov:

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,7 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
+  threshold: 1% # Account for some variability in codecov
 
 parsers:
   gcov:


### PR DESCRIPTION
The updated codecov integration will occasionally flag PRs as failing due to decreases in code coverage. Investigating the logs points to this being sporadic changes due to occasional failures when uploading code coverage. To avoid false positives and a stopgap solution, the threshold for code coverage is set to 0.5% instead of the default 0%