### PR TITLE
Clean up environment before each test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -411,6 +411,13 @@ def db_cluster(fileutils, wlmutils, request):
     exp.stop(db)
 
 
+@pytest.fixture(scope="function", autouse=True)
+def environment_cleanup():
+    os.environ.pop("SSDB", "")
+    os.environ.pop("SSKEYIN", "")
+    os.environ.pop("SSKEYOUT", "")
+
+
 @pytest.fixture
 def dbutils():
     return DBUtils

--- a/smartsim/settings/slurmSettings.py
+++ b/smartsim/settings/slurmSettings.py
@@ -25,10 +25,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import datetime
+import os
 from typing import List, Tuple
 
 from ..error import SSUnsupportedError
 from .base import BatchSettings, RunSettings
+
+from ..log import get_logger
+
+logger = get_logger(__name__)
 
 
 class SrunSettings(RunSettings):
@@ -277,14 +282,32 @@ class SrunSettings(RunSettings):
                     opts += ["=".join((prefix + opt, str(value)))]
         return opts
 
+    def check_env_vars(self):
+        """Warn a user trying to set a variable which is set in the environment
+
+        Given Slurm's env var precedence, trying to export a variable which is already
+        present in the environment will not work.
+        """
+        for k,v in self.env_vars.items():
+            if "," not in str(v):
+                # If a variable is defined, it will take precedence over --export
+                # we warn the user
+                preexisting_var = os.environ.get(k, None)
+                if preexisting_var:
+                    msg = f"Variable {k} is set to {preexisting_var} in current environment. "
+                    msg += f"If the job is running in an interactive allocation, the value {v} will not be set. "
+                    msg += "Please consider removing the variable from the environment and re-run the experiment."
+                    logger.warning(msg)
+
     def format_env_vars(self):
         """Build bash compatible environment variable string for Slurm
 
         :returns: the formatted string of environment variables
         :rtype: list[str]
         """
+        self.check_env_vars()
         return [f"{k}={v}" for k, v in self.env_vars.items() if "," not in str(v)]
-
+    
     def format_comma_sep_env_vars(self) -> Tuple[str, List[str]]:
         """Build environment variable string for Slurm
 
@@ -295,7 +318,7 @@ class SrunSettings(RunSettings):
         :returns: the formatted string of environment variables
         :rtype: tuple[str, list[str]]
         """
-
+        self.check_env_vars()
         exportable_env, compound_env, key_only = [], [], []
 
         for k, v in self.env_vars.items():


### PR DESCRIPTION
This PR adds an environment cleanup fixture which is run before every test. Environment variables such as `SSDB`, `SSKEYIN`, and `SSKEYOUT` are removed if they are found to be set. This avoids issues with testing on Slurm.
To make users aware of Slurm's behavior, a warning is issued if the user tries to export a variable and it is already defined. This warning is not needed when we set a variable to a comma-separated value, as in that case, we are explicitly overwriting the environment value (by setting the value before `srun`).