### PR TITLE
Fix Type Hint in Doc for `create_run_settings`

### DIFF
--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -567,7 +567,7 @@ class Experiment:
         :param exe_args: arguments to pass to the executable
         :type exe_args: list[str], optional
         :param run_args: arguments to pass to the ``run_command``
-        :type run_args: list[str], optional
+        :type run_args: dict[str, str], optional
         :param env_vars: environment variables to pass to the executable
         :type env_vars: dict[str, str], optional
         :return: the created ``RunSettings``


### PR DESCRIPTION
The factory method `Experiment.create_run_setttings` lists the `run_args` param to be a `list[str]`, but every RS constructor expects a `dict[str, str]` without any casting being done behind the scenes.