### PR TITLE
Multiple network interface binding

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,6 +11,28 @@ Jump to :ref:`SmartRedis Changelog <changelog>`
 SmartSim
 ========
 
+Development branch
+------------------
+
+To be released at some future date
+
+Note
+
+This section details changes made in the development branch that have not yet been applied to a released version of the SmartSim library.
+
+Description
+
+A full list of changes and detailed notes can be found below:
+
+- Add support for multiple network interface binding in Orchestrator and Colocated DBs
+
+Detailed notes
+
+- Orchestrator and Colocated DB now accept a list of interfaces to bind to. The argument name is still `interface`
+  for backward compatibility reasons. (PR281_)
+
+.. _PR281: https://github.com/CrayLabs/SmartSim/pull/282
+
 0.4.2
 -----
 

--- a/doc/orchestrator.rst
+++ b/doc/orchestrator.rst
@@ -98,8 +98,8 @@ Here is an example of creating a simple model that is co-located with an
           port=6780,              # database port
           db_cpus=1,              # cpus given to the database on each node
           debug=False             # include debug information (will be slower)
-          limit_app_cpus=False,   # don't overscubscribe app with database cpus
-          ifname=network_interface # specify network interface to use (i.e. "ib0")
+          limit_app_cpus=False,   # don't oversubscribe app with database cpus
+          ifname=network_interface # specify network interface(s) to use (i.e. "ib0" or ["ib0", "lo"])
   )
   exp.start(colo_model)
 

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -178,6 +178,7 @@ class Config:
                 for net_if_addr in net_if_addrs:
                     if net_if_addr.startswith("hsn"):
                         interfaces.append(net_if_addr)
+                return interfaces
             elif "ib0" in net_if_addrs:
                 return "ib0"
             # default to aries network

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -163,17 +163,18 @@ class Config:
         return int(os.environ.get("SMARTSIM_TEST_PORT", 6780))
 
     @property
-    def test_interface(self) -> Union[str, List[str]]:
+    def test_interface(self) -> List[str]:
         interfaces = os.environ.get("SMARTSIM_TEST_INTERFACE", None)
         if interfaces:
             if "," in interfaces:
                 interfaces = interfaces.split(",")
-            return interfaces
+                return interfaces
+            return [interfaces]
     
         # try to pick a sensible one
         net_if_addrs = psutil.net_if_addrs()
         if "ipogif0" in net_if_addrs:
-            return "ipogif0"
+            return ["ipogif0"]
         elif "hsn0" in net_if_addrs:
             interfaces = []
             for net_if_addr in net_if_addrs:
@@ -181,9 +182,9 @@ class Config:
                     interfaces.append(net_if_addr)
             return interfaces
         elif "ib0" in net_if_addrs:
-            return "ib0"
+            return ["ib0"]
         # default to aries network
-        return "ipogif0"
+        return ["ipogif0"]
 
     @property
     def test_account(self) -> str:

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -187,7 +187,7 @@ class Config:
         return ["ipogif0"]
 
     @property
-    def test_account(self) -> str:
+    def test_account(self) -> str:  # pragma: no cover
         # no account by default
         return os.environ.get("SMARTSIM_TEST_ACCOUNT", "")
 

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -164,9 +164,11 @@ class Config:
     @property
     def test_interface(self) -> str:
         interfaces = os.environ.get("SMARTSIM_TEST_INTERFACE", None)
-        if "," in interfaces:
-            interfaces = interfaces.split(",")
-        if not interfaces:
+        if interfaces:
+            if "," in interfaces:
+                interfaces = interfaces.split(",")
+            return interfaces
+        else:
             # try to pick a sensible one
             net_if_addrs = psutil.net_if_addrs()
             if "ipogif0" in net_if_addrs:
@@ -180,8 +182,6 @@ class Config:
                 return "ib0"
             # default to aries network
             return "ipogif0"
-        else:
-            return interfaces
 
     @property
     def test_account(self) -> str:

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -147,23 +147,23 @@ class Config:
         return int(os.environ.get("SMARTSIM_JM_INTERVAL", 10))
 
     @property
-    def wlm_trials(self) -> int:
+    def wlm_trials(self) -> int:  # pragma: no cover
         return int(os.environ.get("SMARTSIM_WLM_TRIALS", 10))
 
     @property
-    def test_launcher(self) -> str:
+    def test_launcher(self) -> str:  # pragma: no cover
         return os.environ.get("SMARTSIM_TEST_LAUNCHER", "local")
 
     @property
-    def test_device(self) -> str:
+    def test_device(self) -> str:  # pragma: no cover
         return os.environ.get("SMARTSIM_TEST_DEVICE", "CPU")
 
     @property
-    def test_port(self) -> int:
+    def test_port(self) -> int:  # pragma: no cover
         return int(os.environ.get("SMARTSIM_TEST_PORT", 6780))
 
     @property
-    def test_interface(self) -> List[str]:
+    def test_interface(self) -> List[str]:  # pragma: no cover
         interfaces = os.environ.get("SMARTSIM_TEST_INTERFACE", None)
         if interfaces:
             if "," in interfaces:

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -170,17 +170,17 @@ class Config:
                 interfaces = interfaces.split(",")
                 return interfaces
             return [interfaces]
-    
+
         # try to pick a sensible one
         net_if_addrs = psutil.net_if_addrs()
         if "ipogif0" in net_if_addrs:
             return ["ipogif0"]
         elif "hsn0" in net_if_addrs:
-            interfaces = []
-            for net_if_addr in net_if_addrs:
-                if net_if_addr.startswith("hsn"):
-                    interfaces.append(net_if_addr)
-            return interfaces
+            return [
+                net_if_addr
+                for net_if_addr in net_if_addrs
+                if net_if_addr.startswith("hsn")
+            ]
         elif "ib0" in net_if_addrs:
             return ["ib0"]
         # default to aries network
@@ -194,6 +194,5 @@ class Config:
 
 @lru_cache(maxsize=128, typed=False)
 def get_config():
-
     # wrap into a function with a cached result
     return Config()

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -27,6 +27,7 @@
 import os
 from functools import lru_cache
 from pathlib import Path
+from typing import Union
 
 import psutil
 
@@ -162,27 +163,27 @@ class Config:
         return int(os.environ.get("SMARTSIM_TEST_PORT", 6780))
 
     @property
-    def test_interface(self) -> str:
+    def test_interface(self) -> Union[str, list[str]]:
         interfaces = os.environ.get("SMARTSIM_TEST_INTERFACE", None)
         if interfaces:
             if "," in interfaces:
                 interfaces = interfaces.split(",")
             return interfaces
-        else:
-            # try to pick a sensible one
-            net_if_addrs = psutil.net_if_addrs()
-            if "ipogif0" in net_if_addrs:
-                return "ipogif0"
-            elif "hsn0" in net_if_addrs:
-                interfaces = []
-                for net_if_addr in net_if_addrs:
-                    if net_if_addr.startswith("hsn"):
-                        interfaces.append(net_if_addr)
-                return interfaces
-            elif "ib0" in net_if_addrs:
-                return "ib0"
-            # default to aries network
+    
+        # try to pick a sensible one
+        net_if_addrs = psutil.net_if_addrs()
+        if "ipogif0" in net_if_addrs:
             return "ipogif0"
+        elif "hsn0" in net_if_addrs:
+            interfaces = []
+            for net_if_addr in net_if_addrs:
+                if net_if_addr.startswith("hsn"):
+                    interfaces.append(net_if_addr)
+            return interfaces
+        elif "ib0" in net_if_addrs:
+            return "ib0"
+        # default to aries network
+        return "ipogif0"
 
     @property
     def test_account(self) -> str:

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -27,7 +27,7 @@
 import os
 from functools import lru_cache
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 import psutil
 
@@ -163,7 +163,7 @@ class Config:
         return int(os.environ.get("SMARTSIM_TEST_PORT", 6780))
 
     @property
-    def test_interface(self) -> Union[str, list[str]]:
+    def test_interface(self) -> Union[str, List[str]]:
         interfaces = os.environ.get("SMARTSIM_TEST_INTERFACE", None)
         if interfaces:
             if "," in interfaces:

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -163,18 +163,25 @@ class Config:
 
     @property
     def test_interface(self) -> str:
-        interface = os.environ.get("SMARTSIM_TEST_INTERFACE", None)
-        if not interface:
+        interfaces = os.environ.get("SMARTSIM_TEST_INTERFACE", None)
+        if "," in interfaces:
+            interfaces = interfaces.split(",")
+        if not interfaces:
             # try to pick a sensible one
             net_if_addrs = psutil.net_if_addrs()
             if "ipogif0" in net_if_addrs:
                 return "ipogif0"
+            elif "hsn0" in net_if_addrs:
+                interfaces = []
+                for net_if_addr in net_if_addrs:
+                    if net_if_addr.startswith("hsn"):
+                        interfaces.append(net_if_addr)
             elif "ib0" in net_if_addrs:
                 return "ib0"
             # default to aries network
             return "ipogif0"
         else:
-            return interface
+            return interfaces
 
     @property
     def test_account(self) -> str:

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -147,7 +147,7 @@ class Config:
         return int(os.environ.get("SMARTSIM_JM_INTERVAL", 10))
 
     @property
-    def wlm_trials(self) -> int:  # pragma: no cover
+    def wlm_trials(self) -> int:
         return int(os.environ.get("SMARTSIM_WLM_TRIALS", 10))
 
     @property

--- a/smartsim/_core/control/manifest.py
+++ b/smartsim/_core/control/manifest.py
@@ -174,7 +174,7 @@ class Manifest:
             s += db_header
             s += f"Shards: {self.db.num_shards}\n"
             s += f"Port: {str(self.db.ports[0])}\n"
-            s += f"Network: {self.db._interface}\n"
+            s += f"Network: {self.db._interfaces}\n"
             s += f"Batch Launch: {self.db.batch}\n"
             if self.db.batch:
                 s += f"{str(self.db.batch_settings)}\n"

--- a/smartsim/_core/entrypoints/colocated.py
+++ b/smartsim/_core/entrypoints/colocated.py
@@ -167,16 +167,15 @@ def main(
 
     lo_address = current_ip("lo")
     try:
-        ip_addresses = [current_ip(interface) for interface in network_interface.split(",")]
-        
+        ip_addresses = [
+            current_ip(interface) for interface in network_interface.split(",")
+        ]
+
     except ValueError as e:
         logger.warning(e)
         ip_addresses = []
 
-    if (
-        all(lo_address == ip_address for ip_address in ip_addresses)
-        or not ip_addresses
-    ):
+    if all(lo_address == ip_address for ip_address in ip_addresses) or not ip_addresses:
         cmd = command + [f"--bind {lo_address}"]
     else:
         # bind to both addresses if the user specified a network

--- a/smartsim/_core/entrypoints/colocated.py
+++ b/smartsim/_core/entrypoints/colocated.py
@@ -165,21 +165,26 @@ def main(
 ):
     global DBPID
 
+    lo_address = current_ip("lo")
     try:
-        ip_address = None
-        if network_interface:
-            ip_address = current_ip(network_interface)
-        lo_address = current_ip("lo")
+        ip_addresses = []
+        ip_addresses.extend(
+            [current_ip(interface) for interface in network_interface.split(",")]
+        )
     except ValueError as e:
         logger.warning(e)
-        ip_address = None
+        ip_addresses = []
 
-    if lo_address == ip_address or not ip_address:
+    if (
+        all([lo_address == ip_address for ip_address in ip_addresses])
+        or not ip_addresses
+    ):
         cmd = command + [f"--bind {lo_address}"]
     else:
         # bind to both addresses if the user specified a network
         # address that exists and is not the loopback address
-        cmd = command + [f"--bind {lo_address} {ip_address}"]
+        cmd = command + [f"--bind {lo_address} " + " ".join(ip_addresses)]
+        cmd += [f"--bind-source-addr {lo_address}"]
 
     # we generally want to catch all exceptions here as
     # if this process dies, the application will most likely fail
@@ -206,7 +211,7 @@ def main(
             "\n\nCo-located database information\n"
             + "\n".join(
                 (
-                    f"\tIP Address: {ip_address}",
+                    f"\tIP Address(es): " + " ".join(ip_addresses + [lo_address]),
                     f"\t# of Database CPUs: {db_cpus}",
                     f"\tAffinity: {cpus_to_use}",
                     f"\tCommand: {' '.join(cmd)}\n\n",

--- a/smartsim/_core/entrypoints/colocated.py
+++ b/smartsim/_core/entrypoints/colocated.py
@@ -184,6 +184,7 @@ def main(
         # bind to both addresses if the user specified a network
         # address that exists and is not the loopback address
         cmd = command + [f"--bind {lo_address} " + " ".join(ip_addresses)]
+        # pin source address to avoid random selection by Redis
         cmd += [f"--bind-source-addr {lo_address}"]
 
     # we generally want to catch all exceptions here as

--- a/smartsim/_core/entrypoints/colocated.py
+++ b/smartsim/_core/entrypoints/colocated.py
@@ -167,23 +167,21 @@ def main(
 
     lo_address = current_ip("lo")
     try:
-        ip_addresses = []
-        ip_addresses.extend(
-            [current_ip(interface) for interface in network_interface.split(",")]
-        )
+        ip_addresses = [current_ip(interface) for interface in network_interface.split(",")]
+        
     except ValueError as e:
         logger.warning(e)
         ip_addresses = []
 
     if (
-        all([lo_address == ip_address for ip_address in ip_addresses])
+        all(lo_address == ip_address for ip_address in ip_addresses)
         or not ip_addresses
     ):
         cmd = command + [f"--bind {lo_address}"]
     else:
         # bind to both addresses if the user specified a network
         # address that exists and is not the loopback address
-        cmd = command + [f"--bind {lo_address} " + " ".join(ip_addresses)]
+        cmd = command + [f"--bind {lo_address} {' '.join(ip_addresses)}"]
         # pin source address to avoid random selection by Redis
         cmd += [f"--bind-source-addr {lo_address}"]
 
@@ -212,10 +210,10 @@ def main(
             "\n\nCo-located database information\n"
             + "\n".join(
                 (
-                    f"\tIP Address(es): " + " ".join(ip_addresses + [lo_address]),
-                    f"\t# of Database CPUs: {db_cpus}",
+                    f"\tIP Address(es): {' '.join(ip_addresses + [lo_address])}",
                     f"\tAffinity: {cpus_to_use}",
                     f"\tCommand: {' '.join(cmd)}\n\n",
+                    f"\t# of Database CPUs: {db_cpus}",
                 )
             )
         )

--- a/smartsim/_core/entrypoints/redis.py
+++ b/smartsim/_core/entrypoints/redis.py
@@ -57,8 +57,12 @@ def main(network_interface: str, command: List[str]):
 
     try:
 
-        ip_address = current_ip(network_interface)
-        cmd = command + [f"--bind {ip_address}"]
+        ip_addresses = [
+            current_ip(net_if) for net_if in network_interface.split(",")
+        ]
+        ip_address = ip_addresses[0]
+        cmd = command + ["--bind " + " ".join(ip_addresses)] + [f"--bind-source-addr {ip_address}"]
+        
 
         print("-" * 10, "  Running  Command  ", "-" * 10, "\n", flush=True)
         print(f"COMMAND: {' '.join(cmd)}\n", flush=True)

--- a/smartsim/_core/entrypoints/redis.py
+++ b/smartsim/_core/entrypoints/redis.py
@@ -61,7 +61,10 @@ def main(network_interface: str, command: List[str]):
             current_ip(net_if) for net_if in network_interface.split(",")
         ]
         ip_address = ip_addresses[0]
-        cmd = command + ["--bind " + " ".join(ip_addresses)] + [f"--bind-source-addr {ip_address}"]
+        cmd = command + ["--bind " + " ".join(ip_addresses)]
+
+        # pin source address to avoid random selection by Redis
+        cmd += [f"--bind-source-addr {ip_address}"]
         
 
         print("-" * 10, "  Running  Command  ", "-" * 10, "\n", flush=True)

--- a/smartsim/_core/entrypoints/redis.py
+++ b/smartsim/_core/entrypoints/redis.py
@@ -60,10 +60,10 @@ def main(network_interface: str, command: List[str]):
         ip_addresses = [
             current_ip(net_if) for net_if in network_interface.split(",")
         ]
-        ip_address = ip_addresses[0]
-        cmd = command + ["--bind " + " ".join(ip_addresses)]
+        cmd = command + [f"--bind {' '.join(ip_addresses)}"]
 
         # pin source address to avoid random selection by Redis
+        ip_address = ip_addresses[0]
         cmd += [f"--bind-source-addr {ip_address}"]
         
 

--- a/smartsim/_core/entrypoints/redis.py
+++ b/smartsim/_core/entrypoints/redis.py
@@ -56,16 +56,12 @@ def main(network_interface: str, command: List[str]):
     global DBPID
 
     try:
-
-        ip_addresses = [
-            current_ip(net_if) for net_if in network_interface.split(",")
-        ]
+        ip_addresses = [current_ip(net_if) for net_if in network_interface.split(",")]
         cmd = command + [f"--bind {' '.join(ip_addresses)}"]
 
         # pin source address to avoid random selection by Redis
         ip_address = ip_addresses[0]
         cmd += [f"--bind-source-addr {ip_address}"]
-        
 
         print("-" * 10, "  Running  Command  ", "-" * 10, "\n", flush=True)
         print(f"COMMAND: {' '.join(cmd)}\n", flush=True)
@@ -101,7 +97,6 @@ def cleanup():
 
 
 if __name__ == "__main__":
-
     os.environ["PYTHONUNBUFFERED"] = "1"
 
     parser = argparse.ArgumentParser(

--- a/smartsim/_core/launcher/colocated.py
+++ b/smartsim/_core/launcher/colocated.py
@@ -83,7 +83,7 @@ def _build_colocated_wrapper_cmd(
     ifname=None,
     **kwargs,
 ):
-    """Build the command use to run a colocated db application
+    """Build the command use to run a colocated DB application
 
     :param cpus: db cpus, defaults to 1
     :type cpus: int, optional
@@ -91,6 +91,10 @@ def _build_colocated_wrapper_cmd(
     :type rai_args: dict[str, str], optional
     :param extra_db_args: extra redis args, defaults to None
     :type extra_db_args: dict[str, str], optional
+    :param port: port to bind DB to
+    :type port: int
+    :param ifname: network interface(s) to bind DB to
+    :type ifname: str | list[str], optional
     :return: the command to run
     :rtype: str
     """
@@ -116,7 +120,9 @@ def _build_colocated_wrapper_cmd(
     ]
     # Add in the interface if using TCP/IP
     if ifname:
-        cmd.extend(["+ifname", ifname])
+        if isinstance(ifname, str):
+            ifname = [ifname]
+        cmd.extend(["+ifname", ",".join(ifname)])
     cmd.append("+command")
     # collect DB binaries and libraries from the config
     db_cmd = [CONFIG.database_exe, CONFIG.database_conf, "--loadmodule", CONFIG.redisai]

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -712,13 +712,14 @@ class Orchestrator(EntityList):
 
     def _check_network_interface(self):
         net_if_addrs = psutil.net_if_addrs()
-        if self._interface not in net_if_addrs and self._interface != "lo":
-            available = list(net_if_addrs.keys())
-            logger.warning(
-                f"{self._interface} is not a valid network interface on this node. \n"
-                "This could be because the head node doesn't have the same networks, if so, ignore this."
-            )
-            logger.warning(f"Found network interfaces are: {available}")
+        for interface in self._interface.split(","):
+            if interface not in net_if_addrs and self._interface != "lo":
+                available = list(net_if_addrs.keys())
+                logger.warning(
+                    f"{self._interface} is not a valid network interface on this node. \n"
+                    "This could be because the head node doesn't have the same networks, if so, ignore this."
+                )
+                logger.warning(f"Found network interfaces are: {available}")
 
     def _fill_reserved(self):
         """Fill the reserved batch and run arguments dictionaries"""

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -715,7 +715,7 @@ class Orchestrator(EntityList):
     def _check_network_interface(self):
         net_if_addrs = psutil.net_if_addrs()
         for interface in self._interfaces:
-            if interface not in net_if_addrs and self._interfaces != "lo":
+            if interface not in net_if_addrs and interface != "lo":
                 available = list(net_if_addrs.keys())
                 logger.warning(
                     f"{interface} is not a valid network interface on this node. \n"

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -85,8 +85,8 @@ class Orchestrator(EntityList):
 
         :param port: TCP/IP port, defaults to 6379
         :type port: int, optional
-        :param interface: network interface, defaults to "lo"
-        :type interface: str, optional
+        :param interface: network interface(s), defaults to "lo"
+        :type interface: str, list[str], optional
 
         Extra configurations for RedisAI
 
@@ -145,7 +145,9 @@ class Orchestrator(EntityList):
         self.ports = []
         self.path = getcwd()
         self._hosts = []
-        self._interface = interface
+        if isinstance(interface, str):
+            interface = [interface]
+        self._interfaces = interface
         self._check_network_interface()
         self.queue_threads = kwargs.get("threads_per_queue", None)
         self.inter_threads = kwargs.get("inter_op_threads", None)
@@ -688,7 +690,7 @@ class Orchestrator(EntityList):
         start_script_args = [
             "-m",
             "smartsim._core.entrypoints.redis",  # entrypoint
-            f"+ifname={self._interface}",  # pass interface to start script
+            "+ifname=" + ",".join(self._interfaces),  # pass interface to start script
             "+command",  # command flag for argparser
             self._redis_exe,  # redis-server
             self._redis_conf,  # redis6.conf file
@@ -712,11 +714,11 @@ class Orchestrator(EntityList):
 
     def _check_network_interface(self):
         net_if_addrs = psutil.net_if_addrs()
-        for interface in self._interface.split(","):
-            if interface not in net_if_addrs and self._interface != "lo":
+        for interface in self._interfaces:
+            if interface not in net_if_addrs and self._interfaces != "lo":
                 available = list(net_if_addrs.keys())
                 logger.warning(
-                    f"{self._interface} is not a valid network interface on this node. \n"
+                    f"{interface} is not a valid network interface on this node. \n"
                     "This could be because the head node doesn't have the same networks, if so, ignore this."
                 )
                 logger.warning(f"Found network interfaces are: {available}")

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -935,7 +935,6 @@ class LSFOrchestrator(Orchestrator):
         single_cmd=True,
         **kwargs,
     ):
-
         """Initialize an Orchestrator reference for LSF based systems
 
         The orchestrator launches as a batch by default. If
@@ -1021,7 +1020,6 @@ class SlurmOrchestrator(Orchestrator):
         single_cmd=False,
         **kwargs,
     ):
-
         """Initialize an Orchestrator reference for Slurm based systems
 
         The orchestrator launches as a batch by default. The Slurm orchestrator

--- a/tests/backends/test_dataloader.py
+++ b/tests/backends/test_dataloader.py
@@ -24,8 +24,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from os import path as osp
 import os
+from os import path as osp
 
 import numpy as np
 import pytest
@@ -33,8 +33,8 @@ import pytest
 from smartsim.database import Orchestrator
 from smartsim.error.errors import SSInternalError
 from smartsim.experiment import Experiment
-from smartsim.status import STATUS_COMPLETED
 from smartsim.ml.data import DataInfo, TrainingDataUploader
+from smartsim.status import STATUS_COMPLETED
 
 shouldrun_tf = True
 if shouldrun_tf:
@@ -52,8 +52,10 @@ if shouldrun_torch:
         import torch
 
         from smartsim.ml.torch import DataLoader
-        from smartsim.ml.torch import DynamicDataGenerator as TorchDataGenerator
-        from smartsim.ml.torch import StaticDataGenerator as TorchStaticDataGenerator
+        from smartsim.ml.torch import \
+            DynamicDataGenerator as TorchDataGenerator
+        from smartsim.ml.torch import \
+            StaticDataGenerator as TorchStaticDataGenerator
     except:
         shouldrun_torch = False
 

--- a/tests/backends/test_dataloader.py
+++ b/tests/backends/test_dataloader.py
@@ -203,11 +203,10 @@ def test_tf_dataloaders(fileutils, wlmutils):
         os.environ.pop("SSKEYOUT", "")
 
 
-def create_trainer_torch(experiment: Experiment, filedir):
-    run_settings = experiment.create_run_settings(
+def create_trainer_torch(experiment: Experiment, filedir, wlmutils):
+    run_settings = wlmutils.get_run_settings(
         exe="python",
-        exe_args=["training_service_torch.py"],
-        env_vars={"PYTHONUNBUFFERED": "1"},
+        args=["training_service_torch.py"],
     )
 
     trainer = experiment.create_model("trainer", run_settings=run_settings)
@@ -271,7 +270,7 @@ def test_torch_dataloaders(fileutils, wlmutils):
                 for _ in torch_static:
                     continue
         
-        trainer = create_trainer_torch(exp, config_dir)
+        trainer = create_trainer_torch(exp, config_dir, wlmutils)
         exp.start(trainer, block=True)
         
         assert exp.get_status(trainer)[0] == STATUS_COMPLETED

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -351,7 +351,9 @@ def test_colocated_db_model_tf(fileutils, wlmutils):
         if all([stat == status.STATUS_COMPLETED for stat in statuses]):
             completed = True
 
-    assert completed
+    if not completed:
+        exp.stop(colo_model)
+        assert False
 
 
 @pytest.mark.skipif(not should_run_pt, reason="Test needs PyTorch to run")

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -26,6 +26,7 @@
 
 
 import sys
+import time
 
 import pytest
 
@@ -296,6 +297,7 @@ def test_db_model_ensemble(fileutils, wlmutils):
     assert all([stat == status.STATUS_COMPLETED for stat in statuses])
 
 
+@pytest.mark.skipif(not should_run_tf, reason="Test needs TF to run")
 def test_colocated_db_model_tf(fileutils, wlmutils):
     """Test DB Models on colocated DB (TensorFlow backend)"""
 
@@ -337,9 +339,19 @@ def test_colocated_db_model_tf(fileutils, wlmutils):
     # Assert we have added both models
     assert len(colo_model._db_models) == 2
 
-    exp.start(colo_model, block=True)
-    statuses = exp.get_status(colo_model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    exp.start(colo_model, block=False)
+
+    completed = False
+    timeout = 90
+    check_interval = 5
+    while timeout and not completed:
+        timeout -= check_interval
+        time.sleep(check_interval)
+        statuses = exp.get_status(colo_model)
+        if all([stat == status.STATUS_COMPLETED for stat in statuses]):
+            completed = True
+
+    assert completed
 
 
 @pytest.mark.skipif(not should_run_pt, reason="Test needs PyTorch to run")

--- a/tests/on_wlm/test_containers_wlm.py
+++ b/tests/on_wlm/test_containers_wlm.py
@@ -61,7 +61,7 @@ def test_singularity_wlm_smartredis(fileutils, wlmutils):
     )
 
     # create and start a database
-    orc = exp.create_database(port=wlmutils.get_test_port())
+    orc = exp.create_database(port=wlmutils.get_test_port(), interface=wlmutils.get_test_interface())
     exp.generate(orc)
     exp.start(orc, block=False)
 

--- a/tests/on_wlm/test_generic_orc_launch.py
+++ b/tests/on_wlm/test_generic_orc_launch.py
@@ -44,7 +44,7 @@ def test_launch_orc_auto(fileutils, wlmutils):
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
     orc = exp.create_database(
-        6780,
+        wlmutils.get_test_port(),
         batch=False,
         interface=network_interface,
         single_cmd=False,
@@ -77,7 +77,7 @@ def test_launch_cluster_orc_single(fileutils, wlmutils):
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
     orc = exp.create_database(
-        6780,
+        wlmutils.get_test_port(),
         db_nodes=3,
         batch=False,
         interface=network_interface,
@@ -111,7 +111,7 @@ def test_launch_cluster_orc_multi(fileutils, wlmutils):
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
     orc = exp.create_database(
-        6780,
+        wlmutils.get_test_port(),
         db_nodes=3,
         batch=False,
         interface=network_interface,
@@ -119,6 +119,7 @@ def test_launch_cluster_orc_multi(fileutils, wlmutils):
         hosts=wlmutils.get_test_hostlist(),
     )
     orc.set_path(test_dir)
+    orc.set_run_arg("exclusive", None)
 
     exp.start(orc, block=True)
     statuses = exp.get_status(orc)

--- a/tests/on_wlm/test_wlm_orc_config_settings.py
+++ b/tests/on_wlm/test_wlm_orc_config_settings.py
@@ -40,7 +40,7 @@ except AttributeError:
     pytestmark = pytest.mark.skip(reason="SmartRedis version is < 0.3.1")
 
 
-def test_config_methods_on_wlm_cluster(dbutils, db):
+def test_config_methods_on_wlm_single(dbutils, db):
     """Test all configuration file edit methods on single node WLM db"""
 
     # test the happy path and ensure all configuration file edit methods

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -99,7 +99,9 @@ def test_multiple_interfaces(fileutils, wlmutils):
     test_dir = fileutils.make_test_dir()
 
     net_if_addrs = psutil.net_if_addrs()
-    net_if_addrs = [net_if_addr for net_if_addr in net_if_addrs if net_if_addr != "lo"]
+    net_if_addrs = [
+        net_if_addr for net_if_addr in net_if_addrs if not net_if_addr.startswith("lo")
+    ]
 
     net_if_addrs = ["lo", net_if_addrs[0]]
 
@@ -121,7 +123,6 @@ def test_multiple_interfaces(fileutils, wlmutils):
 
 
 def test_catch_local_db_errors():
-
     # local database with more than one node not allowed
     with pytest.raises(SSUnsupportedError):
         db = Orchestrator(db_nodes=2)
@@ -300,7 +301,6 @@ def test_catch_orc_errors_lsf(wlmutils):
 
 
 def test_lsf_set_run_args(wlmutils):
-
     orc = Orchestrator(
         wlmutils.get_test_port(),
         db_nodes=3,
@@ -314,7 +314,6 @@ def test_lsf_set_run_args(wlmutils):
 
 
 def test_lsf_set_batch_args(wlmutils):
-
     orc = Orchestrator(
         wlmutils.get_test_port(),
         db_nodes=3,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -94,7 +94,7 @@ def test_orc_active_functions(fileutils, wlmutils):
 
 
 def test_multiple_interfaces(fileutils, wlmutils):
-    exp_name = "test_orc_active_functions"
+    exp_name = "test_multiple_interfaces"
     exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
 


### PR DESCRIPTION
This PR adds the possibility of binding `Orchestrator`s and co-located DBs to multiple network interfaces. It also adds the `--bind-source-addr` argument to any Redis DB we deploy, making sure shards bind to an address we know _a priori_.