### PR TITLE
Updates Fortran documentation for error codes

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,22 +18,27 @@ To be released at some future date
 
 Note
 
-This section details changes made in the development branch that have not yet been applied to a released version of the SmartSim library.
+This section details changes made in the development branch that have not yet
+been applied to a released version of the SmartSim library.
 
 Description
 
 A full list of changes and detailed notes can be found below:
 
+- Update Fortran tutorials for SmartRedis
 - Add support for multiple network interface binding in Orchestrator and Colocated DBs
 
 Detailed notes
 
 - Update the Github Actions runner image from `macos-10.15`` to `macos-12``. The
 former began deprecation in May 2022 and was finally removed in May 2023 (PR285_)
-- Orchestrator and Colocated DB now accept a list of interfaces to bind to. The argument name is still `interface`
-  for backward compatibility reasons. (PR281_)
+- The Fortran tutorials had not been fully updated to show how to handle return/error
+codes. These have now all been updated (PR284_)
+- Orchestrator and Colocated DB now accept a list of interfaces to bind to. The
+argument name is still `interface` for backward compatibility reasons. (PR281_)
 
 .. _PR285: https://github.com/CrayLabs/SmartSim/pull/285
+.. _PR284: https://github.com/CrayLabs/SmartSim/pull/284
 .. _PR281: https://github.com/CrayLabs/SmartSim/pull/281
 
 0.4.2

--- a/doc/sr_integration.rst
+++ b/doc/sr_integration.rst
@@ -44,7 +44,7 @@ Fortran::
 
     type(client_type) :: client
     return_code = client%initialize(use_cluster)
-    if (return_code /= SRNoEryyror) stop 'Error in initialization'
+    if (return_code .ne. SRNoError) stop 'Error in initialization'
 
 C::
 
@@ -177,7 +177,7 @@ to the orchestrator. ::
 Following the guidelines from above, the first step is to initialize the client
 and create a unique identifier for the given processor. This should be done
 within roughly the same portion of the code where the rest of the model
-performs the initialization of other components.  ::
+performs the initialization of other components. ::
 
     ! Import SmartRedis modules
     use, only smartredis_client : client_type
@@ -193,7 +193,7 @@ performs the initialization of other components.  ::
     ! Note adding use_cluster as an additional runtime argument for SmartRedis
     call initialize_model(temperature, number_of_timesteps, use_cluster)
     return_code = smartredis_client%initialize(use_cluster)
-    if (return_code /= SRNoError) stop 'Error in init'
+    if (return_code .ne. SRNoError) stop 'Error in init'
     call MPI_Comm_rank(MPI_COMM_WORLD, mpi_rank, mpi_code)
     ! Build the prefix for all tensors set in this model
     write(name_prefix,'(I6.6,A)') mpi_rank, '_'

--- a/doc/sr_integration.rst
+++ b/doc/sr_integration.rst
@@ -116,7 +116,7 @@ Python::
 Fortran::
 
     if (root_client) return_code = client%set_model_from_file(model_name, model_file, backend, device)
-    if (return_code /= SRNoError) stop 'Error setting model'
+    if (return_code .ne. SRNoError) stop 'Error setting model'
 
 C::
 
@@ -202,7 +202,7 @@ performs the initialization of other components. ::
     ! add the prefix to the model name
     if (mpi_rank==0) then
         return_code = set_model_from_file("example_model_name", "path/to/model.pt", "TORCH", "gpu")
-        if (return_code /= SRNoError) stop 'Error in setting model'
+        if (return_code .ne. SRNoError) stop 'Error in setting model'
     endif
 
 
@@ -217,13 +217,13 @@ Next, add the calls in the main loop to send the temperature to the orchestrator
         model_input(1) = name_prefix//"temperature"
         model_output(1) = name_prefix//"temperature_out"
         return_code = smartredis_client%put_tensor(model_input(1), temperature)
-        if (return_code /= SRNoError) stop 'Error in putting tensor'
+        if (return_code .ne. SRNoError) stop 'Error in putting tensor'
 
         ! Run the machine learning model
         return_code = smartredis_client%run_model("example_model_name", model_input, model_output)
         ! The following line overwrites the prognostic temperature array
         return_code = smartredis_client%unpack_tensor(model_output(1), temperature)
-        if (return_code /= SRNoError) stop 'Error in retrieving tensor'
+        if (return_code .ne. SRNoError) stop 'Error in retrieving tensor'
 
         ! Call a time integrator to step the temperature field forward
         call timestep_simulation(temperature)

--- a/doc/sr_integration.rst
+++ b/doc/sr_integration.rst
@@ -44,7 +44,7 @@ Fortran::
 
     type(client_type) :: client
     return_code = client%initialize(use_cluster)
-    if (return_code /= SRNoError) stop 'Error in initialization'
+    if (return_code /= SRNoEryyror) stop 'Error in initialization'
 
 C::
 
@@ -177,27 +177,34 @@ to the orchestrator. ::
 Following the guidelines from above, the first step is to initialize the client
 and create a unique identifier for the given processor. This should be done
 within roughly the same portion of the code where the rest of the model
-performs the initialization of other components. ::
+performs the initialization of other components.  ::
 
     ! Import SmartRedis modules
     use, only smartredis_client : client_type
+    ! Include all fortran enumerators especially for error checking
+    include "enum_fortran.inc"
 
     ! Declare a new variable called client and a string to create a unique
     ! name for names
     type(client_type) :: smartredis_client
     character(len=7)  :: name_prefix
-    integer :: mpi_rank, mpi_code, smartredis_code
+    integer :: mpi_rank, mpi_code, return_code
 
     ! Note adding use_cluster as an additional runtime argument for SmartRedis
     call initialize_model(temperature, number_of_timesteps, use_cluster)
-    call smartredis_client%initialize(use_cluster)
+    return_code = smartredis_client%initialize(use_cluster)
+    if (return_code /= SRNoError) stop 'Error in init'
     call MPI_Comm_rank(MPI_COMM_WORLD, mpi_rank, mpi_code)
     ! Build the prefix for all tensors set in this model
     write(name_prefix,'(I6.6,A)') mpi_rank, '_'
 
     ! Assume all ranks will use the same machine learning model, so no need to
     ! add the prefix to the model name
-    if (mpi_rank==0) call set_model_from_file("example_model_name", "path/to/model.pt", "TORCH", "gpu")
+    if (mpi_rank==0) then
+        return_code = set_model_from_file("example_model_name", "path/to/model.pt", "TORCH", "gpu")
+        if (return_code /= SRNoError) stop 'Error in setting model'
+    endif
+
 
 Next, add the calls in the main loop to send the temperature to the orchestrator ::
 
@@ -209,12 +216,14 @@ Next, add the calls in the main loop to send the temperature to the orchestrator
         call write_current_state(temperature)
         model_input(1) = name_prefix//"temperature"
         model_output(1) = name_prefix//"temperature_out"
-        call smartredis_client%put_tensor(model_input(1), temperature)
+        return_code = smartredis_client%put_tensor(model_input(1), temperature)
+        if (return_code /= SRNoError) stop 'Error in putting tensor'
 
         ! Run the machine learning model
         return_code = smartredis_client%run_model("example_model_name", model_input, model_output)
         ! The following line overwrites the prognostic temperature array
         return_code = smartredis_client%unpack_tensor(model_output(1), temperature)
+        if (return_code /= SRNoError) stop 'Error in retrieving tensor'
 
         ! Call a time integrator to step the temperature field forward
         call timestep_simulation(temperature)


### PR DESCRIPTION
The examples in the Fortran documentation examples used a mixture of subroutines and functions. The former was deprecated when error handling was implemented to allow the clients to bubble up a return code that Fortran applications can check. This has now been updated to allow others to use the documents as an accurate jumping off point.

Closes https://github.com/CrayLabs/SmartRedis/issues/335