### PR TITLE
Bump the MacOSX runner image version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-12]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, ubuntu-20.04] # Operating systems
+        os: [macos-12, ubuntu-20.04] # Operating systems
         compiler: [8] # GNU compiler version
         rai: [1.2.5, 1.2.7] # Redis AI versions
         py_v: [3.8, 3.9, '3.10'] # Python versions

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -55,7 +55,7 @@ jobs:
         py_v: [3.8, 3.9, '3.10'] # Python versions
         exclude:
           # Do not build with Redis AI 1.2.5 on MacOS
-          - os: macos-10.15
+          - os: macos-12
             rai: 1.2.5
           # Do not build Redis AI 1.2.5 with py3.10
           # as wheels for dependecies are not availble

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -34,7 +34,7 @@ former began deprecation in May 2022 and was finally removed in May 2023 (PR285_
   for backward compatibility reasons. (PR281_)
 
 .. _PR285: https://github.com/CrayLabs/SmartSim/pull/285
-.. _PR281: https://github.com/CrayLabs/SmartSim/pull/282
+.. _PR281: https://github.com/CrayLabs/SmartSim/pull/281
 
 0.4.2
 -----

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -28,9 +28,12 @@ A full list of changes and detailed notes can be found below:
 
 Detailed notes
 
+- Update the Github Actions runner image from `macos-10.15`` to `macos-12``. The
+former began deprecation in May 2022 and was finally removed in May 2023 (PR285_)
 - Orchestrator and Colocated DB now accept a list of interfaces to bind to. The argument name is still `interface`
   for backward compatibility reasons. (PR281_)
 
+.. _PR285: https://github.com/CrayLabs/SmartSim/pull/285
 .. _PR281: https://github.com/CrayLabs/SmartSim/pull/282
 
 0.4.2
@@ -46,10 +49,10 @@ support to allow users to colocate their models with an orchestrator using
 Unix domain sockets and support for launching models as batch jobs.
 
 Additionally, SmartSim has updated its tool chains to provide a better user
-experience. Notably, SmarSim can now be used with Python 3.10, Redis 7.0.5, and 
+experience. Notably, SmarSim can now be used with Python 3.10, Redis 7.0.5, and
 RedisAI 1.2.7. Furthermore, SmartSim now utilizes SmartRedis's aggregation lists to
 streamline the use and extension of ML data loaders, making working with popular
-machine learning frameworks in SmartSim a breeze. 
+machine learning frameworks in SmartSim a breeze.
 
 A full list of changes and detailed notes can be found below:
 
@@ -86,9 +89,9 @@ Detailed Notes
 - Fix bug in colocated database entrypoint stemming from uninitialized variables. This bug affects PyTorch models being loaded into the database. (PR237_)
 - The release of RedisAI 1.2.7 allows us to update support for recent versions of PyTorch, Tensorflow, and ONNX (PR234_)
 - Make installation of correct Torch backend more reliable according to instruction from PyTorch
-- In addition to TCP, add UDS support for colocating an orchestrator with models. Methods 
+- In addition to TCP, add UDS support for colocating an orchestrator with models. Methods
   `Model.colocate_db_tcp` and `Model.colocate_db_uds` were added to expose this functionality.
-  The `Model.colocate_db` method remains and uses TCP for backward compatibility (PR246_) 
+  The `Model.colocate_db` method remains and uses TCP for backward compatibility (PR246_)
 
 .. _PR270: https://github.com/CrayLabs/SmartSim/pull/270
 .. _PR264: https://github.com/CrayLabs/SmartSim/pull/264


### PR DESCRIPTION
We had pinned the MacOS X runner image to 10.15. This particular image on Github Actions began deprecation in May 2022. The runner itself is now no longer available and so all MacOS X Github actions are timing. This bumps the version to the latest image macos-12