### PR TITLE
Clarify attach_generator_files() doc strings

### DIFF
--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -109,7 +109,9 @@ class Model(SmartSimEntity):
         """Attach files to an entity for generation
 
         Attach files needed for the entity that, upon generation,
-        will be located in the path of the entity.
+        will be located in the path of the entity.  Invoking this method
+        after files have already been attached will overwrite
+        the previous list of entity files.
 
         During generation, files "to_copy" are copied into
         the path of the entity, and files "to_symlink" are


### PR DESCRIPTION
This is a small clarification of the doc strings for ``attach_generator_files`` that clearly states multiple calls will overwrite files.