### PR TITLE
Update coloredlogs version

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -26,6 +26,7 @@ Description
 A full list of changes and detailed notes can be found below:
 
 - Remove deprecated code
+- Relax the coloredlogs version
 - Update Fortran tutorials for SmartRedis
 - Add support for multiple network interface binding in Orchestrator and Colocated DBs
 
@@ -33,6 +34,7 @@ Detailed notes
 
 - Deprecated launcher-specific orchestrators, constants, and ML utilities
 were removed. (PR289_)
+- Relax the coloredlogs version to be greater than 10.0 (PR288_)
 - Update the Github Actions runner image from `macos-10.15`` to `macos-12``. The
 former began deprecation in May 2022 and was finally removed in May 2023 (PR285_)
 - The Fortran tutorials had not been fully updated to show how to handle return/error
@@ -41,6 +43,7 @@ codes. These have now all been updated (PR284_)
 argument name is still `interface` for backward compatibility reasons. (PR281_)
 
 .. _PR289: https://github.com/CrayLabs/SmartSim/pull/289
+.. _PR288: https://github.com/CrayLabs/SmartSim/pull/288
 .. _PR285: https://github.com/CrayLabs/SmartSim/pull/285
 .. _PR284: https://github.com/CrayLabs/SmartSim/pull/284
 .. _PR281: https://github.com/CrayLabs/SmartSim/pull/281

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psutil>=5.7.2
-coloredlogs==10.0
+coloredlogs>=10.0
 tabulate>=0.8.9
 smartredis>=0.4.0
 redis==3.5.3

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ class BinaryDistribution(Distribution):
 # Define needed dependencies for the installation
 deps = [
     "psutil>=5.7.2",
-    "coloredlogs==10.0",
+    "coloredlogs>=10.0",
     "tabulate>=0.8.9",
     "redis-py-cluster==2.1.3",
     "redis==3.5.3",


### PR DESCRIPTION
The ``coloredlogs`` dependency version has been relaxed to prevent environment conflicts.  No errors were seen in log outputs.  The dependency was updated in both ``requirements.txt`` and ``setup.py`` until a later issue removes redundant dependencies.