### PR TITLE
create_run_args copy-by-ref fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__
 htmlcov
 smartsim.egg-info
 tests/test_output
+docs/*
 
 # Dependencies
 smartsim/_core/.third-party

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -38,14 +38,15 @@ A full list of changes and detailed notes can be found below:
 
 Detailed notes
 
+- Fix defect where dictionaries used to create run settings can be changed 
+  unexpectedly due to copy-by-ref (PR305_)
 - Typehints have been added. A makefile target `make check-mypy` executes static
   analysis with mypy. (PR295_, PR303_)
 - Simplify code in `random_permutations` parameter generation strategy (PR300_)
 - Remove wait time associated with Experiment launch summary (PR298_)
 - Update Redis conf file to conform with Redis v7.0.5 conf file (PR293_)
 - Migrate from redis-py-cluster to redis-py for cluster status checks (PR292_)
-- Update full test suite to no longer require a tensorflow wheel to be available
-  at test time. (PR291_)
+- Update full test suite to no longer require a tensorflow wheel to be available at test time. (PR291_)
 - Correct spelling of colocated in doc strings (PR290_)
 - Deprecated launcher-specific orchestrators, constants, and ML 
   utilities were removed. (PR289_)
@@ -57,9 +58,11 @@ Detailed notes
 - Orchestrator and Colocated DB now accept a list of interfaces to bind to. The 
   argument name is still `interface` for backward compatibility reasons. (PR281_)
 
+.. _PR305: https://github.com/CrayLabs/SmartSim/pull/305
 .. _PR303: https://github.com/CrayLabs/SmartSim/pull/303
 .. _PR300: https://github.com/CrayLabs/SmartSim/pull/300
 .. _PR298: https://github.com/CrayLabs/SmartSim/pull/298
+.. _PR295: https://github.com/CrayLabs/SmartSim/pull/295
 .. _PR293: https://github.com/CrayLabs/SmartSim/pull/293
 .. _PR292: https://github.com/CrayLabs/SmartSim/pull/292
 .. _PR291: https://github.com/CrayLabs/SmartSim/pull/291
@@ -69,7 +72,6 @@ Detailed notes
 .. _PR285: https://github.com/CrayLabs/SmartSim/pull/285
 .. _PR284: https://github.com/CrayLabs/SmartSim/pull/284
 .. _PR281: https://github.com/CrayLabs/SmartSim/pull/281
-.. _PR295: https://github.com/CrayLabs/SmartSim/pull/295
 
 0.4.2
 -----

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -558,8 +558,8 @@ class Experiment:
         exe: str,
         exe_args: t.Optional[t.List[str]] = None,
         run_command: str = "auto",
-        run_args: t.Optional[t.Dict[str, str]] = None,
-        env_vars: t.Optional[t.Dict[str, str]] = None,
+        run_args: t.Optional[t.Dict[str, t.Union[int, str, float, None]]] = None,
+        env_vars: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         container: t.Optional[Container] = None,
         **kwargs: t.Any,
     ) -> settings.RunSettings:
@@ -593,7 +593,7 @@ class Experiment:
         :param exe_args: arguments to pass to the executable
         :type exe_args: list[str], optional
         :param run_args: arguments to pass to the ``run_command``
-        :type run_args: dict[str, str], optional
+        :type run_args: dict[str, t.Union[int, str, float, None]], optional
         :param env_vars: environment variables to pass to the executable
         :type env_vars: dict[str, str], optional
         :param container: if execution environment is containerized

--- a/smartsim/settings/alpsSettings.py
+++ b/smartsim/settings/alpsSettings.py
@@ -36,8 +36,8 @@ class AprunSettings(RunSettings):
         self,
         exe: str,
         exe_args: t.Optional[t.Union[str, t.List[str]]] = None,
-        run_args: t.Optional[t.Dict[str, str]] = None,
-        env_vars: t.Optional[t.Dict[str, str]] = None,
+        run_args: t.Optional[t.Dict[str, t.Union[int, str, float, None]]] = None,
+        env_vars: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         **kwargs: t.Any,
     ):
         """Settings to run job with ``aprun`` command
@@ -50,7 +50,7 @@ class AprunSettings(RunSettings):
         :param exe_args: executable arguments, defaults to None
         :type exe_args: str | list[str], optional
         :param run_args: arguments for run command, defaults to None
-        :type run_args: dict[str, str], optional
+        :type run_args: dict[str, t.Union[int, str, float, None]], optional
         :param env_vars: environment vars to launch job with, defaults to None
         :type env_vars: dict[str, str], optional
         """
@@ -136,7 +136,7 @@ class AprunSettings(RunSettings):
         :param file_path: Path to the hostlist file
         :type file_path: str
         """
-        self.run_args["node-list-file"] = str(file_path)
+        self.run_args["node-list-file"] = file_path
 
     def set_excluded_hosts(self, host_list: t.Union[str, t.List[str]]) -> None:
         """Specify a list of hosts to exclude for launching this job

--- a/smartsim/settings/cobaltSettings.py
+++ b/smartsim/settings/cobaltSettings.py
@@ -35,7 +35,7 @@ class CobaltBatchSettings(BatchSettings):
         time: str = "",
         queue: t.Optional[str] = None,
         account: t.Optional[str] = None,
-        batch_args: t.Optional[t.Dict[str, str]] = None,
+        batch_args: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         **kwargs: t.Any,
     ) -> None:
         """Specify settings for a Cobalt ``qsub`` batch launch
@@ -91,7 +91,7 @@ class CobaltBatchSettings(BatchSettings):
         """
         # TODO catch existing "n" in batch_args
         if num_nodes:
-            self.batch_args["nodecount"] = int(num_nodes)
+            self.batch_args["nodecount"] = str(int(num_nodes))
 
     def set_hostlist(self, host_list: t.Union[str, t.List[str]]) -> None:
         """Specify the hostlist for this job
@@ -115,7 +115,7 @@ class CobaltBatchSettings(BatchSettings):
         :param num_tasks: number of processes
         :type num_tasks: int
         """
-        self.batch_args["proccount"] = int(num_tasks)
+        self.batch_args["proccount"] = str(int(num_tasks))
 
     def set_queue(self, queue: str) -> None:
         """Set the queue for the batch job

--- a/smartsim/settings/mpiSettings.py
+++ b/smartsim/settings/mpiSettings.py
@@ -45,8 +45,8 @@ class _BaseMPISettings(RunSettings):
         exe: str,
         exe_args: t.Optional[t.Union[str, t.List[str]]] = None,
         run_command: str = "mpiexec",
-        run_args: t.Optional[t.Dict[str, str]] = None,
-        env_vars: t.Optional[t.Dict[str, str]] = None,
+        run_args: t.Optional[t.Dict[str, t.Union[int, str, float, None]]] = None,
+        env_vars: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         fail_if_missing_exec: bool = True,
         **kwargs: t.Any,
     ) -> None:
@@ -119,7 +119,7 @@ class _BaseMPISettings(RunSettings):
         :param task_mapping: task mapping
         :type task_mapping: str
         """
-        self.run_args["map-by"] = str(task_mapping)
+        self.run_args["map-by"] = task_mapping
 
     def set_cpus_per_task(self, cpus_per_task: int) -> None:
         """Set the number of tasks for this job
@@ -142,7 +142,7 @@ class _BaseMPISettings(RunSettings):
         :param bind_type: binding type
         :type bind_type: str
         """
-        self.run_args["bind-to"] = str(bind_type)
+        self.run_args["bind-to"] = bind_type
 
     def set_tasks_per_node(self, tasks_per_node: int) -> None:
         """Set the number of tasks per node
@@ -187,7 +187,7 @@ class _BaseMPISettings(RunSettings):
         :param file_path: Path to the hostlist file
         :type file_path: str
         """
-        self.run_args["hostfile"] = str(file_path)
+        self.run_args["hostfile"] = file_path
 
     def set_verbose_launch(self, verbose: bool) -> None:
         """Set the job to run in verbose mode
@@ -240,7 +240,7 @@ class _BaseMPISettings(RunSettings):
         :param walltime: number like string of seconds that a job will run in secs
         :type walltime: str
         """
-        self.run_args["timeout"] = str(walltime)
+        self.run_args["timeout"] = walltime
 
     def format_run_args(self) -> t.List[str]:
         """Return a list of MPI-standard formatted run arguments
@@ -284,8 +284,8 @@ class MpirunSettings(_BaseMPISettings):
         self,
         exe: str,
         exe_args: t.Optional[t.Union[str, t.List[str]]] = None,
-        run_args: t.Optional[t.Dict[str, str]] = None,
-        env_vars: t.Optional[t.Dict[str, str]] = None,
+        run_args: t.Optional[t.Dict[str, t.Union[int, str, float, None]]] = None,
+        env_vars: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         **kwargs: t.Any,
     ) -> None:
         """Settings to run job with ``mpirun`` command (MPI-standard)
@@ -303,7 +303,7 @@ class MpirunSettings(_BaseMPISettings):
         :param exe_args: executable arguments, defaults to None
         :type exe_args: str | list[str], optional
         :param run_args: arguments for run command, defaults to None
-        :type run_args: dict[str, str], optional
+        :type run_args: dict[str, t.Union[int, str, float, None]], optional
         :param env_vars: environment vars to launch job with, defaults to None
         :type env_vars: dict[str, str], optional
         """
@@ -315,8 +315,8 @@ class MpiexecSettings(_BaseMPISettings):
         self,
         exe: str,
         exe_args: t.Optional[t.Union[str, t.List[str]]] = None,
-        run_args: t.Optional[t.Dict[str, str]] = None,
-        env_vars: t.Optional[t.Dict[str, str]] = None,
+        run_args: t.Optional[t.Dict[str, t.Union[int, str, float, None]]] = None,
+        env_vars: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         **kwargs: t.Any,
     ) -> None:
         """Settings to run job with ``mpiexec`` command (MPI-standard)
@@ -334,7 +334,7 @@ class MpiexecSettings(_BaseMPISettings):
         :param exe_args: executable arguments, defaults to None
         :type exe_args: str | list[str], optional
         :param run_args: arguments for run command, defaults to None
-        :type run_args: dict[str, str], optional
+        :type run_args: dict[str, t.Union[int, str, float, None]], optional
         :param env_vars: environment vars to launch job with, defaults to None
         :type env_vars: dict[str, str], optional
         """
@@ -355,8 +355,8 @@ class OrterunSettings(_BaseMPISettings):
         self,
         exe: str,
         exe_args: t.Optional[t.Union[str, t.List[str]]] = None,
-        run_args: t.Optional[t.Dict[str, str]] = None,
-        env_vars: t.Optional[t.Dict[str, str]] = None,
+        run_args: t.Optional[t.Dict[str, t.Union[int, str, float, None]]] = None,
+        env_vars: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         **kwargs: t.Any,
     ) -> None:
         """Settings to run job with ``orterun`` command (MPI-standard)
@@ -374,7 +374,7 @@ class OrterunSettings(_BaseMPISettings):
         :param exe_args: executable arguments, defaults to None
         :type exe_args: str | list[str], optional
         :param run_args: arguments for run command, defaults to None
-        :type run_args: dict[str, str], optional
+        :type run_args: dict[str, t.Union[int, str, float, None]], optional
         :param env_vars: environment vars to launch job with, defaults to None
         :type env_vars: dict[str, str], optional
         """

--- a/smartsim/settings/palsSettings.py
+++ b/smartsim/settings/palsSettings.py
@@ -59,8 +59,8 @@ class PalsMpiexecSettings(_BaseMPISettings):
         exe: str,
         exe_args: t.Optional[t.Union[str, t.List[str]]] = None,
         run_command: str = "mpiexec",
-        run_args: t.Optional[t.Dict[str, str]] = None,
-        env_vars: t.Optional[t.Dict[str, str]] = None,
+        run_args: t.Optional[t.Dict[str, t.Union[int, str, float, None]]] = None,
+        env_vars: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         fail_if_missing_exec: bool = True,
         **kwargs: t.Any,
     ) -> None:
@@ -79,7 +79,7 @@ class PalsMpiexecSettings(_BaseMPISettings):
         :param exe_args: executable arguments, defaults to None
         :type exe_args: str | list[str], optional
         :param run_args: arguments for run command, defaults to None
-        :type run_args: dict[str, str], optional
+        :type run_args: dict[str, t.Union[int, str, float, None]], optional
         :param env_vars: environment vars to launch job with, defaults to None
         :type env_vars: dict[str, str], optional
         :param fail_if_missing_exec: Throw an exception of the MPI command
@@ -129,7 +129,7 @@ class PalsMpiexecSettings(_BaseMPISettings):
         :param bind_type: binding type
         :type bind_type: str
         """
-        self.run_args["cpu-bind"] = str(bind_type)
+        self.run_args["cpu-bind"] = bind_type
 
     def set_tasks(self, tasks: int) -> None:
         """Set the number of tasks

--- a/smartsim/settings/pbsSettings.py
+++ b/smartsim/settings/pbsSettings.py
@@ -39,8 +39,8 @@ class QsubBatchSettings(BatchSettings):
         time: t.Optional[str] = None,
         queue: t.Optional[str] = None,
         account: t.Optional[str] = None,
-        resources: t.Optional[t.Dict[str, str]] = None,
-        batch_args: t.Optional[t.Dict[str, str]] = None,
+        resources: t.Optional[t.Dict[str, t.Optional[str]]] = None,
+        batch_args: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         **kwargs: t.Any,
     ):
         """Specify ``qsub`` batch parameters for a job

--- a/smartsim/settings/settings.py
+++ b/smartsim/settings/settings.py
@@ -102,8 +102,8 @@ def create_run_settings(
     exe: str,
     exe_args: t.Optional[t.List[str]] = None,
     run_command: str = "auto",
-    run_args: t.Optional[t.Dict[str, str]] = None,
-    env_vars: t.Optional[t.Dict[str, str]] = None,
+    run_args: t.Optional[t.Dict[str, t.Union[int, str, float, None]]] = None,
+    env_vars: t.Optional[t.Dict[str, t.Optional[str]]] = None,
     container: t.Optional[Container] = None,
     **kwargs: t.Any,
 ) -> RunSettings:

--- a/smartsim/settings/slurmSettings.py
+++ b/smartsim/settings/slurmSettings.py
@@ -42,8 +42,8 @@ class SrunSettings(RunSettings):
         self,
         exe: str,
         exe_args: t.Optional[t.Union[str, t.List[str]]] = None,
-        run_args: t.Optional[t.Dict[str, str]] = None,
-        env_vars: t.Optional[t.Dict[str, str]] = None,
+        run_args: t.Optional[t.Dict[str, t.Union[int, str, float, None]]] = None,
+        env_vars: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         alloc: t.Optional[str] = None,
         **kwargs: t.Any,
     ) -> None:
@@ -59,7 +59,7 @@ class SrunSettings(RunSettings):
         :param exe_args: executable arguments, defaults to None
         :type exe_args: list[str] | str, optional
         :param run_args: srun arguments without dashes, defaults to None
-        :type run_args: dict[str, str | None], optional
+        :type run_args: dict[str, t.Union[int, str, float, None]], optional
         :param env_vars: environment variables for job, defaults to None
         :type env_vars: dict[str, str], optional
         :param alloc: allocation ID if running on existing alloc, defaults to None
@@ -132,7 +132,7 @@ class SrunSettings(RunSettings):
         :param file_path: Path to the hostlist file
         :type file_path: str
         """
-        self.run_args["nodefile"] = str(file_path)
+        self.run_args["nodefile"] = file_path
 
     def set_excluded_hosts(self, host_list: t.Union[str, t.List[str]]) -> None:
         """Specify a list of hosts to exclude for launching this job
@@ -354,7 +354,7 @@ class SbatchSettings(BatchSettings):
         nodes: t.Optional[int] = None,
         time: str = "",
         account: t.Optional[str] = None,
-        batch_args: t.Optional[t.Dict[str, str]] = None,
+        batch_args: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         **kwargs: t.Any,
     ) -> None:
         """Specify run parameters for a Slurm batch job
@@ -405,7 +405,7 @@ class SbatchSettings(BatchSettings):
         :type num_nodes: int
         """
         if num_nodes:
-            self.batch_args["nodes"] = int(num_nodes)
+            self.batch_args["nodes"] = str(int(num_nodes))
 
     def set_account(self, account: str) -> None:
         """Set the account for this batch job
@@ -443,7 +443,7 @@ class SbatchSettings(BatchSettings):
         :param num_cpus: number of cpus to use per task
         :type num_cpus: int
         """
-        self.batch_args["cpus-per-task"] = int(cpus_per_task)
+        self.batch_args["cpus-per-task"] = str(int(cpus_per_task))
 
     def set_hostlist(self, host_list: t.Union[str, t.List[str]]) -> None:
         """Specify the hostlist for this job

--- a/tests/test_batch_settings.py
+++ b/tests/test_batch_settings.py
@@ -87,6 +87,61 @@ def test_create_bsub():
     assert args == ["-core_isolation", "-nnodes 1", "-q default"]
 
 
+def test_existing_batch_args_mutation():
+    """
+    Ensure that if the batch_args dict is changed, any previously
+    created batch settings don't reflect the change due to pass-by-ref
+    """
+    batch_args = {"k1": "v1", "k2": "v2"}
+    orig_bargs = {"k1": "v1", "k2": "v2"}
+    bsub = create_batch_settings(
+        "lsf",
+        nodes=1,
+        time="10:00:00",
+        account="myproject",  # test that account is set
+        queue="default",
+        batch_args=batch_args,
+    )
+    
+    # verify initial expectations
+    assert "k1" in bsub.batch_args
+    assert "k2" in bsub.batch_args
+
+    # modify the batch_args dict
+    batch_args["k1"] = f'not-{batch_args["k1"]}'
+
+    # verify that the batch_settings do not reflect the change
+    assert bsub.batch_args["k1"] == orig_bargs["k1"]
+    assert bsub.batch_args["k1"] != batch_args["k1"]
+
+def test_direct_set_batch_args_mutation():
+    """
+    Ensure that if the batch_args dict is set directly, any previously
+    created batch settings don't reflect the change due to pass-by-ref
+    """
+    batch_args = {"k1": "v1", "k2": "v2"}
+    orig_bargs = {"k1": "v1", "k2": "v2"}
+    bsub = create_batch_settings(
+        "lsf",
+        nodes=1,
+        time="10:00:00",
+        account="myproject",  # test that account is set
+        queue="default",
+    )
+    bsub.batch_args = batch_args
+    
+    # verify initial expectations
+    assert "k1" in bsub.batch_args
+    assert "k2" in bsub.batch_args
+
+    # modify the batch_args dict
+    batch_args["k1"] = f'not-{batch_args["k1"]}'
+
+    # verify that the batch_settings do not reflect the change
+    assert bsub.batch_args["k1"] == orig_bargs["k1"]
+    assert bsub.batch_args["k1"] != batch_args["k1"]
+
+
 @pytest.mark.parametrize(
     "batch_args",
     [

--- a/tests/test_lsf_settings.py
+++ b/tests/test_lsf_settings.py
@@ -95,11 +95,36 @@ def test_jsrun_args():
     assert formatted == result
 
 
+def test_jsrun_args_mutation():
+    """Ensure re-using ERF settings doesn't mutate existing run settings"""
+    run_args = {
+        "latency_priority": "gpu-gpu",
+        "immediate": None,
+        "d": "packed",  # test single letter variables
+        "nrs": 10,
+        "np": 100,
+    }
+    settings = JsrunSettings("python", run_args=run_args)
+    
+    erf_settings = {"foo": "1", "bar": "2"}
+    
+    settings.set_erf_sets(erf_settings)
+    assert settings.erf_sets["foo"] == "1"
+    assert settings.erf_sets["bar"] == "2"
+
+    erf_settings["foo"] = "111"
+    erf_settings["bar"] = "111"
+    
+    assert settings.erf_sets["foo"] == "1"
+    assert settings.erf_sets["bar"] == "2"
+
+
 def test_jsrun_update_env():
     env_vars = {"OMP_NUM_THREADS": 20, "LOGGING": "verbose"}
     settings = JsrunSettings("python", env_vars=env_vars)
-    settings.update_env({"OMP_NUM_THREADS": 10})
-    assert settings.env_vars["OMP_NUM_THREADS"] == 10
+    num_threads = 10
+    settings.update_env({"OMP_NUM_THREADS": num_threads})
+    assert settings.env_vars["OMP_NUM_THREADS"] == str(num_threads)
 
 
 def test_jsrun_format_env():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -158,7 +158,7 @@ def test_models_batch_settings_are_ignored_in_ensemble(monkeypatch_exp_controlle
     step, entity = entity_steps[0]
     assert isinstance(entity, Ensemble)
     assert isinstance(step, SbatchStep)
-    assert step.batch_settings.batch_args["nodes"] == 10
+    assert step.batch_settings.batch_args["nodes"] == "10"
     assert len(step.step_cmds) == 1
     step_cmd = step.step_cmds[0]
     assert any("srun" in tok for tok in step_cmd)  # call the model using run settings

--- a/tests/test_run_settings.py
+++ b/tests/test_run_settings.py
@@ -98,6 +98,35 @@ def test_create_run_settings_handles_mpiexec_settings_correctly():
             assert settings.run_command == _run_command
             assert isinstance(settings, MpiexecSettings)
 
+def test_create_run_settings_input_mutation():
+    # Tests that the run args passed in are not modified after initialization
+    key0, key1, key2 = "arg0", "arg1", "arg2"
+    val0, val1, val2 = "val0", "val1", "val2"
+
+    default_run_args = {
+        key0: val0,
+        key1: val1,
+        key2: val2,
+    }
+    rs0 = create_run_settings("local", 
+                               "echo", 
+                               "hello", 
+                               run_command="auto",
+                               run_args=default_run_args)
+    
+    # Confirm initial values are set
+    assert rs0.run_args[key0] == val0
+    assert rs0.run_args[key1] == val1
+    assert rs0.run_args[key2] == val2
+
+    # Update our common run arguments
+    val2_upd = f"not-{val2}"
+    default_run_args[key2] = val2_upd
+
+    # Confirm previously created run settings are not changed
+    assert rs0.run_args[key2] == val2
+
+    
 
 ####### Base Run Settings tests #######
 
@@ -137,6 +166,50 @@ def test_addto_existing_exe_args():
     args = ["sleep.py", "--time=5", "--stop=10"]
     assert list_exe_args_settings.exe_args == args
     assert str_exe_args_settings.exe_args == args
+
+def test_existing_exe_args_mutation():
+    """ 
+    Ensure that if the argument list is changed, any previously
+    created run settings don't reflect the change due to pass-by-ref
+    """
+    args = ["sleep.py", "--time=5"]
+    orig = ["sleep.py", "--time=5"]
+    rs0 = RunSettings("python", args)
+
+    # both should be the same
+    assert rs0.exe_args == args
+
+    # modify the args list
+    args.append("--foo")
+    assert rs0.exe_args == orig
+
+    # create another run settings instance
+    rs1 = RunSettings("python", args)
+    assert rs1.exe_args == args
+    assert rs0.exe_args != rs1.exe_args
+
+def test_direct_set_exe_args_mutation():
+    """ 
+    Ensure that if the argument list is set directly, any previously
+    created run settings don't reflect the change due to pass-by-ref
+    """
+    args = ["sleep.py", "--time=5"]
+    orig = ["sleep.py", "--time=5"]
+    rs0 = RunSettings("python")
+    rs0.exe_args = args
+
+    # both should be the same
+    assert rs0.exe_args == args
+
+    # modify the args list
+    args.append("--foo")
+    assert rs0.exe_args == orig
+
+    # create another run settings instance
+    rs1 = RunSettings("python")
+    rs1.exe_args = args
+    assert rs1.exe_args == args
+    assert rs0.exe_args != rs1.exe_args
 
 
 def test_bad_exe_args():
@@ -320,6 +393,53 @@ def test_update_env_initialized(env_vars):
 
     assert len(rs.env_vars) == len(combined_keys)
     assert {k for k in rs.env_vars.keys()} == combined_keys
+
+
+def test_env_vars_mutation():
+    """
+    Ensure that if the env_vars dict is changed, any previously
+    created run settings don't reflect the change due to pass-by-ref
+    """
+    sample_exe = "python"
+    cmd = "echo"
+
+    env_vars = {"k1": "v1", "k2": "v2"}
+    orig_env = {"k1": "v1", "k2": "v2"}
+    rs = RunSettings(sample_exe, run_command=cmd, env_vars=env_vars)
+
+    # verify initial expectations
+    assert len(rs.env_vars) == len(env_vars)
+    assert rs.env_vars == orig_env
+
+    # update a value in the env_vars dict & verify
+    # that the run settings do not reflect the change
+    env_vars["k1"] = f"not-{env_vars['k1']}"
+    assert rs.env_vars["k1"] != env_vars['k1']
+    assert rs.env_vars["k1"] == orig_env['k1']
+
+
+def test_direct_set_env_vars_mutation():
+    """
+    Ensure that if the env_vars dict is explicitly set, any previously
+    created run settings don't reflect the change due to pass-by-ref
+    """
+    sample_exe = "python"
+    cmd = "echo"
+
+    env_vars = {"k1": "v1", "k2": "v2"}
+    orig_env = {"k1": "v1", "k2": "v2"}
+    rs = RunSettings(sample_exe, run_command=cmd)
+    rs.env_vars = env_vars
+
+    # verify initial expectations
+    assert len(rs.env_vars) == len(env_vars)
+    assert rs.env_vars == orig_env
+
+    # update a value in the env_vars dict & verify
+    # that the run settings do not reflect the change
+    env_vars["k1"] = f"not-{env_vars['k1']}"
+    assert rs.env_vars["k1"] != env_vars['k1']
+    assert rs.env_vars["k1"] == orig_env['k1']
 
 
 @pytest.mark.parametrize(

--- a/tests/test_slurm_settings.py
+++ b/tests/test_slurm_settings.py
@@ -71,8 +71,9 @@ def test_srun_args():
 def test_update_env():
     env_vars = {"OMP_NUM_THREADS": 20, "LOGGING": "verbose"}
     settings = SrunSettings("python", env_vars=env_vars)
-    settings.update_env({"OMP_NUM_THREADS": 10})
-    assert settings.env_vars["OMP_NUM_THREADS"] == 10
+    num_threads = 10
+    settings.update_env({"OMP_NUM_THREADS": num_threads})
+    assert settings.env_vars["OMP_NUM_THREADS"] == str(num_threads)
 
 
 def test_catch_colo_mpmd():


### PR DESCRIPTION
Add a deep copy to the batch & run settings `__init__` methods. This ensures that changes to collections after pass-by-ref are not unexpectedly modified after creating run/batch settings instances.