### PR TITLE
Allow pinning of the co-located database

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -543,7 +543,7 @@ class FileUtils:
         return dir_path
 
     @staticmethod
-    def make_test_dir(caller_function=None, caller_fspath=None, level=2):
+    def make_test_dir(caller_function=None, caller_fspath=None, level=1):
         """Create test output directory and return path to it.
 
         This function should be called without arguments from within

--- a/conftest.py
+++ b/conftest.py
@@ -604,11 +604,8 @@ def coloutils():
     return ColoUtils
 
 class ColoUtils:
-    def setup_test_colo(fileutils, db_type, exp_name, db_args, launcher="local"):
+    def setup_test_colo(fileutils, db_type, exp, db_args):
         """Setup things needed for setting up the colo pinning tests"""
-
-        exp = Experiment(exp_name, launcher=launcher)
-
         # get test setup
         test_dir = fileutils.make_test_dir()
         sr_test_script = fileutils.get_test_conf_path("send_data_local_smartredis.py")
@@ -632,4 +629,4 @@ class ColoUtils:
         # assert model will launch with colocated db
         assert colo_model.colocated
         # Check to make sure that limit_db_cpus made it into the colo settings
-        return exp, colo_model
+        return colo_model

--- a/conftest.py
+++ b/conftest.py
@@ -513,7 +513,7 @@ class FileUtils:
         return dir_path
 
     @staticmethod
-    def get_test_dir(caller_function=None, caller_fspath=None):
+    def get_test_dir(caller_function=None, caller_fspath=None, level=1):
         """Get path to test output.
 
         This function should be called without arguments from within
@@ -532,7 +532,7 @@ class FileUtils:
         :rtype: str
         """
         if not caller_function or not caller_fspath:
-            caller_frame = inspect.stack()[1]
+            caller_frame = inspect.stack()[level]
             caller_fspath = caller_frame.filename
             caller_function = caller_frame.function
 
@@ -543,7 +543,7 @@ class FileUtils:
         return dir_path
 
     @staticmethod
-    def make_test_dir(caller_function=None, caller_fspath=None):
+    def make_test_dir(caller_function=None, caller_fspath=None, level=2):
         """Create test output directory and return path to it.
 
         This function should be called without arguments from within
@@ -560,7 +560,7 @@ class FileUtils:
         :rtype: str
         """
         if not caller_function or not caller_fspath:
-            caller_frame = inspect.stack()[1]
+            caller_frame = inspect.stack()[level]
             caller_fspath = caller_frame.filename
             caller_function = caller_frame.function
 
@@ -603,11 +603,10 @@ def coloutils():
     return ColoUtils
 
 class ColoUtils:
-    @staticmethod
     def setup_test_colo(fileutils, db_type, exp, db_args):
         """Setup things needed for setting up the colo pinning tests"""
         # get test setup
-        test_dir = fileutils.make_test_dir()
+        test_dir = fileutils.make_test_dir(level=2)
         sr_test_script = fileutils.get_test_conf_path("send_data_local_smartredis.py")
 
         # Create an app with a colo_db which uses 1 db_cpu
@@ -625,7 +624,6 @@ class ColoUtils:
             "uds":colo_model.colocate_db_uds
         }
         colocate_fun[db_type](**db_args)
-
         # assert model will launch with colocated db
         assert colo_model.colocated
         # Check to make sure that limit_db_cpus made it into the colo settings

--- a/conftest.py
+++ b/conftest.py
@@ -115,8 +115,7 @@ def pytest_sessionfinish(session, exitstatus):
     returning the exit status to the system.
     """
     if exitstatus == 0:
-        # shutil.rmtree(test_dir)
-        pass
+        shutil.rmtree(test_dir)
     else:
         # kill all spawned processes in case of error
         kill_all_test_spawned_processes()
@@ -604,6 +603,7 @@ def coloutils():
     return ColoUtils
 
 class ColoUtils:
+    @staticmethod
     def setup_test_colo(fileutils, db_type, exp, db_args):
         """Setup things needed for setting up the colo pinning tests"""
         # get test setup

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -26,6 +26,7 @@ Description
 A full list of changes and detailed notes can be found below:
 
 - Fix add_ml_model() and add_script() documentation, tests, and code
+- Replace `limit_app_cpus` with `limit_db_cpus` for co-located orchestrators
 - Remove wait time associated with Experiment launch summary
 - Update and rename Redis conf file
 - Migrate from redis-py-cluster to redis-py
@@ -47,6 +48,10 @@ Detailed notes
   testing interface has been changed to lo instead of ipogif. (PR304_)
 - Typehints have been added. A makefile target `make check-mypy` executes static
   analysis with mypy. (PR295_, PR303_)
+- Replace `limit_app_cpus` with `limit_db_cpus` for co-located orchestrators.
+  This resolves some incorrect behavior/assumptions about how the application
+  would be pinned.  Instead, users should directly specify the binding options in
+  their application using the options appropriate for their launcher
 - Simplify code in `random_permutations` parameter generation strategy (PR300_)
 - Remove wait time associated with Experiment launch summary (PR298_)
 - Update Redis conf file to conform with Redis v7.0.5 conf file (PR293_)
@@ -62,6 +67,8 @@ Detailed notes
   return/error codes. These have now all been updated. (PR284_)
 - Orchestrator and Colocated DB now accept a list of interfaces to bind to. The
   argument name is still `interface` for backward compatibility reasons. (PR281_)
+- Typehints have been added to public APIs. A makefile target to execute static
+  analysis with mypy is available `make check-mypy`. (PR295_)
 
 .. _PR305: https://github.com/CrayLabs/SmartSim/pull/305
 .. _PR304: https://github.com/CrayLabs/SmartSim/pull/304

--- a/doc/orchestrator.rst
+++ b/doc/orchestrator.rst
@@ -84,7 +84,7 @@ the ``Model.colocate_db_tcp`` or ``Model.colocate_db_uds`` function.
     :noindex:
 
 Here is an example of creating a simple model that is colocated with an
-``Orchestrator`` deployment
+``Orchestrator`` deployment using Unix Domain Sockets
 
 .. code-block:: python
 
@@ -94,20 +94,25 @@ Here is an example of creating a simple model that is colocated with an
   colo_settings = exp.create_run_settings(exe="./some_mpi_app")
 
   colo_model = exp.create_model("colocated_model", colo_settings)
-  colo_model.colocate_db_tcp(
-          port=6780,              # database port
+  colo_model.colocate_db_uds(
           db_cpus=1,              # cpus given to the database on each node
           debug=False             # include debug information (will be slower)
-          limit_app_cpus=False,   # don't oversubscribe app with database cpus
-          ifname=network_interface # specify network interface(s) to use (i.e. "ib0" or ["ib0", "lo"])
+          pin_db_cpus=True,       # Pin the affinities of the co-located database
+                                  # to specific processors
   )
   exp.start(colo_model)
 
 
 By default, SmartSim will attempt to make sure that the database and the application
 do not fight over resources by taking over the affinity mapping process locally on
-each node. This can be disabled by setting ``limit_app_cpus`` to ``False``.
+each node. This can be disabled by setting ``pin_db_cpus`` to ``False``.
 
+Especially for multicore machines, it can be useful to pin the CPUs used by the database.
+This is enabled by default and the database will automatically be bound to the first
+logical processors starting from 0 to ``db_cpus-1``. To specify a custom set of cpus,
+set ``db_cpu_list`` following the same syntax as the Linux command ``taskset -c``. The
+RunSettings for the simulation should similarly be bound (e.g. in Slurm using
+``cpu-bind``) to bind the application to a separate set of cores.
 
 Redis
 =====

--- a/doc/orchestrator.rst
+++ b/doc/orchestrator.rst
@@ -97,22 +97,24 @@ Here is an example of creating a simple model that is colocated with an
   colo_model.colocate_db_uds(
           db_cpus=1,              # cpus given to the database on each node
           debug=False             # include debug information (will be slower)
-          pin_db_cpus=True,       # Pin the affinities of the co-located database
-                                  # to specific processors
+          limit_db_cpus=True,     # Limit the database to a specific set of cpus
+          ifname=network_interface # specify network interface(s) to use (i.e. "ib0" or ["ib0", "lo"])
   )
   exp.start(colo_model)
 
 
-By default, SmartSim will attempt to make sure that the database and the application
-do not fight over resources by taking over the affinity mapping process locally on
-each node. This can be disabled by setting ``pin_db_cpus`` to ``False``.
+By default, SmartSim will pin the database to the first _N_ CPUs according to ``db_cpus``. By
+specifying the optional argument ``db_cpu_list``, an alternative pinning can be specified (
+following the format used by ``taskset``). For example, ``db_cpu_list=0-2,5`` limits the database
+to be run on processors 0, 1, 2 and 5. Setting ``limit_db_cpus=False`` disables pinning for the database
+kernel scheduler. For optimal performance, most users will want to also modify the RunSettings for
+the model to pin their application to cores not occupied by the database.
 
-Especially for multicore machines, it can be useful to pin the CPUs used by the database.
-This is enabled by default and the database will automatically be bound to the first
-logical processors starting from 0 to ``db_cpus-1``. To specify a custom set of cpus,
-set ``db_cpu_list`` following the same syntax as the Linux command ``taskset -c``. The
-RunSettings for the simulation should similarly be bound (e.g. in Slurm using
-``cpu-bind``) to bind the application to a separate set of cores.
+.. note::
+
+  Pinning _only_ affects the co-located deployment because both the application and the database
+  are sharing the same compute node. For the clustered deployment, a shard occupies the entirerty
+  of the node.
 
 Redis
 =====

--- a/doc/orchestrator.rst
+++ b/doc/orchestrator.rst
@@ -97,18 +97,21 @@ Here is an example of creating a simple model that is colocated with an
   colo_model.colocate_db_uds(
           db_cpus=1,              # cpus given to the database on each node
           debug=False             # include debug information (will be slower)
-          limit_db_cpus=True,     # Limit the database to a specific set of cpus
           ifname=network_interface # specify network interface(s) to use (i.e. "ib0" or ["ib0", "lo"])
   )
   exp.start(colo_model)
 
 
 By default, SmartSim will pin the database to the first _N_ CPUs according to ``db_cpus``. By
-specifying the optional argument ``db_cpu_list``, an alternative pinning can be specified (
-following the format used by ``taskset``). For example, ``db_cpu_list=0-2,5`` limits the database
-to be run on processors 0, 1, 2 and 5. Setting ``limit_db_cpus=False`` disables pinning for the database
-kernel scheduler. For optimal performance, most users will want to also modify the RunSettings for
-the model to pin their application to cores not occupied by the database.
+specifying the optional argument ``custom_pinning``, an alternative pinning can be specified
+by sending in a list of CPU ids (e.g [0,2,range(5,8)]). For optimal performance, most users
+will want to also modify the RunSettings for the model to pin their application to cores not
+occupied by the database.
+
+.. warning::
+
+  Pinning is not supported on MacOS X. Setting ``custom_pinning`` to anything
+  other than ``None`` will raise a warning and the input will be ignored.
 
 .. note::
 

--- a/smartsim/_core/entrypoints/colocated.py
+++ b/smartsim/_core/entrypoints/colocated.py
@@ -202,21 +202,11 @@ def main(
         raise SSInternalError("Colocated process failed to start") from e
 
     try:
-        if sys.platform != "darwin":
-            # Set CPU affinity to the last $db_cpus CPUs
-            affinity = p.cpu_affinity()
-            cpus_to_use = affinity[-db_cpus:] if affinity else None
-            p.cpu_affinity(cpus_to_use)
-        else:
-            # psutil doesn't support pinning on MacOS
-            cpus_to_use = "CPU pinning disabled on MacOS"
-
         logger.debug(
             "\n\nColocated database information\n"
             + "\n".join(
                 (
                     f"\tIP Address(es): {' '.join(ip_addresses + [lo_address])}",
-                    f"\tAffinity: {cpus_to_use}",
                     f"\tCommand: {' '.join(cmd)}\n\n",
                     f"\t# of Database CPUs: {db_cpus}",
                 )

--- a/smartsim/_core/launcher/colocated.py
+++ b/smartsim/_core/launcher/colocated.py
@@ -142,7 +142,7 @@ def _build_colocated_wrapper_cmd(
     # collect DB binaries and libraries from the config
 
     db_cmd = []
-    if limit_db_cpus:
+    if limit_db_cpus and db_cpu_list:
         db_cmd.extend([
             'taskset', '-c', db_cpu_list
         ])

--- a/smartsim/_core/launcher/colocated.py
+++ b/smartsim/_core/launcher/colocated.py
@@ -138,9 +138,10 @@ def _build_colocated_wrapper_cmd(
             'taskset', '-c', custom_pinning
         ])
     db_cmd.extend([
-        CONFIG.database_exe,
-        CONFIG.database_conf,
-        "--loadmodule", CONFIG.redisai]
+            CONFIG.database_exe,
+            CONFIG.database_conf,
+            "--loadmodule", CONFIG.redisai
+        ]
     )
 
     # add extra redisAI configurations

--- a/smartsim/_core/launcher/colocated.py
+++ b/smartsim/_core/launcher/colocated.py
@@ -137,10 +137,12 @@ def _build_colocated_wrapper_cmd(
         db_cmd.extend([
             'taskset', '-c', custom_pinning
         ])
-    db_cmd.extend([
+    db_cmd.extend(
+        [
             CONFIG.database_exe,
             CONFIG.database_conf,
-            "--loadmodule", CONFIG.redisai
+            "--loadmodule",
+            CONFIG.redisai
         ]
     )
 

--- a/smartsim/_core/launcher/colocated.py
+++ b/smartsim/_core/launcher/colocated.py
@@ -122,9 +122,6 @@ def _build_colocated_wrapper_cmd(
     # up the backgrounded db process
 
     cmd = []
-    if limit_db_cpus:
-        cmd.extend(["taskset -c", f"{db_cpu_list}"])
-
     cmd.extend(
         [
             sys.executable,
@@ -143,7 +140,17 @@ def _build_colocated_wrapper_cmd(
         cmd.extend(["+ifname", ",".join(ifname)])
     cmd.append("+command")
     # collect DB binaries and libraries from the config
-    db_cmd = [CONFIG.database_exe, CONFIG.database_conf, "--loadmodule", CONFIG.redisai]
+
+    db_cmd = []
+    if limit_db_cpus:
+        db_cmd.extend([
+            'taskset', '-c', db_cpu_list
+        ])
+    db_cmd.extend([
+        CONFIG.database_exe,
+        CONFIG.database_conf,
+        "--loadmodule", CONFIG.redisai]
+    )
 
     # add extra redisAI configurations
     for arg, value in (rai_args or {}).items():

--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -157,10 +157,7 @@ class SrunStep(Step):
         srun_cmd += self.run_settings.format_run_args()
 
         if self.run_settings.colocated_db_settings:
-            # disable cpu binding as the entrypoint will set that
-            # for the application and database process now
-            srun_cmd.append("--cpu-bind=none")
-
+            
             # Replace the command with the entrypoint wrapper script
             bash = shutil.which("bash")
             launch_script_path = self.get_colocated_launch_script()

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -70,7 +70,6 @@ class Step:
         return osp.join(self.cwd, self.entity_name + ending)
 
     def get_colocated_launch_script(self) -> str:
-        from .localStep import LocalStep
         # prep step for colocated launch if specifed in run settings
         script_path = self.get_step_file(script_name=".colocated_launcher.sh")
 
@@ -82,11 +81,6 @@ class Step:
             db_log_file = self.get_step_file(ending="-db.log")
         else:
             db_log_file = "/dev/null"
-
-        if sys.platform == 'darwin' and db_settings["db_cpu_list"]:
-                logger.warning(
-                    "DB pinning is not supported on MacOS, setting limit_db_cpus = False")
-                db_settings["limit_db_cpus"] = False
 
         # write the colocated wrapper shell script to the directory for this
         # entity currently being prepped to launch

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -86,10 +86,10 @@ class Step:
         # TODO: support this only on linux
         if (
             self.__class__.__name__ == "LocalStep"
-            and db_settings["limit_app_cpus"] is True
+            and db_settings["limit_db_cpus"] is True
         ):  # pragma: no cover
-            logger.warning("Setting limit_app_cpus=False for local launcher")
-            db_settings["limit_app_cpus"] = False
+            logger.warning("Setting limit_db_cpus=False for local launcher")
+            db_settings["limit_db_cpus"] = False
 
         # write the colocated wrapper shell script to the directory for this
         # entity currently being prepped to launch

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -27,6 +27,7 @@
 from __future__ import annotations
 
 import os.path as osp
+import sys
 import time
 import typing as t
 
@@ -69,6 +70,7 @@ class Step:
         return osp.join(self.cwd, self.entity_name + ending)
 
     def get_colocated_launch_script(self) -> str:
+        from .localStep import LocalStep
         # prep step for colocated launch if specifed in run settings
         script_path = self.get_step_file(script_name=".colocated_launcher.sh")
 
@@ -81,15 +83,11 @@ class Step:
         else:
             db_log_file = "/dev/null"
 
-        # if user specified to use taskset with local launcher
-        # (not allowed b/c MacOS doesn't support it)
-        # TODO: support this only on linux
-        if (
-            self.__class__.__name__ == "LocalStep"
-            and db_settings["limit_db_cpus"] is True
-        ):  # pragma: no cover
-            logger.warning("Setting limit_db_cpus=False for local launcher")
-            db_settings["limit_db_cpus"] = False
+        if sys.platform == 'darwin':
+            if isinstance(self, LocalStep) and db_settings["limit_db_cpus"] is True:
+                logger.warning(
+                    "DB pinning is not supported on MacOS, setting limit_db_cpus = False")
+                db_settings["limit_db_cpus"] = False
 
         # write the colocated wrapper shell script to the directory for this
         # entity currently being prepped to launch

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -83,8 +83,7 @@ class Step:
         else:
             db_log_file = "/dev/null"
 
-        if sys.platform == 'darwin':
-            if isinstance(self, LocalStep) and db_settings["limit_db_cpus"] is True:
+        if sys.platform == 'darwin' and db_settings["db_cpu_list"]:
                 logger.warning(
                     "DB pinning is not supported on MacOS, setting limit_db_cpus = False")
                 db_settings["limit_db_cpus"] = False
@@ -93,7 +92,7 @@ class Step:
         # entity currently being prepped to launch
         write_colocated_launch_script(script_path, db_log_file, db_settings)
         return script_path
-    
+
     def add_to_batch(self, step: Step) -> None:
         """Add a job step to this batch
 

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -358,8 +358,8 @@ class Model(SmartSimEntity):
 
         # Deal with MacOSX limitations first. The "None" (default) disables pinning
         # and is equivalent to []. The only invalid option is an iterable
-        if "darwin" in sys.platform:
-            if not (pin_ids is None) or not pin_ids:
+        if "darwin" == sys.platform:
+            if pin_ids is None or not pin_ids:
                 return None
             elif isinstance(pin_ids, collections.abc.Iterable):
                 warnings.warn(

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -202,6 +202,9 @@ class Model(SmartSimEntity):
         :type db_cpus: int, optional
         :param limit_db_cpus: whether to limit the number of cpus used by the database defaults to True
         :type limit_db_cpus: bool, optional
+        :param db_cpu_list: lists the cpus which the database can be run on. Follows `taskset -c` syntax
+                            e.g. '0-2,5' specifies processors 0, 1, 2, and 5
+        :type db_cpu_list: str, optional
         :param debug: launch Model with extra debug information about the colocated db
         :type debug: bool, optional
         :param kwargs: additional keyword arguments to pass to the orchestrator database
@@ -262,6 +265,9 @@ class Model(SmartSimEntity):
         :type db_cpus: int, optional
         :param limit_db_cpus: whether to limit the number of cpus used by the database, defaults to True
         :type limit_db_cpus: bool, optional
+        :param db_cpu_list: lists the cpus which the database can be run on. Follows `taskset -c` syntax
+                            e.g. '0-2,5' specifies processors 0, 1, 2, and 5
+        :type db_cpu_list: str, optional
         :param debug: launch Model with extra debug information about the colocated db
         :type debug: bool, optional
         :param kwargs: additional keyword arguments to pass to the orchestrator database
@@ -297,10 +303,14 @@ class Model(SmartSimEntity):
         if hasattr(self.run_settings, "_prep_colocated_db"):
             self.run_settings._prep_colocated_db(common_options["cpus"])
 
-        # TODO list which db settings can be extras
+        if "limit_app_cpus" in common_options:
+            raise SSUnsupportedError(
+                "Pinning of app CPUs via limit_app_cpus is no supported. Modify RunSettings " +
+                "instead using the correct binding option for your launcher."
+            )
 
+        # TODO list which db settings can be extras
         cpus = common_options["cpus"]
-        print(cpus)
         # Deal with cases where the database should be pinned to cpus
         # (1) if the user set a db_cpu_list, but not limit_db_cpus
         if common_options["db_cpu_list"] and not common_options["limit_db_cpus"]:
@@ -324,7 +334,6 @@ class Model(SmartSimEntity):
                     f"pinning to processors {cpu_list}"
                 )
             )
-            print(cpu_list)
             common_options["db_cpu_list"] = cpu_list
 
         colo_db_config = {}

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -169,7 +169,7 @@ class Model(SmartSimEntity):
         unix_socket: str = "/tmp/redis.socket",
         socket_permissions: int = 755,
         db_cpus: int = 1,
-        custom_pinning: t.Optional[t.Iterable[t.Union(int, t.Iterable[int])]] = None,
+        custom_pinning: t.Optional[t.Iterable[t.Union[int, t.Iterable[int]]]] = None,
         debug: bool = False,
         **kwargs: t.Any,
     ) -> None:
@@ -228,7 +228,7 @@ class Model(SmartSimEntity):
         port: int = 6379,
         ifname: t.Union[str, list[str]] = "lo",
         db_cpus: int = 1,
-        custom_pinning: t.Optional[t.Iterable[t.Union(int, t.Iterable[int])]] = None,
+        custom_pinning: t.Optional[t.Iterable[t.Union[int, t.Iterable[int]]]] = None,
         debug: bool = False,
         **kwargs: t.Any,
     ) -> None:
@@ -334,14 +334,14 @@ class Model(SmartSimEntity):
 
     @staticmethod
     def _create_pinning_string(
-        pin_ids: t.Optional[t.Iterable[t.Union(int, t.Iterable[int])]],
+        pin_ids: t.Optional[t.Iterable[t.Union[int, t.Iterable[int]]]],
         cpus: int
         ) -> t.Optional[str]:
         """Create a comma-separated string CPU ids. By default, None returns
         0,1,...,cpus-1; an empty iterable will disable pinning altogether,
         and an iterable constructs a comma separate string (e.g. 0,2,5)
         """
-        def _stringify_id(id: int) -> int:
+        def _stringify_id(id: int) -> str:
             """Return the cPU id as a string if an int, otherwise raise a ValueError"""
             if isinstance(id, int):
                 if id < 0:

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -167,7 +167,7 @@ class Model(SmartSimEntity):
         unix_socket: str = "/tmp/redis.socket",
         socket_permissions: int = 755,
         db_cpus: int = 1,
-        limit_db_cpus: bool = False,
+        limit_db_cpus: bool = True,
         db_cpu_list: t.Optional[str] = None,
         debug: bool = False,
         **kwargs: t.Any,
@@ -200,7 +200,7 @@ class Model(SmartSimEntity):
         :type socket_permissions: int, optional
         :param db_cpus: number of cpus to use for orchestrator, defaults to 1
         :type db_cpus: int, optional
-        :param limit_db_cpus: whether to limit the number of cpus used by the app, defaults to True
+        :param limit_db_cpus: whether to limit the number of cpus used by the database defaults to True
         :type limit_db_cpus: bool, optional
         :param debug: launch Model with extra debug information about the colocated db
         :type debug: bool, optional

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -454,7 +454,6 @@ def test_colocated_db_model_pytorch(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_db_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -518,7 +517,6 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_db_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -532,7 +530,6 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i + 1,
             db_cpus=1,
-            limit_db_cpus=False,
             debug=True,
             ifname=test_interface
         )
@@ -629,7 +626,62 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
         device=test_device,
         devices_per_node=test_num_gpus,
         inputs=inputs,
-        outputs=outputs
+        outputs=outputs,
+        tag="test",
+    )
+
+    # Ensemble should add all available DBModels to new model
+    colo_ensemble.add_model(colo_model)
+    colo_model.colocate_db(
+        port=wlmutils.get_test_port() + len(colo_ensemble),
+        db_cpus=1,
+        debug=True,
+        ifname="lo",
+    )
+    colo_model.add_ml_model(
+        "cnn2",
+        "TF",
+        model_path=model_file2,
+        device="CPU",
+        inputs=inputs2,
+        outputs=outputs2,
+    )
+
+    exp.start(colo_ensemble, block=True)
+    statuses = exp.get_status(colo_ensemble)
+    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+
+
+@pytest.mark.skipif(not should_run_tf, reason="Test needs TF to run")
+def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils):
+    """Test DBModel on colocated ensembles, first adding the DBModel to the
+    ensemble, then colocating DB.
+    """
+
+    exp_name = "test-colocated-db-model-ensemble-reordered"
+
+    # get test setup
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
+    sr_test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
+
+    # create colocated model
+    colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=sr_test_script)
+
+    colo_ensemble = exp.create_ensemble(
+        "colocated_ens", run_settings=colo_settings, replicas=2
+    )
+    colo_ensemble.set_path(test_dir)
+
+    colo_model = exp.create_model("colocated_model", colo_settings)
+    colo_model.set_path(test_dir)
+
+    model_file, inputs, outputs = save_tf_cnn(test_dir, "model1.pb")
+    model_file2, inputs2, outputs2 = save_tf_cnn(test_dir, "model2.pb")
+
+    # Test adding a model from ensemble
+    colo_ensemble.add_ml_model(
+        "cnn", "TF", model_path=model_file, device="CPU", inputs=inputs, outputs=outputs
     )
 
     # Colocate a database with the first ensemble members
@@ -637,7 +689,6 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port = test_port + i,
             db_cpus=1,
-            limit_db_cpus=False,
             debug=True,
             ifname=test_interface
         )
@@ -660,7 +711,6 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port + len(colo_ensemble),
         db_cpus=1,
-        limit_db_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -712,7 +762,6 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_db_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -739,7 +788,6 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_db_cpus=False,
             debug=True,
             ifname=test_interface
         )
@@ -774,7 +822,6 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
             entity.colocate_db_tcp(
                 port=test_port + i,
                 db_cpus=1,
-                limit_db_cpus=False,
                 debug=True,
                 ifname=test_interface,
             )

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -387,7 +387,6 @@ def test_colocated_db_model_tf(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_app_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -455,7 +454,7 @@ def test_colocated_db_model_pytorch(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_app_cpus=False,
+        limit_db_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -519,7 +518,7 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_app_cpus=False,
+        limit_db_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -533,7 +532,7 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i + 1,
             db_cpus=1,
-            limit_app_cpus=False,
+            limit_db_cpus=False,
             debug=True,
             ifname=test_interface
         )
@@ -638,7 +637,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port = test_port + i,
             db_cpus=1,
-            limit_app_cpus=False,
+            limit_db_cpus=False,
             debug=True,
             ifname=test_interface
         )
@@ -661,7 +660,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port + len(colo_ensemble),
         db_cpus=1,
-        limit_app_cpus=False,
+        limit_db_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -713,7 +712,7 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_app_cpus=False,
+        limit_db_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -740,7 +739,7 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_app_cpus=False,
+            limit_db_cpus=False,
             debug=True,
             ifname=test_interface
         )
@@ -775,7 +774,7 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
             entity.colocate_db_tcp(
                 port=test_port + i,
                 db_cpus=1,
-                limit_app_cpus=False,
+                limit_db_cpus=False,
                 debug=True,
                 ifname=test_interface,
             )

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -626,62 +626,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
         device=test_device,
         devices_per_node=test_num_gpus,
         inputs=inputs,
-        outputs=outputs,
-        tag="test",
-    )
-
-    # Ensemble should add all available DBModels to new model
-    colo_ensemble.add_model(colo_model)
-    colo_model.colocate_db(
-        port=wlmutils.get_test_port() + len(colo_ensemble),
-        db_cpus=1,
-        debug=True,
-        ifname="lo",
-    )
-    colo_model.add_ml_model(
-        "cnn2",
-        "TF",
-        model_path=model_file2,
-        device="CPU",
-        inputs=inputs2,
-        outputs=outputs2,
-    )
-
-    exp.start(colo_ensemble, block=True)
-    statuses = exp.get_status(colo_ensemble)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
-
-
-@pytest.mark.skipif(not should_run_tf, reason="Test needs TF to run")
-def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils):
-    """Test DBModel on colocated ensembles, first adding the DBModel to the
-    ensemble, then colocating DB.
-    """
-
-    exp_name = "test-colocated-db-model-ensemble-reordered"
-
-    # get test setup
-    test_dir = fileutils.make_test_dir()
-    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
-    sr_test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
-
-    # create colocated model
-    colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=sr_test_script)
-
-    colo_ensemble = exp.create_ensemble(
-        "colocated_ens", run_settings=colo_settings, replicas=2
-    )
-    colo_ensemble.set_path(test_dir)
-
-    colo_model = exp.create_model("colocated_model", colo_settings)
-    colo_model.set_path(test_dir)
-
-    model_file, inputs, outputs = save_tf_cnn(test_dir, "model1.pb")
-    model_file2, inputs2, outputs2 = save_tf_cnn(test_dir, "model2.pb")
-
-    # Test adding a model from ensemble
-    colo_ensemble.add_ml_model(
-        "cnn", "TF", model_path=model_file, device="CPU", inputs=inputs, outputs=outputs
+        outputs=outputs
     )
 
     # Colocate a database with the first ensemble members

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -237,7 +237,7 @@ def test_colocated_db_script(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_app_cpus=False,
+        limit_db_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -316,7 +316,7 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_app_cpus=False,
+            limit_db_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -332,7 +332,7 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port + len(colo_ensemble),
         db_cpus=1,
-        limit_app_cpus=False,
+        limit_db_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -421,7 +421,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_app_cpus=False,
+            limit_db_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -437,7 +437,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port + len(colo_ensemble),
         db_cpus=1,
-        limit_app_cpus=False,
+        limit_db_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -495,7 +495,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_app_cpus=False,
+        limit_db_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -522,7 +522,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_app_cpus=False,
+            limit_db_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -560,7 +560,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
             entity.colocate_db_tcp(
                 port=test_port + i,
                 db_cpus=1,
-                limit_app_cpus=False,
+                limit_db_cpus=False,
                 debug=True,
                 ifname=test_interface,
             )

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -237,6 +237,7 @@ def test_colocated_db_script(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
+        limit_app_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -315,6 +316,7 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
+            limit_app_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -330,6 +332,7 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port + len(colo_ensemble),
         db_cpus=1,
+        limit_app_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -418,6 +421,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
+            limit_app_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -433,6 +437,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port + len(colo_ensemble),
         db_cpus=1,
+        limit_app_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -490,6 +495,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
+        limit_app_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -516,6 +522,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
+            limit_app_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -553,6 +560,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
             entity.colocate_db_tcp(
                 port=test_port + i,
                 db_cpus=1,
+                limit_app_cpus=False,
                 debug=True,
                 ifname=test_interface,
             )

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -237,7 +237,6 @@ def test_colocated_db_script(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_db_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -316,7 +315,6 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_db_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -332,7 +330,6 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port + len(colo_ensemble),
         db_cpus=1,
-        limit_db_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -421,7 +418,6 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_db_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -437,7 +433,6 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port + len(colo_ensemble),
         db_cpus=1,
-        limit_db_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -495,7 +490,6 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_db_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -522,7 +516,6 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_db_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -560,7 +553,6 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
             entity.colocate_db_tcp(
                 port=test_port + i,
                 db_cpus=1,
-                limit_db_cpus=False,
                 debug=True,
                 ifname=test_interface,
             )

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -237,7 +237,6 @@ def test_colocated_db_script(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_app_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -316,7 +315,6 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_app_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -332,7 +330,6 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port + len(colo_ensemble),
         db_cpus=1,
-        limit_app_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -421,7 +418,6 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_app_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -437,7 +433,6 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port + len(colo_ensemble),
         db_cpus=1,
-        limit_app_cpus=False,
         debug=True,
         ifname=test_interface
     )
@@ -495,7 +490,6 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
     colo_model.colocate_db_tcp(
         port=test_port,
         db_cpus=1,
-        limit_app_cpus=False,
         debug=True,
         ifname=test_interface,
     )
@@ -522,7 +516,6 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
         entity.colocate_db_tcp(
             port=test_port + i,
             db_cpus=1,
-            limit_app_cpus=False,
             debug=True,
             ifname=test_interface,
         )
@@ -560,7 +553,6 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
             entity.colocate_db_tcp(
                 port=test_port + i,
                 db_cpus=1,
-                limit_app_cpus=False,
                 debug=True,
                 ifname=test_interface,
             )

--- a/tests/conftest/setup_test_colo/colocated_model.out
+++ b/tests/conftest/setup_test_colo/colocated_model.out
@@ -1,4 +1,0 @@
-SmartRedis Library@19-19-36:WARNING: Environment variable SR_LOG_FILE is not set. Defaulting to stdout
-SmartRedis Library@19-19-36:WARNING: Environment variable SR_LOG_LEVEL is not set. Defaulting to INFO
-default@19-19-36:ERROR: Unable to connect to backend database: Failed to connect to Redis: Connection refused
-Test worked! Sent and received array: [1 2 3 4]

--- a/tests/conftest/setup_test_colo/colocated_model.out
+++ b/tests/conftest/setup_test_colo/colocated_model.out
@@ -1,0 +1,4 @@
+SmartRedis Library@19-19-36:WARNING: Environment variable SR_LOG_FILE is not set. Defaulting to stdout
+SmartRedis Library@19-19-36:WARNING: Environment variable SR_LOG_LEVEL is not set. Defaulting to INFO
+default@19-19-36:ERROR: Unable to connect to backend database: Failed to connect to Redis: Connection refused
+Test worked! Sent and received array: [1 2 3 4]

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -30,96 +30,16 @@ import warnings
 import pytest
 
 from smartsim import Experiment, status
+from ..test_colo_model_local import test_colocated_model_pinning_auto_1cpu, test_colocated_model_pinning_auto_2cpu, test_colocated_model_pinning_manual, test_launch_colocated_model_defaults
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
     pytestmark = pytest.mark.skip(reason="Not testing WLM integrations")
 
+@pytest.mark.parametrize("db_type", ["uds", "tcp", "deprecated"])
+def test_launch_colocated_model(fileutils, db_type):
+    test_launch_colocated_model_defaults(fileutils, db_type, pytest.test_launcher)
 
 @pytest.mark.parametrize("db_type", ["uds", "tcp", "deprecated"])
-def test_launch_colocated_model(fileutils, wlmutils, db_type):
-    """Test the launch of a model with a colocated database"""
-
-    launcher = wlmutils.get_test_launcher()
-    exp_name = "test-launch-colocated-model-with-restart"
-    exp = Experiment(exp_name, launcher=launcher)
-
-    # get test setup
-    test_dir = fileutils.make_test_dir()
-    sr_test_script = fileutils.get_test_conf_path("send_data_local_smartredis.py")
-    network_interface = wlmutils.get_test_interface()
-
-    # create colocated model
-    colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=sr_test_script)
-    colo_settings.set_tasks_per_node(1)
-
-    colo_model = exp.create_model("colocated_model", colo_settings)
-    colo_model.set_path(test_dir)
-    db_args = {
-        "db_cpus": 1,
-        "limit_app_cpus": False,
-        "debug": True,
-    }
-
-    if db_type in ["tcp", "deprecated"]:
-        colocate_fun = {
-            "tcp": colo_model.colocate_db_tcp,
-            "deprecated": colo_model.colocate_db,
-        }
-        with warnings.catch_warnings(record=True) as w:
-            colocate_fun[db_type](port=6780, ifname="lo", **db_args)
-            if db_type == "deprecated":
-                assert len(w) == 1
-                assert issubclass(w[-1].category, DeprecationWarning)
-                assert "Please use `colocate_db_tcp` or `colocate_db_uds`" in str(
-                    w[-1].message
-                )
-    elif db_type == "uds":
-        colo_model.colocate_db_uds(**db_args)
-
-    # assert model will launch with colocated db
-    assert colo_model.colocated
-
-    exp.start(colo_model, block=True)
-    statuses = exp.get_status(colo_model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
-
-    # test restarting the colocated model
-
-    exp.start(colo_model, block=True)
-    statuses = exp.get_status(colo_model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
-
-
-def test_launch_colocated_pinned_model(fileutils, wlmutils):
-    """Test the launch of a model with a colocated database and limit the
-    cpus of the user application.
-
-    This test will skip if the ``taskset`` command is not found
-    """
-
-    launcher = wlmutils.get_test_launcher()
-    exp_name = "test-launch-colocated-pinned-model"
-    exp = Experiment(exp_name, launcher=launcher)
-
-    # get test setup
-    test_dir = fileutils.make_test_dir()
-    sr_test_script = fileutils.get_test_conf_path("send_data_local_smartredis.py")
-    network_interface = wlmutils.get_test_interface()
-
-    # create colocated model
-    colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=sr_test_script)
-    colo_settings.set_tasks_per_node(1)
-
-    colo_model = exp.create_model("colocated_pinned_model", colo_settings)
-    colo_model.set_path(test_dir)
-    colo_model.colocate_db(
-        port=6780, db_cpus=2, limit_app_cpus=True, debug=True, ifname=network_interface
-    )
-
-    # assert model will launch with colocated db
-    assert colo_model.colocated
-
-    exp.start(colo_model, block=True)
-    statuses = exp.get_status(colo_model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+def test_launch_colocated_pinned_model(fileutils, db_type):
+    test_colocated_model_pinning_auto_2cpu(fileutils, db_type, pytest.launcher)

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -25,25 +25,30 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import sys
-import warnings
 
 import pytest
 
 from smartsim import Experiment, status
+from smartsim.entity import Model
 
-launcher = pytest.test_launcher
-supported_dbs = ["uds", "tcp", "deprecated"]
+if sys.platform == "darwin":
+    supported_dbs = ["tcp", "deprecated"]
+else:
+    supported_dbs = ["uds", "tcp", "deprecated"]
+    supported_dbs = ["uds"]
 
 # retrieved from pytest fixtures
+launcher = pytest.test_launcher
 if launcher not in pytest.wlm_options:
     pytestmark = pytest.mark.skip(reason="Not testing WLM integrations")
 
-@pytest.mark.parametrize("db_type", ["uds", "tcp", "deprecated"])
-def test_launch_colocated_model(fileutils, coloutils, db_type):
-    """Test the launch of a model with a colocated database"""
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_launch_colocated_model_defaults(fileutils, coloutils, db_type):
+    """Test the launch of a model with a colocated database and local launcher"""
 
-    exp = Experiment("colocated_model_wlm", launcher=launcher)
     db_args = { }
+
+    exp = Experiment("colocated_model_defaults", launcher=launcher)
     colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
@@ -51,6 +56,7 @@ def test_launch_colocated_model(fileutils, coloutils, db_type):
         db_args,
     )
 
+    assert colo_model.run_settings.colocated_db_settings["custom_pinning"] == "0"
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all([stat == status.STATUS_COMPLETED for stat in statuses])
@@ -60,14 +66,14 @@ def test_launch_colocated_model(fileutils, coloutils, db_type):
     statuses = exp.get_status(colo_model)
     assert all([stat == status.STATUS_COMPLETED for stat in statuses])
 
-@pytest.mark.parametrize("db_type", ["uds", "tcp", "deprecated"])
-def test_launch_colocated_pinned_model(fileutils, coloutils, db_type):
-    db_args = {
-        "limit_db_cpus": True,
-        "db_cpus": 2,
-    }
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_disable_pinning(fileutils, coloutils, db_type):
 
-    exp = Experiment("colocated_model_pinning_auto_2cpu", launcher=launcher)
+    exp = Experiment("colocated_model_pinning_auto_1cpu", launcher=launcher)
+    db_args = {
+        "db_cpus": 1,
+        "custom_pinning": [],
+    }
 
     # Check to make sure that the CPU mask was correctly generated
     colo_model = coloutils.setup_test_colo(
@@ -76,31 +82,97 @@ def test_launch_colocated_pinned_model(fileutils, coloutils, db_type):
         exp,
         db_args,
     )
-    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0-1"
-    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
+    assert colo_model.run_settings.colocated_db_settings["custom_pinning"] is None
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all([stat == status.STATUS_COMPLETED for stat in statuses])
 
 @pytest.mark.parametrize("db_type", supported_dbs)
-def test_colocated_model_pinning_manual(fileutils, coloutils, db_type):
-    # Check to make sure that the CPU mask was correctly generated
+def test_colocated_model_pinning_auto_2cpu(fileutils, coloutils, db_type):
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    exp = Experiment("colocated_model_pinning_auto_2cpu", launcher=launcher)
+
     db_args = {
-        "limit_db_cpus": True,
         "db_cpus": 2,
-        "db_cpu_list": "0,2"
     }
 
-    colo_model = coloutils._setup_test_colo(
+    # Check to make sure that the CPU mask was correctly generated
+    colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
-        "colocated_model_pinning_manual",
+        exp,
         db_args,
     )
-    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0,2"
-    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
+    assert colo_model.run_settings.colocated_db_settings["custom_pinning"] == "0,1"
+    exp.start(colo_model, block=True)
+    statuses = exp.get_status(colo_model)
+    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_pinning_range(fileutils, coloutils, db_type):
+    # Check to make sure that the CPU mask was correctly generated
+    # Assume that there are at least 4 cpus on the node
+
+    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+
+    db_args = {
+        "db_cpus": 4,
+        "custom_pinning": range(5)
+    }
+
+    colo_model = coloutils.setup_test_colo(
+        fileutils,
+        db_type,
+        exp,
+        db_args,
+    )
+    assert colo_model.run_settings.colocated_db_settings["custom_pinning"] == "0,1,2,3"
+    exp.start(colo_model, block=True)
+    statuses = exp.get_status(colo_model)
+    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_pinning_list(fileutils, coloutils, db_type):
+    # Check to make sure that the CPU mask was correctly generated
+    # note we presume that this has more than 2 CPUs on the supercomputer node
+
+    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+
+    db_args = {
+        "db_cpus": 2,
+        "custom_pinning": [0,2]
+    }
+
+    colo_model = coloutils.setup_test_colo(
+        fileutils,
+        db_type,
+        exp,
+        db_args,
+    )
+    assert colo_model.run_settings.colocated_db_settings["custom_pinning"] == "0,2"
+    exp.start(colo_model, block=True)
+    statuses = exp.get_status(colo_model)
+    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_pinning_mixed(fileutils, coloutils, db_type):
+    # Check to make sure that the CPU mask was correctly generated
+    # note we presume that this at least 4 CPUs on the supercomputer node
+
+    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+
+    db_args = {
+        "db_cpus": 2,
+        "custom_pinning": [range(2), 3]
+    }
+
+    colo_model = coloutils.setup_test_colo(
+        fileutils,
+        db_type,
+        exp,
+        db_args,
+    )
+    assert colo_model.run_settings.colocated_db_settings["custom_pinning"] == "0,1,3"
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all([stat == status.STATUS_COMPLETED for stat in statuses])

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -35,7 +35,6 @@ if sys.platform == "darwin":
     supported_dbs = ["tcp", "deprecated"]
 else:
     supported_dbs = ["uds", "tcp", "deprecated"]
-    supported_dbs = ["uds"]
 
 # retrieved from pytest fixtures
 launcher = pytest.test_launcher

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -30,16 +30,124 @@ import warnings
 import pytest
 
 from smartsim import Experiment, status
-from ..test_colo_model_local import test_colocated_model_pinning_auto_1cpu, test_colocated_model_pinning_auto_2cpu, test_colocated_model_pinning_manual, test_launch_colocated_model_defaults
+
+launcher = pytest.test_launcher
+supported_dbs = ["uds", "tcp", "deprecated"]
 
 # retrieved from pytest fixtures
-if pytest.test_launcher not in pytest.wlm_options:
+if launcher not in pytest.wlm_options:
     pytestmark = pytest.mark.skip(reason="Not testing WLM integrations")
 
-@pytest.mark.parametrize("db_type", ["uds", "tcp", "deprecated"])
-def test_launch_colocated_model(fileutils, db_type):
-    test_launch_colocated_model_defaults(fileutils, db_type, pytest.test_launcher)
+def _setup_test_colo(fileutils, db_type, exp_name, db_args, launcher):
+    """Setup things needed for setting up the colo pinning tests"""
 
-@pytest.mark.parametrize("db_type", ["uds", "tcp", "deprecated"])
-def test_launch_colocated_pinned_model(fileutils, db_type):
-    test_colocated_model_pinning_auto_2cpu(fileutils, db_type, pytest.launcher)
+    exp = Experiment(exp_name, launcher=launcher)
+
+    # get test setup
+    test_dir = fileutils.make_test_dir()
+    sr_test_script = fileutils.get_test_conf_path("send_data_local_smartredis.py")
+
+    # Create an app with a colo_db which uses 1 db_cpu
+    colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=sr_test_script)
+    colo_model = exp.create_model(f"colocated_model", colo_settings)
+    colo_model.set_path(test_dir)
+
+    if db_type in ['tcp', "deprecated"]:
+        db_args["port"] = 6780
+        db_args["ifname"] = "lo"
+
+    colocate_fun = {
+        "tcp": colo_model.colocate_db_tcp,
+        "deprecated": colo_model.colocate_db,
+        "uds":colo_model.colocate_db_uds
+    }
+    colocate_fun[db_type](**db_args)
+
+    # assert model will launch with colocated db
+    assert colo_model.colocated
+    # Check to make sure that limit_db_cpus made it into the colo settings
+    return exp, colo_model
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_launch_colocated_model_defaults(fileutils, db_type):
+    """Test the launch of a model with a colocated database and local launcher"""
+
+    db_args = { }
+
+    exp, colo_model = _setup_test_colo(
+        fileutils,
+        db_type,
+        "colocated_model_with_restart",
+        db_args,
+        launcher
+    )
+
+    exp.start(colo_model, block=True)
+    statuses = exp.get_status(colo_model)
+    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+
+    # test restarting the colocated model
+    exp.start(colo_model, block=True)
+    statuses = exp.get_status(colo_model)
+    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_pinning_auto_1cpu(fileutils, db_type):
+
+    db_args = {
+        "limit_db_cpus": True,
+        "db_cpus": 1,
+    }
+
+    # Check to make sure that the CPU mask was correctly generated
+    exp, colo_model = _setup_test_colo(
+        fileutils,
+        db_type,
+        "colocated_model_pinning_auto_1cpu",
+        db_args,
+        launcher
+    )
+    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0"
+    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
+    exp.start(colo_model)
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_pinning_auto_2cpu(fileutils, db_type):
+
+    db_args = {
+        "limit_db_cpus": True,
+        "db_cpus": 2,
+    }
+
+    # Check to make sure that the CPU mask was correctly generated
+    exp, colo_model = _setup_test_colo(
+        fileutils,
+        db_type,
+        "colocated_model_pinning_auto_2cpu",
+        db_args,
+        launcher
+    )
+    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0-1"
+    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
+    exp.start(colo_model)
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_pinning_manual(fileutils, db_type):
+    # Check to make sure that the CPU mask was correctly generated
+
+    db_args = {
+        "limit_db_cpus": True,
+        "db_cpus": 2,
+        "db_cpu_list": "0,2"
+    }
+
+    exp, colo_model = _setup_test_colo(
+        fileutils,
+        db_type,
+        "colocated_model_pinning_manual",
+        db_args,
+        launcher
+    )
+    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0,2"
+    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
+    exp.start(colo_model)

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -38,43 +38,11 @@ supported_dbs = ["uds", "tcp", "deprecated"]
 if launcher not in pytest.wlm_options:
     pytestmark = pytest.mark.skip(reason="Not testing WLM integrations")
 
-def _setup_test_colo(fileutils, db_type, exp_name, db_args, launcher):
-    """Setup things needed for setting up the colo pinning tests"""
-
-    exp = Experiment(exp_name, launcher=launcher)
-
-    # get test setup
-    test_dir = fileutils.make_test_dir()
-    sr_test_script = fileutils.get_test_conf_path("send_data_local_smartredis.py")
-
-    # Create an app with a colo_db which uses 1 db_cpu
-    colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=sr_test_script)
-    colo_model = exp.create_model(f"colocated_model", colo_settings)
-    colo_model.set_path(test_dir)
-
-    if db_type in ['tcp', "deprecated"]:
-        db_args["port"] = 6780
-        db_args["ifname"] = "lo"
-
-    colocate_fun = {
-        "tcp": colo_model.colocate_db_tcp,
-        "deprecated": colo_model.colocate_db,
-        "uds":colo_model.colocate_db_uds
-    }
-    colocate_fun[db_type](**db_args)
-
-    # assert model will launch with colocated db
-    assert colo_model.colocated
-    # Check to make sure that limit_db_cpus made it into the colo settings
-    return exp, colo_model
-
-@pytest.mark.parametrize("db_type", supported_dbs)
-def test_launch_colocated_model_defaults(fileutils, db_type):
-    """Test the launch of a model with a colocated database and local launcher"""
-
+@pytest.mark.parametrize("db_type", ["uds", "tcp", "deprecated"])
+def test_launch_colocated_model(fileutils, coloutils, db_type):
+    """Test the launch of a model with a colocated database"""
     db_args = { }
-
-    exp, colo_model = _setup_test_colo(
+    exp, colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
         "colocated_model_with_restart",
@@ -91,36 +59,15 @@ def test_launch_colocated_model_defaults(fileutils, db_type):
     statuses = exp.get_status(colo_model)
     assert all([stat == status.STATUS_COMPLETED for stat in statuses])
 
-@pytest.mark.parametrize("db_type", supported_dbs)
-def test_colocated_model_pinning_auto_1cpu(fileutils, db_type):
-
-    db_args = {
-        "limit_db_cpus": True,
-        "db_cpus": 1,
-    }
-
-    # Check to make sure that the CPU mask was correctly generated
-    exp, colo_model = _setup_test_colo(
-        fileutils,
-        db_type,
-        "colocated_model_pinning_auto_1cpu",
-        db_args,
-        launcher
-    )
-    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0"
-    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
-    exp.start(colo_model)
-
-@pytest.mark.parametrize("db_type", supported_dbs)
-def test_colocated_model_pinning_auto_2cpu(fileutils, db_type):
-
+@pytest.mark.parametrize("db_type", ["uds", "tcp", "deprecated"])
+def test_launch_colocated_pinned_model(fileutils, coloutils, db_type):
     db_args = {
         "limit_db_cpus": True,
         "db_cpus": 2,
     }
 
     # Check to make sure that the CPU mask was correctly generated
-    exp, colo_model = _setup_test_colo(
+    exp, colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
         "colocated_model_pinning_auto_2cpu",

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -35,68 +35,12 @@ from smartsim import Experiment, status
 if sys.platform == "darwin":
     supported_dbs = ["tcp", "deprecated"]
 else:
-    # supported_dbs = ["uds", "tcp", "deprecated"]
-    supported_dbs = ["uds"]
+    supported_dbs = ["uds", "tcp", "deprecated"]
 
-
-@pytest.mark.parametrize("db_type", supported_dbs)
-def test_launch_colocated_model(fileutils, db_type):
-    """Test the launch of a model with a colocated database and local launcher"""
-
-    exp_name = "test-launch-colocated-model-with-restart"
-    exp = Experiment(exp_name, launcher="local")
-
-    # get test setup
-    test_dir = fileutils.make_test_dir()
-    sr_test_script = fileutils.get_test_conf_path("send_data_local_smartredis.py")
-
-    # create colocated model
-    colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=sr_test_script)
-
-    colo_model = exp.create_model("colocated_model", colo_settings)
-    colo_model.set_path(test_dir)
-
-    db_args = {
-        "db_cpus": 1,
-        "limit_db_cpus": False,
-        "debug": True,
-    }
-
-    if db_type in ["tcp", "deprecated"]:
-        colocate_fun = {
-            "tcp": colo_model.colocate_db_tcp,
-            "deprecated": colo_model.colocate_db,
-        }
-        with warnings.catch_warnings(record=True) as w:
-            colocate_fun[db_type](port=6780, ifname="lo", **db_args)
-            if db_type == "deprecated":
-                assert len(w) == 1
-                assert issubclass(w[-1].category, DeprecationWarning)
-                assert "Please use `colocate_db_tcp` or `colocate_db_uds`" in str(
-                    w[-1].message
-                )
-    elif db_type == "uds":
-        colo_model.colocate_db_uds(**db_args)
-
-    # assert model will launch with colocated db
-    assert colo_model.colocated
-
-    exp.start(colo_model, block=True)
-    statuses = exp.get_status(colo_model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
-
-    # test restarting the colocated model
-
-    exp.start(colo_model, block=True)
-    statuses = exp.get_status(colo_model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
-
-
-def _setup_test_colo_pinning(fileutils, db_type, db_cpu):
+def _setup_test_colo(fileutils, db_type, exp_name, db_args, launcher="local"):
     """Setup things needed for setting up the colo pinning tests"""
 
-    exp_name = "test-launch-colocated-model-pinning-auto"
-    exp = Experiment(exp_name, launcher="local")
+    exp = Experiment(exp_name, launcher=launcher)
 
     # get test setup
     test_dir = fileutils.make_test_dir()
@@ -104,14 +48,8 @@ def _setup_test_colo_pinning(fileutils, db_type, db_cpu):
 
     # Create an app with a colo_db which uses 1 db_cpu
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=sr_test_script)
-    colo_model = exp.create_model(f"colocated_model_{db_cpu}", colo_settings)
+    colo_model = exp.create_model(f"colocated_model", colo_settings)
     colo_model.set_path(test_dir)
-
-    db_args = {
-        "db_cpus": db_cpu,
-        "limit_db_cpus": True,
-        "debug": True,
-    }
 
     if db_type in ['tcp', "deprecated"]:
         db_args["port"] = 6780
@@ -127,18 +65,88 @@ def _setup_test_colo_pinning(fileutils, db_type, db_cpu):
     # assert model will launch with colocated db
     assert colo_model.colocated
     # Check to make sure that limit_db_cpus made it into the colo settings
-    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
     return exp, colo_model
 
 @pytest.mark.parametrize("db_type", supported_dbs)
-def test_colocated_model_pinning_auto_1cpu(fileutils, db_type):
-    # Check to make sure that the CPU mask was correctly generated
-    exp, colo_model = _setup_test_colo_pinning(fileutils, db_type, 1)
-    pdb.set_trace()
-    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0"
+def test_launch_colocated_model_defaults(fileutils, db_type, launcher="local"):
+    """Test the launch of a model with a colocated database and local launcher"""
+
+    db_args = { }
+
+    exp, colo_model = _setup_test_colo(
+        fileutils,
+        db_type,
+        "colocated_model_with_restart",
+        db_args,
+        launcher
+    )
+
+    exp.start(colo_model, block=True)
+    statuses = exp.get_status(colo_model)
+    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+
+    # test restarting the colocated model
+    exp.start(colo_model, block=True)
+    statuses = exp.get_status(colo_model)
+    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
 
 @pytest.mark.parametrize("db_type", supported_dbs)
-def test_colocated_model_pinning_auto_2cpu(fileutils, db_type):
+def test_colocated_model_pinning_auto_1cpu(fileutils, db_type, launcher="local"):
+
+    db_args = {
+        "limit_db_cpus": True,
+        "db_cpus": 1,
+    }
+
     # Check to make sure that the CPU mask was correctly generated
-    exp, colo_model = _setup_test_colo_pinning(fileutils, db_type, 2)
+    exp, colo_model = _setup_test_colo(
+        fileutils,
+        db_type,
+        "colocated_model_pinning_auto_1cpu",
+        db_args,
+        launcher
+    )
+    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0"
+    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
+    exp.start(colo_model)
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_pinning_auto_2cpu(fileutils, db_type, launcher="local"):
+
+    db_args = {
+        "limit_db_cpus": True,
+        "db_cpus": 2,
+    }
+
+    # Check to make sure that the CPU mask was correctly generated
+    exp, colo_model = _setup_test_colo(
+        fileutils,
+        db_type,
+        "colocated_model_pinning_auto_2cpu",
+        db_args,
+        launcher
+    )
     assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0-1"
+    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
+    exp.start(colo_model)
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_pinning_manual(fileutils, db_type, launcher="local"):
+    # Check to make sure that the CPU mask was correctly generated
+
+    db_args = {
+        "limit_db_cpus": True,
+        "db_cpus": 2,
+        "db_cpu_list": "0,2"
+    }
+
+    exp, colo_model = _setup_test_colo(
+        fileutils,
+        db_type,
+        "colocated_model_pinning_manual",
+        db_args,
+        launcher
+    )
+    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0,2"
+    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
+    exp.start(colo_model)

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -23,7 +23,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+import pdb
 
 import sys
 import warnings
@@ -35,7 +35,8 @@ from smartsim import Experiment, status
 if sys.platform == "darwin":
     supported_dbs = ["tcp", "deprecated"]
 else:
-    supported_dbs = ["uds", "tcp", "deprecated"]
+    # supported_dbs = ["uds", "tcp", "deprecated"]
+    supported_dbs = ["uds"]
 
 
 @pytest.mark.parametrize("db_type", supported_dbs)
@@ -57,7 +58,7 @@ def test_launch_colocated_model(fileutils, db_type):
 
     db_args = {
         "db_cpus": 1,
-        "limit_app_cpus": False,
+        "limit_db_cpus": False,
         "debug": True,
     }
 
@@ -89,3 +90,55 @@ def test_launch_colocated_model(fileutils, db_type):
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+
+
+def _setup_test_colo_pinning(fileutils, db_type, db_cpu):
+    """Setup things needed for setting up the colo pinning tests"""
+
+    exp_name = "test-launch-colocated-model-pinning-auto"
+    exp = Experiment(exp_name, launcher="local")
+
+    # get test setup
+    test_dir = fileutils.make_test_dir()
+    sr_test_script = fileutils.get_test_conf_path("send_data_local_smartredis.py")
+
+    # Create an app with a colo_db which uses 1 db_cpu
+    colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=sr_test_script)
+    colo_model = exp.create_model(f"colocated_model_{db_cpu}", colo_settings)
+    colo_model.set_path(test_dir)
+
+    db_args = {
+        "db_cpus": db_cpu,
+        "limit_db_cpus": True,
+        "debug": True,
+    }
+
+    if db_type in ['tcp', "deprecated"]:
+        db_args["port"] = 6780
+        db_args["ifname"] = "lo"
+
+    colocate_fun = {
+        "tcp": colo_model.colocate_db_tcp,
+        "deprecated": colo_model.colocate_db,
+        "uds":colo_model.colocate_db_uds
+    }
+    colocate_fun[db_type](**db_args)
+
+    # assert model will launch with colocated db
+    assert colo_model.colocated
+    # Check to make sure that limit_db_cpus made it into the colo settings
+    assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
+    return exp, colo_model
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_pinning_auto_1cpu(fileutils, db_type):
+    # Check to make sure that the CPU mask was correctly generated
+    exp, colo_model = _setup_test_colo_pinning(fileutils, db_type, 1)
+    pdb.set_trace()
+    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0"
+
+@pytest.mark.parametrize("db_type", supported_dbs)
+def test_colocated_model_pinning_auto_2cpu(fileutils, db_type):
+    # Check to make sure that the CPU mask was correctly generated
+    exp, colo_model = _setup_test_colo_pinning(fileutils, db_type, 2)
+    assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0-1"

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -34,6 +34,7 @@ from smartsim.entity import Model
 
 if sys.platform == "darwin":
     supported_dbs = ["tcp", "deprecated"]
+    supported_dbs = ["tcp"]
 else:
     supported_dbs = ["uds", "tcp", "deprecated"]
 
@@ -46,8 +47,8 @@ def test_macosx_warning(fileutils, coloutils):
 
     exp = Experiment("colocated_model_defaults", launcher="local")
     with pytest.warns(
-        RuntimeError,
-        match="CPU pinning is not supported on MacOSX. Ignoring pinning specification."
+        RuntimeWarning,
+        # match="CPU pinning is not supported on MacOSX. Ignoring pinning specification."
     ):
         colo_model = coloutils.setup_test_colo(
             fileutils,
@@ -69,6 +70,7 @@ def test_unsupported_limit_app(fileutils, coloutils):
             db_args,
         )
 
+@pytest.mark.skipif(is_mac, reason="Unsupported on MacOSX")
 @pytest.mark.parametrize("custom_pinning", [1,"10","#",1.,['a'],[1.]])
 def test_unsupported_custom_pinning(fileutils, coloutils, custom_pinning):
     db_type = "uds" # Test is insensitive to choice of db
@@ -83,6 +85,7 @@ def test_unsupported_custom_pinning(fileutils, coloutils, custom_pinning):
             db_args,
         )
 
+@pytest.mark.skipif(is_mac, reason="Unsupported on MacOSX")
 @pytest.mark.parametrize("pin_list, num_cpus, expected", [
     pytest.param(None, 2, "0,1", id="Automatic creation of pinned cpu list"),
     pytest.param([1,2], 2, "1,2", id="Individual ids only"),
@@ -130,7 +133,6 @@ def test_colocated_model_disable_pinning(fileutils, coloutils, db_type, launcher
         "db_cpus": 1,
         "custom_pinning": [],
     }
-
     # Check to make sure that the CPU mask was correctly generated
     colo_model = coloutils.setup_test_colo(
         fileutils,

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -34,7 +34,6 @@ from smartsim.entity import Model
 
 if sys.platform == "darwin":
     supported_dbs = ["tcp", "deprecated"]
-    supported_dbs = ["tcp"]
 else:
     supported_dbs = ["uds", "tcp", "deprecated"]
 

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -48,7 +48,7 @@ def test_macosx_warning(fileutils, coloutils):
     exp = Experiment("colocated_model_defaults", launcher="local")
     with pytest.warns(
         RuntimeWarning,
-        # match="CPU pinning is not supported on MacOSX. Ignoring pinning specification."
+        match="CPU pinning is not supported on MacOSX. Ignoring pinning specification."
     ):
         colo_model = coloutils.setup_test_colo(
             fileutils,

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -36,15 +36,15 @@ if sys.platform == "darwin":
 else:
     supported_dbs = ["uds", "tcp", "deprecated"]
 
-def test_create_pinning_string():
-    # Automatic creation of pinned cpu list
-    assert Model._create_pinning_string(None,2) == '0,1'
-    # Individual ids only
-    assert Model._create_pinning_string([1,2],2) == '1,2'
-    # Mixed ranges and individual ids
-    assert Model._create_pinning_string([range(2),3],3) == '0,1,3'
-    # Range only
-    assert Model._create_pinning_string(range(3),3) == '0,1,2'
+@pytest.mark.parametrize("pin_list, num_cpus, expected", [
+    pytest.param(None, 2, "0,1", id="Automatic creation of pinned cpu list"),
+    pytest.param([1,2], 2, "1,2", id="Individual ids only"),
+    pytest.param([range(2),3], 3, "0,1,3", id="Mixed ranges and individual ids"),
+    pytest.param(range(3), 3, "0,1,2", id="Range only"),
+    pytest.param([range(8, 10), range(6, 1, -2)], 4, "2,4,6,8,9", id="Multiple ranges"),
+])
+def test_create_pinning_string(pin_list, num_cpus, expected):
+    assert Model._create_pinning_string(pin_list, num_cpus) == expected
 
 
 @pytest.mark.parametrize("db_type", supported_dbs)

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -40,12 +40,12 @@ def test_launch_colocated_model_defaults(fileutils, coloutils, db_type, launcher
 
     db_args = { }
 
-    exp, colo_model = coloutils.setup_test_colo(
+    exp = Experiment("colocated_model_defaults", launcher=launcher)
+    colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
-        "colocated_model_with_restart",
+        exp,
         db_args,
-        launcher
     )
 
     exp.start(colo_model, block=True)
@@ -60,18 +60,18 @@ def test_launch_colocated_model_defaults(fileutils, coloutils, db_type, launcher
 @pytest.mark.parametrize("db_type", supported_dbs)
 def test_colocated_model_pinning_auto_1cpu(fileutils, coloutils, db_type, launcher="local"):
 
+    exp = Experiment("colocated_model_pinning_auto_1cpu", launcher=launcher)
     db_args = {
         "limit_db_cpus": True,
         "db_cpus": 1,
     }
 
     # Check to make sure that the CPU mask was correctly generated
-    exp, colo_model = coloutils.setup_test_colo(
+    colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
-        "colocated_model_pinning_auto_1cpu",
+        exp,
         db_args,
-        launcher
     )
     assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0"
     assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
@@ -82,18 +82,19 @@ def test_colocated_model_pinning_auto_1cpu(fileutils, coloutils, db_type, launch
 @pytest.mark.parametrize("db_type", supported_dbs)
 def test_colocated_model_pinning_auto_2cpu(fileutils, coloutils, db_type, launcher="local"):
 
+    exp = Experiment("colocated_model_pinning_auto_2cpu", launcher=launcher)
+
     db_args = {
         "limit_db_cpus": True,
         "db_cpus": 2,
     }
 
     # Check to make sure that the CPU mask was correctly generated
-    exp, colo_model = coloutils.setup_test_colo(
+    colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
-        "colocated_model_pinning_auto_2cpu",
+        exp,
         db_args,
-        launcher
     )
     assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0-1"
     assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]
@@ -105,18 +106,19 @@ def test_colocated_model_pinning_auto_2cpu(fileutils, coloutils, db_type, launch
 def test_colocated_model_pinning_manual(fileutils, coloutils, db_type, launcher="local"):
     # Check to make sure that the CPU mask was correctly generated
 
+    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+
     db_args = {
         "limit_db_cpus": True,
         "db_cpus": 2,
         "db_cpu_list": "0,2"
     }
 
-    exp, colo_model = coloutils.setup_test_colo(
+    colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
-        "colocated_model_pinning_manual",
+        exp,
         db_args,
-        launcher
     )
     assert colo_model.run_settings.colocated_db_settings["db_cpu_list"] == "0,2"
     assert colo_model.run_settings.colocated_db_settings["limit_db_cpus"]


### PR DESCRIPTION
This updates the strategy for adding a co-located deployment for simulation and database. Prior, the co-located database was always pinned to the last N logical processors on a machine. In the case of a Slurm machine, user-specified bind settings were being overwritten leading to a general inflexibility for users trying to maximize performance. Additionally, `limit_app_cpus` was not working as intended because only the launcher command was being pinned and not the application launched by the launcher command.

The changes here provide two options, `limit_db_cpus` and `db_cpu_list` to control the pinning of the co-located database. `limit_db_cpus` enables the pinning using `taskset` and `db_cpu_list` is a user-provided string that specifies which processors the orchestrator should be bound to.  If `db_cpu_list` is not provided, the database is automatically pinned to the first N logical processors.