### PR TITLE
Set Test Colo DB Pinning to the Intended Range

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -55,12 +55,12 @@ jobs:
           cp -r doc-branch/docs/* ./docs/
           rm -rf doc-branch
 
-      - name: build documentation with docker
+      - name: Build documentation with docker
         run: make docks
 
       - name: Commit files
         run: |
-          git add -A
+          git add -Af
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -m "Update develop documentation"

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -116,7 +116,7 @@ def test_colocated_model_pinning_range(fileutils, coloutils, db_type):
 
     db_args = {
         "db_cpus": 4,
-        "custom_pinning": range(5)
+        "custom_pinning": range(4)
     }
 
     colo_model = coloutils.setup_test_colo(


### PR DESCRIPTION
This test is running a colo database on 4 cpus but pins the process to the range of the first 5 cpus. This seems an odd choice as there is theoretically no benefit to `taskset`ing to more than 4 cpus. This was causing also test to fail as the `custom_pinning` key  in the run settings colocated db settings is was being compared to a str of `0,1,2,3` (i.e. the firsts 4 cpus).

Given this, it seems likely that the original author intended to set the `taskset` cpu range be the first 4 cpus. This PR changes the custom task set range provided in the test from `range(5) == '0,1,2,3,4'` to `range(4) == '0,1,2,3'`