### PR TITLE
Fix the dbmodel and dbscript test errors

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -25,6 +25,7 @@ Description
 
 A full list of changes and detailed notes can be found below:
 
+- Fix tests for db models and scripts
 - Fix add_ml_model() and add_script() documentation, tests, and code
 - Replace `limit_app_cpus` with `limit_db_cpus` for co-located orchestrators
 - Remove wait time associated with Experiment launch summary
@@ -40,6 +41,8 @@ A full list of changes and detailed notes can be found below:
 
 Detailed notes
 
+- Fix a defect in the tests related to database models and scripts that was
+  causing key collisions when testing on workload managers (PR313_)
 - Fix defect where dictionaries used to create run settings can be changed
   unexpectedly due to copy-by-ref (PR305_)
 - The underlying code for Model.add_ml_model() and Model.add_script() was fixed
@@ -70,6 +73,7 @@ Detailed notes
 - Typehints have been added to public APIs. A makefile target to execute static
   analysis with mypy is available `make check-mypy`. (PR295_)
 
+.. _PR313: https://github.com/CrayLabs/SmartSim/pull/313
 .. _PR305: https://github.com/CrayLabs/SmartSim/pull/305
 .. _PR304: https://github.com/CrayLabs/SmartSim/pull/304
 .. _PR303: https://github.com/CrayLabs/SmartSim/pull/303

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -154,6 +154,8 @@ def test_tf_db_model(fileutils, wlmutils, mlutils):
 
     # Create RunSettings
     run_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    run_settings.set_nodes(1)
+    run_settings.set_tasks_per_node(1)
 
     # Create Model
     smartsim_model = exp.create_model("smartsim_model", run_settings)
@@ -226,6 +228,8 @@ def test_pt_db_model(fileutils, wlmutils, mlutils):
 
     # Create RunSettings
     run_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    run_settings.set_nodes(1)
+    run_settings.set_tasks_per_node(1)
 
     # Create Model
     smartsim_model = exp.create_model("smartsim_model", run_settings)
@@ -287,6 +291,8 @@ def test_db_model_ensemble(fileutils, wlmutils, mlutils):
 
     # Create RunSettings
     run_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    run_settings.set_nodes(1)
+    run_settings.set_tasks_per_node(1)
 
     # Create ensemble
     smartsim_ensemble = exp.create_ensemble(
@@ -380,6 +386,8 @@ def test_colocated_db_model_tf(fileutils, wlmutils, mlutils):
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    colo_settings.set_nodes(1)
+    colo_settings.set_tasks_per_node(1)
 
     # Create colocated Model
     colo_model = exp.create_model("colocated_model", colo_settings)
@@ -447,6 +455,8 @@ def test_colocated_db_model_pytorch(fileutils, wlmutils, mlutils):
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    colo_settings.set_nodes(1)
+    colo_settings.set_tasks_per_node(1)
 
     # Create colocated SmartSim Model
     colo_model = exp.create_model("colocated_model", colo_settings)
@@ -504,6 +514,8 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
 
     # Create RunSettings for colocated model
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    colo_settings.set_nodes(1)
+    colo_settings.set_tasks_per_node(1)
 
     # Create ensemble of two identical models
     colo_ensemble = exp.create_ensemble(
@@ -603,6 +615,8 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    colo_settings.set_nodes(1)
+    colo_settings.set_tasks_per_node(1)
 
     # Create the ensemble of two identical SmartSim Model
     colo_ensemble = exp.create_ensemble(
@@ -700,6 +714,8 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    colo_settings.set_nodes(1)
+    colo_settings.set_tasks_per_node(1)
 
     # Create colocated SmartSim Model
     colo_model = exp.create_model("colocated_model", colo_settings)

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -71,6 +71,8 @@ def test_db_script(fileutils, wlmutils, mlutils):
 
     # Create the RunSettings
     run_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    run_settings.set_nodes(1)
+    run_settings.set_tasks_per_node(1)
 
     # Create the SmartSim Model
     smartsim_model = exp.create_model("smartsim_model", run_settings)
@@ -141,6 +143,8 @@ def test_db_script_ensemble(fileutils, wlmutils, mlutils):
 
     # Create RunSettings
     run_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    run_settings.set_nodes(1)
+    run_settings.set_tasks_per_node(1)
 
     # Create Ensemble with two identical models
     ensemble = exp.create_ensemble(
@@ -230,6 +234,8 @@ def test_colocated_db_script(fileutils, wlmutils, mlutils):
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    colo_settings.set_nodes(1)
+    colo_settings.set_tasks_per_node(1)
 
     # Create model with colocated database
     colo_model = exp.create_model("colocated_model", colo_settings)
@@ -297,6 +303,8 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    colo_settings.set_nodes(1)
+    colo_settings.set_tasks_per_node(1)
 
     # Create SmartSim Ensemble with two identical models
     colo_ensemble = exp.create_ensemble(
@@ -391,6 +399,8 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    colo_settings.set_nodes(1)
+    colo_settings.set_tasks_per_node(1)
 
     # Create Ensemble with two identical SmartSim Model
     colo_ensemble = exp.create_ensemble(
@@ -483,6 +493,8 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    colo_settings.set_nodes(1)
+    colo_settings.set_tasks_per_node(1)
 
     # Create a SmartSim model with a colocated database
     colo_model = exp.create_model("colocated_model", colo_settings)


### PR DESCRIPTION
In PR 304 (https://github.com/CrayLabs/SmartSim/pull/304), the DB model and script tests were updated to enable testing on workload managers.  However, these tests were not constrained to run on only one node and one process during the update.  As a result, each SmartSim ``model`` and ``Ensemble`` member is run with a generic run command (e.g. ``srun``) that results in multiple, identical clones of the test entity running on each compute node (e.g. in a generic slurm interactive allocation with three nodes, a ``srun`` command without ``-N`` and/or ``-n`` arguments will launch the test script on three compute nodes).  This oversight causes a combination of key collisions that results in sporadic test failures.  This PR addresses those test failures.  