### PR TITLE
Fix tests for PBS on swan

### DIFF
--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -583,6 +583,8 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
         outputs=outputs2,
     )
 
+    exp.generate(colo_ensemble, overwrite=True)
+
     # Launch and check successful completion
     try:
         exp.start(colo_ensemble, block=True)
@@ -683,6 +685,8 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
         inputs=inputs2,
         outputs=outputs2,
     )
+
+    exp.generate(colo_ensemble, overwrite=True)
 
     # Launch and check successful completion
     try:

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -367,6 +367,8 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
     # Assert we have added both models to each entity
     assert all([len(entity._db_scripts) == 2 for entity in colo_ensemble])
 
+    exp.generate(colo_ensemble, overwrite=True)
+
     # Launch and check successful completion
     try:
         exp.start(colo_ensemble, block=True)
@@ -461,6 +463,8 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
     assert len(colo_ensemble._db_scripts) == 1
     # Assert we have added both models to each entity
     assert all([len(entity._db_scripts) == 2 for entity in colo_ensemble])
+
+    exp.generate(colo_ensemble, overwrite=True)
 
     # Launch and check successful completion
     try:

--- a/tests/on_wlm/test_generic_orc_launch.py
+++ b/tests/on_wlm/test_generic_orc_launch.py
@@ -119,7 +119,6 @@ def test_launch_cluster_orc_multi(fileutils, wlmutils):
         hosts=wlmutils.get_test_hostlist(),
     )
     orc.set_path(test_dir)
-    orc.set_run_arg("exclusive", None)
 
     exp.start(orc, block=True)
     statuses = exp.get_status(orc)


### PR DESCRIPTION
Tests were failing on swan:

- One test had hardcoded in slurm semantics
- Ensemble tests in dbmodel and dbscript were both failing because it seems like each ensemble member was potentially executing the wrong .colocated_launcher.sh script. To solve this problem for now, we add a generate step before the launch of the ensemble which puts everything into its own run directory and avoids the problem