### PR TITLE
Bump the SmartRedis version to 0.4.1

### DIFF
--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -245,7 +245,7 @@ class Versioner:
 
     # Versions
     SMARTSIM = Version_(get_env("SMARTSIM_VERSION", "0.4.2"))
-    SMARTREDIS = Version_(get_env("SMARTREDIS_VERSION", "0.4.0"))
+    SMARTREDIS = Version_(get_env("SMARTREDIS_VERSION", "0.4.1"))
     SMARTSIM_SUFFIX = get_env("SMARTSIM_SUFFIX", "")
 
     # Redis


### PR DESCRIPTION
SmartSim can now require SmartRedis v0.4.1 which has been released on PyPI.
This updates the Version class to reflect this new release.