### PR TITLE
Make file tweaks to documentation and add Frontier guide

### DIFF
--- a/doc/api/smartsim_api.rst
+++ b/doc/api/smartsim_api.rst
@@ -455,12 +455,15 @@ Ensemble
 .. autosummary::
 
    Ensemble.__init__
-   Ensemble.models
    Ensemble.add_model
+   Ensemble.add_ml_model
+   Ensemble.add_script
+   Ensemble.add_function
    Ensemble.attach_generator_files
-   Ensemble.register_incoming_entity
    Ensemble.enable_key_prefixing
+   Ensemble.models
    Ensemble.query_key_prefixing
+   Ensemble.register_incoming_entity
 
 .. autoclass:: Ensemble
    :members:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,22 +11,19 @@ Jump to :ref:`SmartRedis Changelog <changelog>`
 SmartSim
 ========
 
-Development branch
+0.5.0
 ------------------
 
-To be released at some future date
-
-Note
-
-This section details changes made in the development branch that have not yet
-been applied to a released version of the SmartSim library.
+Released on 6 July 2023
 
 Description
 
 A full list of changes and detailed notes can be found below:
 
+- Update SmartRedis dependency to v0.4.1
 - Fix tests for db models and scripts
 - Fix add_ml_model() and add_script() documentation, tests, and code
+- Remove `requirements.txt` and other places where dependencies were defined
 - Replace `limit_app_cpus` with `limit_db_cpus` for co-located orchestrators
 - Remove wait time associated with Experiment launch summary
 - Update and rename Redis conf file
@@ -41,8 +38,12 @@ A full list of changes and detailed notes can be found below:
 
 Detailed notes
 
+- Updates SmartRedis to the most current release (PR316_)
+- Fixes and enhancements to documentation (PR317_, PR314_, PR287_)
+- Various fixes and enhancements to the test suite (PR315_, PR312_, PR310_, PR302_, PR283_)
 - Fix a defect in the tests related to database models and scripts that was
   causing key collisions when testing on workload managers (PR313_)
+- Remove `requirements.txt` and other places where dependencies were defined. (PR307_)
 - Fix defect where dictionaries used to create run settings can be changed
   unexpectedly due to copy-by-ref (PR305_)
 - The underlying code for Model.add_ml_model() and Model.add_script() was fixed
@@ -50,11 +51,11 @@ Detailed notes
   non-local launchers.  Documentation was updated and fixed.  Also, the default
   testing interface has been changed to lo instead of ipogif. (PR304_)
 - Typehints have been added. A makefile target `make check-mypy` executes static
-  analysis with mypy. (PR295_, PR303_)
+  analysis with mypy. (PR295_, PR301_, PR303_)
 - Replace `limit_app_cpus` with `limit_db_cpus` for co-located orchestrators.
   This resolves some incorrect behavior/assumptions about how the application
   would be pinned.  Instead, users should directly specify the binding options in
-  their application using the options appropriate for their launcher
+  their application using the options appropriate for their launcher (PR306_)
 - Simplify code in `random_permutations` parameter generation strategy (PR300_)
 - Remove wait time associated with Experiment launch summary (PR298_)
 - Update Redis conf file to conform with Redis v7.0.5 conf file (PR293_)
@@ -73,10 +74,20 @@ Detailed notes
 - Typehints have been added to public APIs. A makefile target to execute static
   analysis with mypy is available `make check-mypy`. (PR295_)
 
+.. _PR317: https://github.com/CrayLabs/SmartSim/pull/317
+.. _PR316: https://github.com/CrayLabs/SmartSim/pull/316
+.. _PR315: https://github.com/CrayLabs/SmartSim/pull/314
+.. _PR314: https://github.com/CrayLabs/SmartSim/pull/314
 .. _PR313: https://github.com/CrayLabs/SmartSim/pull/313
+.. _PR312: https://github.com/CrayLabs/SmartSim/pull/312
+.. _PR310: https://github.com/CrayLabs/SmartSim/pull/310
+.. _PR307: https://github.com/CrayLabs/SmartSim/pull/307
+.. _PR306: https://github.com/CrayLabs/SmartSim/pull/306
 .. _PR305: https://github.com/CrayLabs/SmartSim/pull/305
 .. _PR304: https://github.com/CrayLabs/SmartSim/pull/304
 .. _PR303: https://github.com/CrayLabs/SmartSim/pull/303
+.. _PR302: https://github.com/CrayLabs/SmartSim/pull/302
+.. _PR301: https://github.com/CrayLabs/SmartSim/pull/301
 .. _PR300: https://github.com/CrayLabs/SmartSim/pull/300
 .. _PR298: https://github.com/CrayLabs/SmartSim/pull/298
 .. _PR295: https://github.com/CrayLabs/SmartSim/pull/295
@@ -86,8 +97,10 @@ Detailed notes
 .. _PR290: https://github.com/CrayLabs/SmartSim/pull/290
 .. _PR289: https://github.com/CrayLabs/SmartSim/pull/289
 .. _PR288: https://github.com/CrayLabs/SmartSim/pull/288
+.. _PR287: https://github.com/CrayLabs/SmartSim/pull/287
 .. _PR285: https://github.com/CrayLabs/SmartSim/pull/285
 .. _PR284: https://github.com/CrayLabs/SmartSim/pull/284
+.. _PR283: https://github.com/CrayLabs/SmartSim/pull/283
 .. _PR281: https://github.com/CrayLabs/SmartSim/pull/281
 
 0.4.2

--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -73,10 +73,9 @@ SmartSim, users can run multiple testing commands with the developer Makefile
 
 .. note::
 
-You must have the extra dev dependencies installed in 
-your python environment to execute tests.
-
-- Install smartsim with ``dev`` extension ``pip install -e .[dev]``
+    You must have the extra dev dependencies installed in your python
+    environment to execute tests. Install smartsim with ``dev`` extension
+    ``pip install -e .[dev]``
 
 
 Local

--- a/doc/installation_instructions/platform.rst
+++ b/doc/installation_instructions/platform.rst
@@ -10,6 +10,8 @@ that SmartSim may be used on.
 
 .. include:: platform/nonroot-linux.rst
 
+.. include:: platform/frontier.rst
+
 .. include:: platform/cray.rst
 
 .. include:: platform/ncar-cheyenne.rst

--- a/doc/installation_instructions/platform/frontier.rst
+++ b/doc/installation_instructions/platform/frontier.rst
@@ -10,11 +10,11 @@ As of 2023-07-06, users can use the following instructions, however we
 anticipate that all the SmartSim dependencies will be available system-wide via
 the modules system.
 
-Known issues
-------------
+Known limitations
+-----------------
 
-We are continually working on getting all the SmartSim on Frontier, however we
-do have some known issues:
+We are continually working on getting all the features of SmartSim working on
+Frontier, however we do have some known limitations:
 
 * For now, only Torch models are supported. We are working to find a recipe to
   install Tensorflow with ROCm support from scratch

--- a/doc/installation_instructions/platform/frontier.rst
+++ b/doc/installation_instructions/platform/frontier.rst
@@ -1,0 +1,145 @@
+OLCF Frontier
+=============
+
+Summary
+-------
+
+Frontier is an AMD CPU/AMD GPU system.
+
+As of 2023-07-06, users can use the following instructions, however we
+anticipate that all the SmartSim dependencies will be available system-wide via
+the modules system.
+
+Known issues
+------------
+
+We are continually working on getting all the SmartSim on Frontier, however we
+do have some known issues:
+
+* For now, only Torch models are supported. We are working to find a recipe to
+  install Tensorflow with ROCm support from scratch
+* The colocated database will fail without specifying ``custom_pinning``. This
+  is because the default pinning assumes that processor 0 is available, but the
+  'low-noise' default on Frontier reserves the processor on each NUMA node.
+  Users should pass a list of processor ids to the ``custom_pinning`` argument that
+  avoids the reserved processors
+* The Singularity-based tests are currently failing. We are investigating how to
+  interact with Frontier's configuration. Please contact us if this is interfering
+  with your application
+
+Please raise an issue in the SmartSim Github or contact the developers if the above
+issues are affecting your workflow or if you find any other problems.
+
+Build process
+-------------
+
+To install the SmartRedis and SmartSim python packages on Frontier, please follow
+these instructions, being sure to set the following variables
+
+.. code:: bash
+
+   export PROJECT_NAME=CHANGE_ME
+   export VENV_NAME=CHANGE_ME
+
+Then continue with the install:
+
+.. code:: bash
+
+   module load PrgEnv-gnu-amd git-lfs cmake cray-python
+   module unload xalt amd-mixed
+   module load rocm/4.5.2
+   export CC=gcc
+   export CXX=g++
+
+   export SCRATCH=/lustre/orion/$PROJECT_NAME/scratch/$USER/
+   export VENV_HOME=$SCRATCH/$VENV_NAME/
+
+   python3 -m venv $VENV_HOME
+   source $VENV_HOME/bin/activate
+   pip install torch==1.11.0+rocm4.5.2 torchvision==0.12.0+rocm4.5.2 torchaudio==0.11.0  --extra-index-url  https://download.pytorch.org/whl/rocm4.5.2
+
+
+   cd $SCRATCH
+   git clone https://github.com/CrayLabs/SmartRedis.git
+   cd SmartRedis
+   make lib-with-fortran
+   pip install .
+
+   # Download SmartSim and site-specific files
+   cd $SCRATCH
+   git clone https://github.com/CrayLabs/site-deployments.git
+   git clone https://github.com/CrayLabs/SmartSim.git
+   cd SmartSim
+   pip install -e .[dev]
+
+Next to finish the compilation, we need to manually modify one of the auxiliary
+cmake files that comes packaged with Torch
+
+.. code::bash
+
+   export TORCH_CMAKE_DIR=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)')
+   # Manual step: modify all references to the 'rocm' directory to rocm-4.5.2
+   vim $TORCH_CMAKE_DIR/Caffe2/Caffe2Targets.cmake
+
+Finally, build Redis (or keydb for a more performant solution), RedisAI, and the
+machine-learning backends using:
+
+.. code:: bash
+
+   KEYDB_FLAG="" # set this to --keydb if desired
+   smart build --device gpu --torch_dir $TORCH_CMAKE_DIR --no_tf -v $(KEYDB_FLAG)
+
+Set up environment
+------------------
+
+Before running SmartSim, the environment should match the one used to
+build, and some variables should be set to work around some ROCm PyTorch
+issues:
+
+.. code:: bash
+
+   # Set these to the same values that were used for install
+   export PROJECT_NAME=CHANGE_ME
+   export VENV_NAME=CHANGE_ME
+
+.. code:: bash
+
+   module load PrgEnv-gnu-amd git-lfs cmake cray-python
+   module unload xalt amd-mixed
+   module load rocm/4.5.2
+
+   export SCRATCH=/lustre/orion/$PROJECT_NAME/scratch/$USER/
+   export MIOPEN_USER_DB_PATH=/tmp/miopendb/
+   export MIOPEN_SYSTEM_DB_PATH=$MIOPEN_USER_DB_PATH
+   mkdir -p $MIOPEN_USER_DB_PATH
+   export MIOPEN_DISABLE_CACHE=1
+   export VENV_HOME=$SCRATCH/$VENV_NAME/
+   source $VENV_HOME/bin/activate
+   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$VENV_HOME/lib/python3.9/site-packages/torch/lib
+
+Binding DBs to Slingshot
+------------------------
+
+Each Frontier node has *four* NICs, which also means users need to bind
+DBs to *four* network interfaces, ``hsn0``, ``hsn1``, ``hsn2``,
+``hsn3``. Typically, orchestrators will need to be created in the
+following way:
+
+.. code:: python
+
+   exp = Experiment("my_exp", launcher="slurm")
+   orc = exp.create_database(db_nodes=3, interface=["hsn0","hsn1","hsn2","hsn3"], single_cmd=True)
+
+Running tests
+-------------
+
+The same environment set to run SmartSim must be set to run tests. The
+environment variables needed to run the test suite are the following:
+
+.. code:: bash
+
+   export SMARTSIM_TEST_ACCOUNT=PROJECT_NAME # Change this to above
+   export SMARTSIM_TEST_LAUNCHER=slurm
+   export SMARTSIM_TEST_DEVICE=gpu
+   export SMARTSIM_TEST_PORT=6789
+   export SMARTSIM_TEST_INTERFACE="hsn0,hsn1,hsn2,hsn3"

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -25,11 +25,8 @@ level of the SmartSim directory::
 
 .. note::
 
-You must have the extra dev dependencies installed in
-your python environment to execute tests.
-
-Install ``dev`` dependencies with ``pip``
-- Install smartsim with ``dev`` extension ``pip install -e .[dev]``
+  You must have the extra dev dependencies installed in your python environment to
+  execute tests. Install ``dev`` dependencies with ``pip install -e .[dev]``
 
 
 Test Suites


### PR DESCRIPTION
Fixes some warnings that arose due to incorrectly formatted documentation. Also adds, a guide for Frontier users on how to build SmartSim.