### PR TITLE
fix for incorrect logging message format/args

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,12 +19,15 @@ To be released at some future point in time
 
 Description
 
+- Fix malformed logging format strings
 - Update linting support and apply to existing errors
 
 Detailed Notes
 
+- Fix incorrectly formatted positional arguments in log format strings (PR330_)
 - Update pylint dependency, update .pylintrc, mitigate non-breaking issues, suppress api breaks (PR311_)
 
+.. _PR330: https://github.com/CrayLabs/SmartSim/pull/330
 .. _PR311: https://github.com/CrayLabs/SmartSim/pull/311
 
 0.5.0

--- a/smartsim/_core/entrypoints/colocated.py
+++ b/smartsim/_core/entrypoints/colocated.py
@@ -207,15 +207,10 @@ def main(
 
     try:
         logger.debug(
-            (
-                "\n\nColocated database information\n"
-                "\n\tIP Address(es): {}"
-                "\n\tCommand: {}\n\n"
-                "\n\t# of Database CPUs: {}"
-            ),
-            ' '.join(ip_addresses + [lo_address]),
-            ' '.join(cmd),
-            db_cpus
+            "\n\nColocated database information\n"
+            f"\n\tIP Address(es): {' '.join(ip_addresses + [lo_address])}"
+            f"\n\tCommand: {' '.join(cmd)}\n\n"
+            f"\n\t# of Database CPUs: {db_cpus}"
         )
     except Exception as e:
         cleanup()

--- a/smartsim/_core/launcher/step/alpsStep.py
+++ b/smartsim/_core/launcher/step/alpsStep.py
@@ -106,8 +106,8 @@ class AprunStep(Step):
         elif "COBALT_JOBID" in os.environ:
             self.alloc = os.environ["COBALT_JOBID"]
             logger.debug(
-                "Running on Cobalt allocation {} gleaned from user environment",
-                self.alloc,
+                f"Running on Cobalt allocation {self.alloc} gleaned "
+                "from user environment"
             )
         else:
             raise AllocationError(


### PR DESCRIPTION
A bug was introduced during pylint mitigation. The following error occurs when logging details of a freshly started colocated database:

```
--- Logging error ---
Traceback (most recent call last):
  File "/Users/ankona/.pyenv/versions/3.9.15/lib/python3.9/logging/__init__.py", line 1083, in emit
    msg = self.format(record)
  File "/Users/ankona/.pyenv/versions/3.9.15/lib/python3.9/logging/__init__.py", line 927, in format
    return fmt.format(record)
  File "/Users/ankona/.pyenv/versions/3.9.15/lib/python3.9/logging/__init__.py", line 663, in format
    record.message = record.getMessage()
  File "/Users/ankona/.pyenv/versions/3.9.15/lib/python3.9/logging/__init__.py", line 367, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/Users/ankona/.pyenv/versions/3.9.15/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/ankona/.pyenv/versions/3.9.15/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/ankona/code/ss/smartsim/_core/entrypoints/colocated.py", line 329, in <module>
    main(
  File "/Users/ankona/code/ss/smartsim/_core/entrypoints/colocated.py", line 209, in main
    logger.debug(
Message: '\n\nColocated database information\n\n\tIP Address(es): {}\n\tCommand: {}\n\n\n\t# of Database CPUs: {}'
Arguments: 
('127.0.0.1 127.0.0.1', 
 '/Users/ankona/code/ss/smartsim/_core/bin/redis-server /Users/ankona/code/ss/smartsim/_core/config/redis.conf --loadmodule /Users/ankona/code/ss/smartsim/_core/lib/redisai.so --port 6780 --logfile /Users/ankona/code/ss/tests/test_output/backends/test_dbscript/test_colocated_db_script/colocated_model-db.log --bind 127.0.0.1', 
 1)

```

This fix uses f-strings to ensure arguments are correctly converted during log message formatting.

### Triggering
The error can be triggered by executing `pytest tests/backends/test_dbscript.py`