### PR TITLE
Log sacct failures

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,14 +19,17 @@ To be released at some future point in time
 
 Description
 
+- Log ignored error messages from `sacct`
 - Fix malformed logging format strings
 - Update linting support and apply to existing errors
 
 Detailed Notes
 
+- Log errors reported from slurm WLM when attempts to retrieve status fail (PR331_)
 - Fix incorrectly formatted positional arguments in log format strings (PR330_)
 - Update pylint dependency, update .pylintrc, mitigate non-breaking issues, suppress api breaks (PR311_)
 
+.. _PR331: https://github.com/CrayLabs/SmartSim/pull/331
 .. _PR330: https://github.com/CrayLabs/SmartSim/pull/330
 .. _PR311: https://github.com/CrayLabs/SmartSim/pull/311
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -25,10 +25,11 @@ Description
 
 Detailed Notes
 
-- Log errors reported from slurm WLM when attempts to retrieve status fail (PR331_)
+- Log errors reported from slurm WLM when attempts to retrieve status fail (PR331_, PR332_)
 - Fix incorrectly formatted positional arguments in log format strings (PR330_)
 - Update pylint dependency, update .pylintrc, mitigate non-breaking issues, suppress api breaks (PR311_)
 
+.. _PR332: https://github.com/CrayLabs/SmartSim/pull/332
 .. _PR331: https://github.com/CrayLabs/SmartSim/pull/331
 .. _PR330: https://github.com/CrayLabs/SmartSim/pull/330
 .. _PR311: https://github.com/CrayLabs/SmartSim/pull/311

--- a/smartsim/_core/launcher/slurm/slurmLauncher.py
+++ b/smartsim/_core/launcher/slurm/slurmLauncher.py
@@ -224,7 +224,10 @@ class SlurmLauncher(WLMLauncher):
         step_id: t.Optional[str] = None
         trials = CONFIG.wlm_trials
         while trials > 0:
-            output, _ = sacct(["--noheader", "-p", "--format=jobname,jobid"])
+            output, err = sacct(["--noheader", "-p", "--format=jobname,jobid"])
+            if err:
+                logger.warning(f"An error occurred while calling sacct: {err}")
+
             step_id = parse_step_id_from_sacct(output, step.name)
             if step_id:
                 break


### PR DESCRIPTION
After experiencing a crash in the slurm database, tests began failing unexpectedly. This fix ensures that a warning will be logged if the database goes down again.