### PR TITLE
Fetch torch at pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ extras_require = {
         "types-setuptools",
     ],
     # see smartsim/_core/_install/buildenv.py for more details
-    "ml": versions.ml_extras_required(),
+    **versions.ml_extras_required()
 }
 
 

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -28,6 +28,7 @@ import sys
 
 from smartsim._core._cli.cli import default_cli
 
+
 def main() -> int:
     smart_cli = default_cli()
     return smart_cli.execute(sys.argv)

--- a/smartsim/_core/_cli/clean.py
+++ b/smartsim/_core/_cli/clean.py
@@ -38,8 +38,10 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         help="Remove all SmartSim non-python dependencies as well",
     )
 
+
 def execute(args: argparse.Namespace) -> int:
     return clean(get_install_path() / "_core", _all=args.clobber)
+
 
 def execute_all(args: argparse.Namespace) -> int:
     args.clobber = True

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -36,6 +36,7 @@ from smartsim._core._cli.clean import execute as clean_execute
 from smartsim._core._cli.clean import execute_all as clobber_execute
 from smartsim._core._cli.dbcli import execute as dbcli_execute
 from smartsim._core._cli.site import execute as site_execute
+from smartsim._core._cli.test import execute as test_execute
 from smartsim._core._cli.utils import MenuItemConfig
 
 
@@ -57,9 +58,9 @@ class SmartCli:
         )
 
         for cmd, item in self.menu.items():
-            parser = subparsers.add_parser(cmd,
-                                           description=item.description,
-                                           help=item.description)
+            parser = subparsers.add_parser(
+                cmd, description=item.description, help=item.description
+            )
             if item.configurator:
                 item.configurator(parser)
 
@@ -95,16 +96,22 @@ def default_cli() -> SmartCli:
         MenuItemConfig(
             "dbcli",
             "Print the path to the redis-cli binary",
-            dbcli_execute
+            dbcli_execute,
         ),
         MenuItemConfig(
             "site",
             "Print the installation site of SmartSim",
-            site_execute),
+            site_execute,
+        ),
         MenuItemConfig(
             "clobber",
             "Remove all previous dependency installations",
-            clobber_execute
+            clobber_execute,
+        ),
+        MenuItemConfig(
+            "test",
+            "Run a simple SmartSim experiment to cofirm that it is built correctly",
+            test_execute,
         ),
     ]
 

--- a/smartsim/_core/_cli/test.py
+++ b/smartsim/_core/_cli/test.py
@@ -1,0 +1,207 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import io
+import tempfile
+import typing as t
+from contextlib import contextmanager
+import socket
+from types import TracebackType
+
+import numpy as np
+from smartredis import Client
+
+from smartsim import Experiment
+from smartsim._core.utils.helpers import installed_redisai_backends
+from smartsim._core._cli.utils import SMART_LOGGER_FORMAT
+from smartsim.log import get_logger
+
+SMART_LOGGER_FORMAT = "[%(name)s] %(levelname)s %(message)s"
+logger = get_logger("Smart", fmt=SMART_LOGGER_FORMAT)
+
+# Many of the functions in this module will import optional
+# ML python packages only if they are needed to test the build is working
+#
+# pylint: disable=import-error,import-outside-toplevel
+# mypy: disable-error-code="import"
+
+
+class _VerificationTempDir(tempfile.TemporaryDirectory):
+    """A Temporary directory to be used as a context manager that will only
+    clean itself up if no error is raised within its context
+    """
+
+    def __exit__(
+        self,
+        exc: t.Optional[t.Type[BaseException]],
+        value: t.Optional[BaseException],
+        tb: t.Optional[TracebackType],
+    ) -> None:
+        if not value:  # Yay, no error! Clean up as normal
+            super().__exit__(exc, value, tb)
+        else:  # Uh-oh! Better make sure this is not implicitly cleaned up
+            self._finalizer.detach()  # type: ignore[attr-defined]
+
+
+def execute(_args: argparse.Namespace, /) -> int:
+    backends = installed_redisai_backends()
+    try:
+        with _VerificationTempDir() as temp_dir:
+            test_install(
+                location=temp_dir,
+                port=None,  # TODO: allow users to pass as arg `--port`?
+                with_tf="tensorflow" in backends,
+                with_pt="torch" in backends,
+                with_onnx="onnxruntime" in backends,
+            )
+    except Exception as e:
+        logger.error(
+            "SmartSim failed to run a simple experiment!\n"
+            f"Experiment failed due to the following exception:\n{e}\n\n"
+            f"Output files are available at `{temp_dir}`"
+        )
+        return 2
+    return 0
+
+
+def test_install(
+    location: str,
+    port: t.Optional[int],
+    with_tf: bool,
+    with_pt: bool,
+    with_onnx: bool,
+) -> None:
+    exp = Experiment("TestExperiment", exp_path=location, launcher="local")
+    port = port or _find_free_port()
+    with _make_managed_local_orc(exp, port) as client:
+        logger.info("Verifying Tensor Transfer")
+        client.put_tensor("plain-tensor", np.ones((1, 1, 3, 3)))
+        client.get_tensor("plain-tensor")
+        if with_tf:
+            logger.info("Verifying TensorFlow Backend")
+            _test_tf_install(client)
+        if with_pt:
+            logger.info("Verifying Torch Backend")
+            _test_torch_install(client)
+        if with_onnx:
+            logger.info("Verifying ONNX Backend")
+            _test_onnx_install(client)
+
+
+@contextmanager
+def _make_managed_local_orc(
+    exp: Experiment, port: int
+) -> t.Generator[Client, None, None]:
+    """Context managed orc that will be stopped if an exception is raised"""
+    orc = exp.create_database(db_nodes=1, interface="lo", port=port)
+    exp.generate(orc)
+    exp.start(orc)
+    try:
+        (client_addr,) = orc.get_address()
+        yield Client(address=client_addr, cluster=False)
+    finally:
+        exp.stop(orc)
+
+
+def _find_free_port() -> int:
+    """A 'good enough' way to find an open port to bind to"""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("0.0.0.0", 0))
+        _, port = sock.getsockname()
+        return port
+
+
+def _test_tf_install(client: Client) -> None:
+    from tensorflow import keras
+
+    from smartsim.ml.tf import serialize_model
+
+    fcn = keras.Sequential(
+        layers=[
+            keras.layers.InputLayer(input_shape=(28, 28), name="input"),
+            keras.layers.Flatten(input_shape=(28, 28), name="flatten"),
+            keras.layers.Dense(128, activation="relu", name="dense"),
+            keras.layers.Dense(10, activation="softmax", name="output"),
+        ],
+        name="FullyConnectedNetwork",
+    )
+    fcn.compile(
+        optimizer="adam", loss="sparse_categorical_crossentropy", metrics=["accuracy"]
+    )
+    model, inputs, outputs = serialize_model(fcn)
+
+    client.set_model(
+        "keras-fcn", model, "TF", device="CPU", inputs=inputs, outputs=outputs
+    )
+    client.put_tensor("keras-input", np.random.rand(1, 28, 28).astype(np.float32))
+    client.run_model("keras-fcn", inputs=["keras-input"], outputs=["keras-output"])
+    client.get_tensor("keras-output")
+
+
+def _test_torch_install(client: Client) -> None:
+    import torch
+    from torch import nn
+
+    class Net(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(1, 1, 3)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.conv(x)
+
+    net = Net()
+    forward_input = torch.rand(1, 1, 3, 3)
+    traced = torch.jit.trace(net, forward_input)  # type: ignore[no-untyped-call]
+    buffer = io.BytesIO()
+    torch.jit.save(traced, buffer)  # type: ignore[no-untyped-call]
+    model = buffer.getvalue()
+
+    client.set_model("torch-nn", model, backend="TORCH", device="CPU")
+    client.put_tensor("torch-in", torch.rand(1, 1, 3, 3).numpy())
+    client.run_model("torch-nn", inputs=["torch-in"], outputs=["torch-out"])
+    client.get_tensor("torch-out")
+
+
+def _test_onnx_install(client: Client) -> None:
+    from skl2onnx import to_onnx
+    from sklearn.cluster import KMeans
+
+    data = np.arange(20, dtype=np.float32).reshape(10, 2)
+    model = KMeans(n_clusters=2)
+    model.fit(data)
+
+    kmeans = to_onnx(model, data, target_opset=11)
+    model = kmeans.SerializeToString()
+    sample = np.arange(20, dtype=np.float32).reshape(10, 2)
+
+    client.put_tensor("onnx-input", sample)
+    client.set_model("onnx-kmeans", model, "ONNX", device="CPU")
+    client.run_model(
+        "onnx-kmeans", inputs=["onnx-input"], outputs=["onnx-labels", "onnx-transform"]
+    )
+    client.get_tensor("onnx-labels")

--- a/smartsim/_core/_cli/utils.py
+++ b/smartsim/_core/_cli/utils.py
@@ -26,14 +26,11 @@
 
 import importlib
 import shutil
-import subprocess
-import sys
 import typing as t
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
 from smartsim._core._install.buildenv import SetupError
-from smartsim._core._install.builder import BuildError
 from smartsim._core.utils import colorize
 from smartsim.log import get_logger
 
@@ -63,32 +60,6 @@ def color_bool(trigger: bool = True) -> str:
     return colorize(str(trigger), color=_color)
 
 
-def pip_install(
-    packages: t.List[str], end_point: t.Optional[str] = None, verbose: bool = False
-) -> None:
-    """Install a pip package to be used in the SmartSim build
-    Currently only Torch shared libraries are re-used for the build
-    """
-    # form pip install command
-    cmd = [sys.executable, "-m", "pip", "install"]
-    cmd.extend(packages)
-    if end_point:
-        cmd.extend(["-f", end_point])
-
-    if verbose:
-        logger.info(f"Installing packages {packages}...")
-    # pylint: disable-next=consider-using-with
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    _, err = proc.communicate()
-    returncode = int(proc.returncode)
-    if returncode != 0:
-        error = f"{packages} installation failed with exitcode {returncode}\n"
-        error += err.decode("utf-8")
-        raise BuildError(error)
-    if verbose:
-        logger.info(f"{packages} installed successfully")
-
-
 def clean(core_path: Path, _all: bool = False) -> int:
     """Remove pre existing installations of ML runtimes
 
@@ -102,7 +73,6 @@ def clean(core_path: Path, _all: bool = False) -> int:
 
     lib_path = core_path / "lib"
     if lib_path.is_dir():
-
         # remove RedisAI
         rai_path = lib_path / "redisai.so"
         if rai_path.is_file():

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -34,6 +34,8 @@ from functools import lru_cache
 from pathlib import Path
 from shutil import which
 
+_TRedisAIBackendStr = t.Literal["tensorflow", "torch", "onnxruntime", "tflite"]
+
 
 def create_lockfile_name() -> str:
     """Generate a unique lock filename using UUID"""
@@ -212,11 +214,14 @@ def _installed(base_path: Path, backend: str) -> bool:
 def redis_install_base(backends_path: t.Optional[str] = None) -> Path:
     # pylint: disable-next=import-outside-toplevel
     from ..._core.config import CONFIG
+
     base_path = Path(backends_path) if backends_path else CONFIG.lib_path / "backends"
     return base_path
 
 
-def installed_redisai_backends(backends_path: t.Optional[str] = None) -> t.List[str]:
+def installed_redisai_backends(
+    backends_path: t.Optional[str] = None,
+) -> t.Set[_TRedisAIBackendStr]:
     """Check which ML backends are available for the RedisAI module.
 
     The optional argument ``backends_path`` is needed if the backends
@@ -229,11 +234,15 @@ def installed_redisai_backends(backends_path: t.Optional[str] = None) -> t.List[
     :param backends_path: path containing backends, defaults to None
     :type backends_path: str, optional
     :return: list of installed RedisAI backends
-    :rtype: list[str]
+    :rtype: set[str]
     """
     # import here to avoid circular import
     base_path = redis_install_base(backends_path)
-    backends = ["tensorflow", "torch", "onnxruntime", "tflite"]
+    backends: t.Set[_TRedisAIBackendStr] = {
+        "tensorflow",
+        "torch",
+        "onnxruntime",
+        "tflite",
+    }
 
-    installed = [backend for backend in backends if _installed(base_path, backend)]
-    return installed
+    return {backend for backend in backends if _installed(base_path, backend)}

--- a/tests/backends/test_cli_mini_exp.py
+++ b/tests/backends/test_cli_mini_exp.py
@@ -1,0 +1,68 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+from contextlib import contextmanager
+
+import smartredis
+
+import smartsim._core._cli.test
+from smartsim._core.utils.helpers import installed_redisai_backends
+
+
+def test_cli_miniexp_doesnt_error_out_with_dev_build(
+    local_db,
+    fileutils,
+    monkeypatch,
+):
+    """Presumably devs running the test suite have built SS correctly.
+    This test runs the "mini-exp" shipped users through the CLI
+    to ensure that it does not accidentally report false positive/negatives
+    """
+
+    @contextmanager
+    def _mock_make_managed_local_orc(*a, **kw):
+        client_addr ,= local_db.get_address()
+        yield smartredis.Client(address=client_addr, cluster=False)
+
+    monkeypatch.setattr(
+        smartsim._core._cli.test,
+        "_make_managed_local_orc",
+        _mock_make_managed_local_orc,
+    )
+    backends = installed_redisai_backends()
+    db_port ,= local_db.ports
+
+    smartsim._core._cli.test.test_install(
+        # Shouldn't matter bc making the managed is stubbed
+        # but best to give it "correct" vals for safety
+        location=fileutils.get_test_dir(),
+        port=db_port,
+        # Test the backends the dev has installed
+        with_tf="tensorflow" in backends,
+        with_pt="torch" in backends,
+        with_onnx="onnxruntime" in backends,
+    )


### PR DESCRIPTION
This PR is a rivial purposal to unify SmartSim optional dependency resolution to #309. This Pr divides the the optional ML dependencies into 2 categories (`[ml-cpu]` and `[ml-cuida]`) to add the additional context needed to know which version of torch to fetch at `pip install` time.

Similar to #309, `smart build` will continue to warn about ML package conflicts if RAI is built in a different context to the installed  ML packages. A new target to the CLI `smart test` has also been added to verify that a user's install of SmartSim is able to run a simple ML experiment.

Since this PR removes the ability to fetch python packages through pip, the `--only_python_packages` flag of `smart build` has been removed.