### PR TITLE
Mitigate suppressed protected-access errors from pylint

### DIFF
--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -636,28 +636,26 @@ class Controller:
 
         for model in manifest.models:
             if not model.colocated:
-                # pylint: disable=protected-access
-                for db_model in model._db_models:
+                for db_model in model.db_models:
                     set_ml_model(db_model, client)
-                for db_script in model._db_scripts:
+                for db_script in model.db_scripts:
                     set_script(db_script, client)
 
         for ensemble in manifest.ensembles:
-            # pylint: disable=protected-access
-            for db_model in ensemble._db_models:
+            for db_model in ensemble.db_models:
                 set_ml_model(db_model, client)
-            for db_script in ensemble._db_scripts:
+            for db_script in ensemble.db_scripts:
                 set_script(db_script, client)
             for entity in ensemble.models:
                 if not entity.colocated:
                     # Set models which could belong only
                     # to the entities and not to the ensemble
                     # but avoid duplicates
-                    for db_model in entity._db_models:
-                        if db_model not in ensemble._db_models:
+                    for db_model in entity.db_models:
+                        if db_model not in ensemble.db_models:
                             set_ml_model(db_model, client)
-                    for db_script in entity._db_scripts:
-                        if db_script not in ensemble._db_scripts:
+                    for db_script in entity.db_scripts:
+                        if db_script not in ensemble.db_scripts:
                             set_script(db_script, client)
 
 

--- a/smartsim/_core/control/manifest.py
+++ b/smartsim/_core/control/manifest.py
@@ -172,12 +172,10 @@ class Manifest:
         """Check if any entity has DBObjects to set"""
 
         def has_db_models(entity: t.Union[EntityList, Model]) -> bool:
-            # pylint: disable=protected-access
-            return len(entity._db_models) > 0
+            return len(list(entity.db_models)) > 0
 
         def has_db_scripts(entity: t.Union[EntityList, Model]) -> bool:
-            # pylint: disable=protected-access
-            return len(entity._db_scripts) > 0
+            return len(list(entity.db_scripts)) > 0
 
         has_db_objects = False
         for model in self.models:

--- a/smartsim/_core/generation/generator.py
+++ b/smartsim/_core/generation/generator.py
@@ -170,7 +170,7 @@ class Generator:
                 mkdir(elist_dir)
             elist.path = elist_dir
 
-            self._gen_entity_dirs(elist.models, entity_list=elist)
+            self._gen_entity_dirs(list(elist.models), entity_list=elist)
 
     def _gen_entity_dirs(
         self,

--- a/smartsim/_core/launcher/step/cobaltStep.py
+++ b/smartsim/_core/launcher/step/cobaltStep.py
@@ -96,8 +96,7 @@ class CobaltBatchStep(Step):
             for opt in self.batch_settings.format_batch_args():
                 script_file.write(f"#COBALT {opt}\n")
 
-            # pylint: disable-next=protected-access
-            for cmd in self.batch_settings._preamble:
+            for cmd in self.batch_settings.preamble:
                 script_file.write(f"{cmd}\n")
 
             for i, cmd in enumerate(self.step_cmds):

--- a/smartsim/_core/launcher/step/pbsStep.py
+++ b/smartsim/_core/launcher/step/pbsStep.py
@@ -90,8 +90,7 @@ class QsubBatchStep(Step):
             for opt in self.batch_settings.format_batch_args():
                 script_file.write(f"#PBS {opt}\n")
 
-            # pylint: disable-next=protected-access
-            for cmd in self.batch_settings._preamble:
+            for cmd in self.batch_settings.preamble:
                 script_file.write(f"{cmd}\n")
 
             for i, cmd in enumerate(self.step_cmds):

--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -94,8 +94,7 @@ class SbatchStep(Step):
             for opt in self.batch_settings.format_batch_args():
                 script_file.write(f"#SBATCH {opt}\n")
 
-            # pylint: disable-next=protected-access
-            for cmd in self.batch_settings._preamble:
+            for cmd in self.batch_settings.preamble:
                 script_file.write(f"{cmd}\n")
 
             for i, cmd in enumerate(self.step_cmds):

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -474,8 +474,6 @@ class Ensemble(EntityList):
 
     @staticmethod
     def _extend_entity_db_models(model: Model, db_models: t.List[DBModel]) -> None:
-        # todo: create ticket to fix the bug allowing dupes (since current_models
-        # is before for-loop, any dupes in input::db_models will propagate)
         entity_db_models = [db_model.name for db_model in model.db_models]
 
         for db_model in db_models:
@@ -484,8 +482,6 @@ class Ensemble(EntityList):
 
     @staticmethod
     def _extend_entity_db_scripts(model: Model, db_scripts: t.List[DBScript]) -> None:
-        # todo: create ticket to fix the bug allowing dupes (since current_scripts
-        # is before for-loop, any dupes in input::db_scripts will propagate)
         entity_db_scripts = [db_script.name for db_script in model.db_scripts]
         for db_script in db_scripts:
             if not db_script.name in entity_db_scripts:

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -103,7 +103,7 @@ class Ensemble(EntityList):
         super().__init__(name, getcwd(), perm_strat=perm_strat, **kwargs)
 
     @property
-    def models(self) -> t.List[Model]:
+    def models(self) -> t.Iterable[Model]:
         """
         Helper property to cast self.entities to Model type for type correctness
         """
@@ -474,16 +474,19 @@ class Ensemble(EntityList):
 
     @staticmethod
     def _extend_entity_db_models(model: Model, db_models: t.List[DBModel]) -> None:
-        # pylint: disable=protected-access
-        entity_db_models = [db_model.name for db_model in model._db_models]
+        # todo: create ticket to fix the bug allowing dupes (since current_models
+        # is before for-loop, any dupes in input::db_models will propagate)
+        entity_db_models = [db_model.name for db_model in model.db_models]
+
         for db_model in db_models:
-            if not db_model.name in entity_db_models:
-                model._append_db_model(db_model)
+            if db_model.name not in entity_db_models:
+                model.add_ml_model_object(db_model)
 
     @staticmethod
     def _extend_entity_db_scripts(model: Model, db_scripts: t.List[DBScript]) -> None:
-        # pylint: disable=protected-access
-        entity_db_scripts = [db_script.name for db_script in model._db_scripts]
+        # todo: create ticket to fix the bug allowing dupes (since current_scripts
+        # is before for-loop, any dupes in input::db_scripts will propagate)
+        entity_db_scripts = [db_script.name for db_script in model.db_scripts]
         for db_script in db_scripts:
             if not db_script.name in entity_db_scripts:
-                model._append_db_script(db_script)
+                model.add_script_object(db_script)

--- a/smartsim/entity/entityList.py
+++ b/smartsim/entity/entityList.py
@@ -27,7 +27,9 @@
 import typing as t
 
 if t.TYPE_CHECKING:
-    import smartsim  # pylint: disable=unused-import
+    # pylint: disable=unused-import
+    import smartsim
+    from smartsim.entity.dbobject import DBModel, DBScript
 
 
 class EntityList:
@@ -44,6 +46,16 @@ class EntityList:
     def _initialize_entities(self, **kwargs: t.Any) -> None:
         """Initialize the SmartSimEntity objects in the container"""
         raise NotImplementedError
+
+    @property
+    def db_models(self) -> t.Iterable[DBModel]:
+        """Return an immutable collection of attached models"""
+        return (model for model in self._db_models)
+
+    @property
+    def db_scripts(self) -> t.Iterable[DBScript]:
+        """Return an immutable collection of attached scripts"""
+        return (script for script in self._db_scripts)
 
     @property
     def batch(self) -> bool:

--- a/smartsim/entity/entityList.py
+++ b/smartsim/entity/entityList.py
@@ -29,7 +29,6 @@ import typing as t
 if t.TYPE_CHECKING:
     # pylint: disable=unused-import
     import smartsim
-    from smartsim.entity.dbobject import DBModel, DBScript
 
 
 class EntityList:
@@ -48,12 +47,12 @@ class EntityList:
         raise NotImplementedError
 
     @property
-    def db_models(self) -> t.Iterable[DBModel]:
+    def db_models(self) -> t.Iterable["smartsim.entity.DBModel"]:
         """Return an immutable collection of attached models"""
         return (model for model in self._db_models)
 
     @property
-    def db_scripts(self) -> t.Iterable[DBScript]:
+    def db_scripts(self) -> t.Iterable["smartsim.entity.DBScript"]:
         """Return an immutable collection of attached scripts"""
         return (script for script in self._db_scripts)
 

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -39,6 +39,7 @@ from .files import EntityFiles
 from ..settings.base import BatchSettings, RunSettings
 from ..log import get_logger
 
+
 logger = get_logger(__name__)
 
 class Model(SmartSimEntity):
@@ -79,6 +80,16 @@ class Model(SmartSimEntity):
         self._db_models: t.List[DBModel] = []
         self._db_scripts: t.List[DBScript] = []
         self.files: t.Optional[EntityFiles] = None
+
+    @property
+    def db_models(self) -> t.Iterable[DBModel]:
+        """Return an immutable collection of attached models"""
+        return (model for model in self._db_models)
+
+    @property
+    def db_scripts(self) -> t.Iterable[DBScript]:
+        """Return an immutable collection attached of scripts"""
+        return (script for script in self._db_scripts)
 
     @property
     def colocated(self) -> bool:
@@ -461,7 +472,7 @@ class Model(SmartSimEntity):
             inputs=inputs,
             outputs=outputs,
         )
-        self._append_db_model(db_model)
+        self.add_ml_model_object(db_model)
 
     def add_script(
         self,
@@ -506,7 +517,7 @@ class Model(SmartSimEntity):
             device=device,
             devices_per_node=devices_per_node,
         )
-        self._append_db_script(db_script)
+        self.add_script_object(db_script)
 
     def add_function(
         self,
@@ -543,7 +554,7 @@ class Model(SmartSimEntity):
         db_script = DBScript(
             name=name, script=function, device=device, devices_per_node=devices_per_node
         )
-        self._append_db_script(db_script)
+        self.add_script_object(db_script)
 
     def __hash__(self) -> int:
         return hash(self.name)
@@ -566,7 +577,7 @@ class Model(SmartSimEntity):
             entity_str += "DB Scripts: \n" + str(len(self._db_scripts)) + "\n"
         return entity_str
 
-    def _append_db_model(self, db_model: DBModel) -> None:
+    def add_ml_model_object(self, db_model: DBModel) -> None:
         if not db_model.is_file and self.colocated:
             err_msg = "ML model can not be set from memory for colocated databases.\n"
             err_msg += (
@@ -577,7 +588,7 @@ class Model(SmartSimEntity):
 
         self._db_models.append(db_model)
 
-    def _append_db_script(self, db_script: DBScript) -> None:
+    def add_script_object(self, db_script: DBScript) -> None:
         if db_script.func and self.colocated:
             if not isinstance(db_script.func, str):
                 err_msg = (

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -657,6 +657,7 @@ class BatchSettings(SettingsBase):
         else:
             raise TypeError("Expected str or List[str] for lines argument")
 
+    @property
     def preamble(self) -> t.Iterable[str]:
         """Return an iterable of preamble clauses to be prepended to the batch file"""
         return (clause for clause in self._preamble)

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -657,6 +657,10 @@ class BatchSettings(SettingsBase):
         else:
             raise TypeError("Expected str or List[str] for lines argument")
 
+    def preamble(self) -> t.Iterable[str]:
+        """Return an iterable of preamble clauses to be prepended to the batch file"""
+        return (clause for clause in self._preamble)
+
     def __str__(self) -> str:  # pragma: no-cover
         string = f"Batch Command: {self._batch_cmd}"
         if self.batch_args:

--- a/tests/test_batch_settings.py
+++ b/tests/test_batch_settings.py
@@ -185,10 +185,10 @@ def test_preamble():
     )
 
     bsub.add_preamble(["single line"])
-    assert len(bsub._preamble) == 1
+    assert len(list(bsub.preamble)) == 1
 
     bsub.add_preamble(["another line"])
-    assert len(bsub._preamble) == 2
+    assert len(list(bsub.preamble)) == 2
 
     bsub.add_preamble(["first line", "last line"])
-    assert len(bsub._preamble) == 4
+    assert len(list(bsub.preamble)) == 4

--- a/tests/test_lsf_settings.py
+++ b/tests/test_lsf_settings.py
@@ -229,7 +229,7 @@ def test_bsub_batch_manual():
     assert formatted == result
     sbatch.add_preamble("module load gcc")
     sbatch.add_preamble(["module load openmpi", "conda activate smartsim"])
-    assert sbatch.preamble == [
+    assert list(sbatch.preamble) == [
         "module load gcc",
         "module load openmpi",
         "conda activate smartsim",

--- a/tests/test_lsf_settings.py
+++ b/tests/test_lsf_settings.py
@@ -229,7 +229,7 @@ def test_bsub_batch_manual():
     assert formatted == result
     sbatch.add_preamble("module load gcc")
     sbatch.add_preamble(["module load openmpi", "conda activate smartsim"])
-    assert sbatch._preamble == [
+    assert sbatch.preamble == [
         "module load gcc",
         "module load openmpi",
         "conda activate smartsim",


### PR DESCRIPTION
Mitigate the following protected-access errors & remove suppression:

1. `EntityList._db_models` -> add `db_models` property returning immutable collection
2. `EntityList._db_scripts` -> add `db_scripts` property returning immutable collection
3. `Model._db_models` -> add `db_models` property returning immutable collection
4. `Model._db_scripts` -> add `db_scripts` property returning immutable collection
5. Add `Model.add_ml_model_object` passthrough to `_append_db_model`
6. Add `EntityList.add_ml_model_object` passthrough to `_append_db_model`
7. `BatchSettings._preamble` -> add `preamble` property returning immutable collection

