### PR TITLE
Integrate PalsMpiexecSettings into Experiment factory methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ _build
 
 smartredis
 
+# Envs
+venv/
+.venv/
+env/
+.env/
+
 # written upon install
 smartsim/version.py
 

--- a/conftest.py
+++ b/conftest.py
@@ -141,19 +141,13 @@ def get_hostlist() -> t.Optional[t.List[str]]:
     if not test_hostlist:
         if "COBALT_NODEFILE" in os.environ:
             try:
-                cobalt_fp = os.environ["COBALT_NODEFILE"]
-                with open(cobalt_fp, "r", encoding="utf-8") as nodefile:
-                    lines = nodefile.readlines()
-                    test_hostlist = list({line.strip() for line in lines})
-            except Exception:
+                return _parse_hostlist_file(os.environ["COBALT_NODEFILE"])
+            except FileNotFoundError:
                 return None
         elif "PBS_NODEFILE" in os.environ and not shutil.which("aprun"):
             try:
-                pbs_fp = os.environ["PBS_NODEFILE"]
-                with open(pbs_fp, "r", encoding="utf-8") as nodefile:
-                    lines = nodefile.readlines()
-                    test_hostlist = list({line.strip() for line in lines})
-            except Exception:
+                return _parse_hostlist_file(os.environ["PBS_NODEFILE"])
+            except FileNotFoundError:
                 return None
         elif "SLURM_JOB_NODELIST" in os.environ:
             try:
@@ -167,6 +161,11 @@ def get_hostlist() -> t.Optional[t.List[str]]:
             except Exception:
                 return None
     return test_hostlist
+
+
+def _parse_hostlist_file(path: str) -> t.List[str]:
+    with open(path, "r", encoding="utf-8") as nodefile:
+        return list({line.strip() for line in nodefile.readlines()})
 
 
 @pytest.fixture(scope="session")

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -258,6 +258,7 @@ class Controller:
         launcher_map: t.Dict[str, t.Type[Launcher]] = {
             "slurm": SlurmLauncher,
             "pbs": PBSLauncher,
+            "pals": PBSLauncher,
             "cobalt": CobaltLauncher,
             "lsf": LSFLauncher,
             "local": LocalLauncher,
@@ -387,7 +388,7 @@ class Controller:
     def _launch_step(
         self, job_step: Step, entity: t.Union[SmartSimEntity, EntityList]
     ) -> None:
-        """Use the launcher to launch a job stop
+        """Use the launcher to launch a job step
 
         :param job_step: a job step instance
         :type job_step: Step

--- a/smartsim/_core/launcher/launcher.py
+++ b/smartsim/_core/launcher/launcher.py
@@ -110,9 +110,10 @@ class WLMLauncher(Launcher):  # cov-wlm
             raise SSUnsupportedError(
                 f"RunSettings type {type(step_settings)} not supported by this launcher"
             ) from None
+        try:
+            return step_class(name, cwd, step_settings)
         except AllocationError as e:
             raise LauncherError("Step creation failed") from e
-        return step_class(name, cwd, step_settings)
 
     # these methods are implemented in WLM launchers and
     # don't need to be covered here.

--- a/smartsim/_core/launcher/launcher.py
+++ b/smartsim/_core/launcher/launcher.py
@@ -105,16 +105,14 @@ class WLMLauncher(Launcher):  # cov-wlm
         :rtype: Step
         """
         try:
-            settings_class = step_settings.__class__
-            if settings_class in self.supported_rs:
-                step_class = self.supported_rs[settings_class]
-                step = step_class(name, cwd, step_settings)
-                return step
+            step_class = self.supported_rs[type(step_settings)]
+        except KeyError:
             raise SSUnsupportedError(
                 f"RunSettings type {type(step_settings)} not supported by this launcher"
-            )
+            ) from None
         except AllocationError as e:
             raise LauncherError("Step creation failed") from e
+        return step_class(name, cwd, step_settings)
 
     # these methods are implemented in WLM launchers and
     # don't need to be covered here.
@@ -123,12 +121,6 @@ class WLMLauncher(Launcher):  # cov-wlm
         self, step_names: t.List[str]
     ) -> t.List[t.List[str]]:  # pragma: no cover
         raise SSUnsupportedError("Node acquisition not supported for this launcher")
-
-    def run(self, step: Step) -> t.Optional[str]:  # pragma: no cover
-        raise NotImplementedError
-
-    def stop(self, step_name: str) -> StepInfo:  # pragma: no cover
-        raise NotImplementedError
 
     def get_step_update(
         self, step_names: t.List[str]

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -64,6 +64,7 @@ logger = get_logger(__name__)
 by_launcher: t.Dict[str, t.List[str]] = {
     "slurm": ["srun", "mpirun", "mpiexec"],
     "pbs": ["aprun", "mpirun", "mpiexec"],
+    "pals": ["mpiexec"],
     "cobalt": ["aprun", "mpirun", "mpiexec"],
     "lsf": ["jsrun"],
     "local": [""],

--- a/smartsim/settings/palsSettings.py
+++ b/smartsim/settings/palsSettings.py
@@ -58,7 +58,6 @@ class PalsMpiexecSettings(_BaseMPISettings):
         self,
         exe: str,
         exe_args: t.Optional[t.Union[str, t.List[str]]] = None,
-        run_command: str = "mpiexec",
         run_args: t.Optional[t.Dict[str, t.Union[int, str, float, None]]] = None,
         env_vars: t.Optional[t.Dict[str, t.Optional[str]]] = None,
         fail_if_missing_exec: bool = True,
@@ -89,7 +88,7 @@ class PalsMpiexecSettings(_BaseMPISettings):
         super().__init__(
             exe,
             exe_args,
-            run_command=run_command,
+            run_command="mpiexec",
             run_args=run_args,
             env_vars=env_vars,
             fail_if_missing_exec=fail_if_missing_exec,

--- a/tests/test_configs/mpi_impl_stubs/pals/mpiexec
+++ b/tests/test_configs/mpi_impl_stubs/pals/mpiexec
@@ -26,7 +26,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Based on running mpiexec.slurm without loading a specific MPI
-# implementation 
+# Stub executable to print out a generic PALS ``mpiexec --version`` message
 
 echo "mpiexec version 1.2.12 revision d3dd612f9372 built Apr 12 2023"

--- a/tests/test_configs/mpi_impl_stubs/pals/mpiexec
+++ b/tests/test_configs/mpi_impl_stubs/pals/mpiexec
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Based on running mpiexec.slurm without loading a specific MPI
+# implementation 
+
+echo "mpiexec version 1.2.12 revision d3dd612f9372 built Apr 12 2023"

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -24,6 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import contextlib
 
 import pytest
 
@@ -154,15 +155,12 @@ def test_summary(fileutils):
     assert 0 == int(row["RunID"])
     assert 0 == int(row["Returncode"])
 
+def test_launcher_detection(wlmutils, monkeypatch):
+    if wlmutils.get_test_launcher() == "pals":
+        pytest.skip(reason="Launcher detection cannot currently detect pbs vs pals")
+    if wlmutils.get_test_launcher() == "local":
+        monkeypatch.setenv("PATH", "")  # Remove all WLMs from PATH
 
-def test_launcher_detection(wlmutils):
     exp = Experiment("test-launcher-detection", launcher="auto")
 
-    # We check whether the right launcher is found. But if
-    # the test launcher was set to local, we tolerate finding
-    # another one (this cannot be avoided)
-    if (
-        exp._launcher != wlmutils.get_test_launcher()
-        and wlmutils.get_test_launcher() != "local"
-    ):
-        assert False
+    assert exp._launcher == wlmutils.get_test_launcher()


### PR DESCRIPTION
Registers the `PalsMpiexecSettings` class in SmartsSim's `Experiment` factory methods so that the correct `_BaseMpiSettings` class is returned depending on the launcher the user is intending to use:
```py
>>> pbs_exp = Experiment(launcher="pbs", ...)
>>> rs_1 = pbs_exp.create_run_settings(run_command="mpiexec", ...)
>>> type(rs_1)  # returns a OpenMPI compliant RunSettings
<smartsim.settings.mpiSettings.MpiexecSettings object at 0x7f9fe02eee00>
>>> pals_exp = Experiment(launcher="pals", ...)
>>> rs_2 = pals_exp.create_run_settings(run_command="mpiexec", ...)
>>> type(rs_2)  # returns a PALS compliant RunSettings
<smartsim.settings.palsSettings.PalsMpiexecSettings object at 0x7f9fdaf6f1c0>
```