### PR TITLE
Remove ensemble generation from DB Object tests

### DIFF
--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -585,8 +585,6 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
         outputs=outputs2,
     )
 
-    exp.generate(colo_ensemble, overwrite=True)
-
     # Launch and check successful completion
     try:
         exp.start(colo_ensemble, block=True)
@@ -687,8 +685,6 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
         inputs=inputs2,
         outputs=outputs2,
     )
-
-    exp.generate(colo_ensemble, overwrite=True)
 
     # Launch and check successful completion
     try:

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -369,8 +369,6 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
     # Assert we have added both models to each entity
     assert all([len(entity._db_scripts) == 2 for entity in colo_ensemble])
 
-    exp.generate(colo_ensemble, overwrite=True)
-
     # Launch and check successful completion
     try:
         exp.start(colo_ensemble, block=True)
@@ -386,7 +384,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
     script to the ensemble, then colocating the DB"""
 
     # Set Experiment name
-    exp_name = "test-colocated-db-script"
+    exp_name = "test-colocated-db-script-reord"
 
     # Retrieve parameters from testing environment
     test_launcher = wlmutils.get_test_launcher()
@@ -465,8 +463,6 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
     assert len(colo_ensemble._db_scripts) == 1
     # Assert we have added both models to each entity
     assert all([len(entity._db_scripts) == 2 for entity in colo_ensemble])
-
-    exp.generate(colo_ensemble, overwrite=True)
 
     # Launch and check successful completion
     try:


### PR DESCRIPTION
This PR is a quick bugfix. In the DB Object tests (bot DB scripts and DB models), we are currently calling `exp.generate` for some ensembles, but that is not needed, as they are automatically generated in the exp path.

While this PR fixes the test output path issue, there remains an issue with the generation of ensembles: the path should be honored. I will put up a different ticket for that issue.
