### PR TITLE
Send shutdown command to DB

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -596,8 +596,8 @@ class FileUtils:
         :type caller_function: str, optional
         :param caller_fspath: absolute path to file containing caller, defaults to None
         :type caller_fspath: str or Path, optional
-        :param level: indicate depth in the call stack relative to test method. 
-        :type level: int, optional 
+        :param level: indicate depth in the call stack relative to test method.
+        :type level: int, optional
         :param sub_dir: a relative path to create in the test directory
         :type sub_dir: str or Path, optional
 

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -36,27 +36,26 @@ import typing as t
 from smartredis import Client
 
 from ..._core.launcher.step import Step
-from ..._core.utils.redis import db_is_active, set_ml_model, set_script
+from ..._core.utils.redis import db_is_active, set_ml_model, set_script, shutdown_db
 from ...database import Orchestrator
-from ...entity import EntityList, SmartSimEntity, Model, Ensemble
+from ...entity import Ensemble, EntityList, Model, SmartSimEntity
 from ...error import LauncherError, SmartSimError, SSInternalError, SSUnsupportedError
 from ...log import get_logger
-from ...status import STATUS_RUNNING, TERMINAL_STATUSES
+from ...settings.base import BatchSettings
+from ...status import STATUS_CANCELLED, STATUS_RUNNING, TERMINAL_STATUSES
 from ..config import CONFIG
 from ..launcher import (
-    SlurmLauncher,
-    PBSLauncher,
-    LocalLauncher,
     CobaltLauncher,
+    LocalLauncher,
     LSFLauncher,
+    PBSLauncher,
+    SlurmLauncher,
 )
 from ..launcher.launcher import Launcher
 from ..utils import check_cluster_status, create_cluster
+from .job import Job
 from .jobmanager import JobManager
 from .manifest import Manifest
-from .job import Job
-from ...settings.base import BatchSettings
-
 
 logger = get_logger(__name__)
 
@@ -188,6 +187,21 @@ class Controller:
                     output=status.output,
                 )
                 self._jobs.move_to_completed(job)
+
+    def stop_db(self, db: Orchestrator) -> None:
+        """Stop an orchestrator
+        :param db: orchestrator to be stopped
+        :type db: Orchestrator
+        """
+        if db.batch:
+            self.stop_entity(db)
+        else:
+            shutdown_db(db.hosts, db.ports)
+            with JM_LOCK:
+                for entity in db:
+                    job = self._jobs[entity.name]
+                    job.set_status(STATUS_CANCELLED, "", 0, output=None, error=None)
+                    self._jobs.move_to_completed(job)
 
     def stop_entity_list(self, entity_list: EntityList) -> None:
         """Stop an instance of an entity list
@@ -550,7 +564,7 @@ class Controller:
                     # TODO remove in favor of by node status check
                     time.sleep(CONFIG.jm_interval)
                 elif any(stat in TERMINAL_STATUSES for stat in statuses):
-                    self.stop_entity_list(orchestrator)
+                    self.stop_db(orchestrator)
                     msg = "Orchestrator failed during startup"
                     msg += f" See {orchestrator.path} for details"
                     raise SmartSimError(msg)
@@ -558,7 +572,7 @@ class Controller:
                     logger.debug("Waiting for orchestrator instances to spin up...")
             except KeyboardInterrupt:
                 logger.info("Orchestrator launch cancelled - requesting to stop")
-                self.stop_entity_list(orchestrator)
+                self.stop_db(orchestrator)
 
                 # re-raise keyboard interrupt so the job manager will display
                 # any running and un-killed jobs as this method is only called

--- a/smartsim/_core/utils/redis.py
+++ b/smartsim/_core/utils/redis.py
@@ -218,7 +218,7 @@ def set_script(db_script: DBScript, client: Client) -> None:
 
 def shutdown_db(hosts: t.List[str], ports: t.List[int]) -> None:  # cov-wlm
     """Send shutdown signal to cluster instances.
-    
+
     Should only be used in the case where cluster deallocation
     needs to occur manually. Usually, the SmartSim task manager
     will take care of this automatically.

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -407,6 +407,13 @@ class Orchestrator(EntityList):
         if self.launcher == "lsf":
             for db in self.dbnodes:
                 db.set_hosts(host_list)
+        elif (self.launcher == "pals"
+              and isinstance(self.dbnodes[0].run_settings, PalsMpiexecSettings)
+              and self.dbnodes[0].is_mpmd
+              and hasattr(self.dbnodes[0].run_settings, "mpmd")):
+            # In this case, --hosts is a global option, we only set it to the
+            # first run command
+            self.dbnodes[0].run_settings.set_hostlist(host_list)
         else:
             for host, db in zip(host_list, self.dbnodes):
                 if isinstance(db.run_settings, AprunSettings):

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -409,8 +409,7 @@ class Orchestrator(EntityList):
                 db.set_hosts(host_list)
         elif (self.launcher == "pals"
               and isinstance(self.dbnodes[0].run_settings, PalsMpiexecSettings)
-              and self.dbnodes[0].is_mpmd
-              and hasattr(self.dbnodes[0].run_settings, "mpmd")):
+              and self.dbnodes[0].is_mpmd):
             # In this case, --hosts is a global option, we only set it to the
             # first run command
             self.dbnodes[0].run_settings.set_hostlist(host_list)

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -220,12 +220,15 @@ class Experiment:
         :raises TypeError: if wrong type
         :raises SmartSimError: if stop request fails
         """
+        stop_manifest = Manifest(*args)
         try:
-            stop_manifest = Manifest(*args)
             for entity in stop_manifest.models:
                 self._control.stop_entity(entity)
-            for entity_list in stop_manifest.all_entity_lists:
+            for entity_list in stop_manifest.ensembles:
                 self._control.stop_entity_list(entity_list)
+            db = stop_manifest.db
+            if db:
+                self._control.stop_db(db)
         except SmartSimError as e:
             logger.error(e)
             raise

--- a/smartsim/settings/palsSettings.py
+++ b/smartsim/settings/palsSettings.py
@@ -221,3 +221,20 @@ class PalsMpiexecSettings(_BaseMPISettings):
             formatted += ["--envlist", ",".join(export_vars)]
 
         return formatted
+
+    def set_hostlist(self, host_list: t.Union[str, t.List[str]]) -> None:
+        """Set the hostlist for the PALS ``mpirun`` command
+
+        This sets ``--hosts``
+
+        :param host_list: list of host names
+        :type host_list: str | list[str]
+        :raises TypeError: if not str or list of str
+        """
+        if isinstance(host_list, str):
+            host_list = [host_list.strip()]
+        if not isinstance(host_list, list):
+            raise TypeError("host_list argument must be a list of strings")
+        if not all(isinstance(host, str) for host in host_list):
+            raise TypeError("host_list argument must be list of strings")
+        self.run_args["hosts"] = ",".join(host_list)

--- a/smartsim/settings/palsSettings.py
+++ b/smartsim/settings/palsSettings.py
@@ -223,7 +223,7 @@ class PalsMpiexecSettings(_BaseMPISettings):
         return formatted
 
     def set_hostlist(self, host_list: t.Union[str, t.List[str]]) -> None:
-        """Set the hostlist for the PALS ``mpirun`` command
+        """Set the hostlist for the PALS ``mpiexec`` command
 
         This sets ``--hosts``
 

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -804,7 +804,7 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
 @pytest.mark.skipif(not should_run_tf, reason="Test needs TensorFlow to run")
 def test_inconsistent_params_db_model():
     """Test error when devices_per_node parameter>1 when devices is set to CPU in DBModel"""
-    
+
     # Create and save ML model to filesystem
     model, inputs, outputs = create_tf_cnn()
     with pytest.raises(SSUnsupportedError) as ex:
@@ -819,6 +819,6 @@ def test_inconsistent_params_db_model():
             outputs=outputs,
         )
     assert (
-            ex.value.args[0] 
+            ex.value.args[0]
             == "Cannot set devices_per_node>1 if CPU is specified under devices"
         )

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -31,12 +31,11 @@ import pytest
 
 from smartsim import Experiment, status
 from smartsim._core.utils import installed_redisai_backends
-from smartsim.entity import ensemble
+from smartsim.entity import Ensemble
 from smartsim.error.errors import SSUnsupportedError
 from smartsim.log import get_logger
 
 from smartsim.entity.dbobject import DBModel
-from smartsim.settings.palsSettings import PalsMpiexecSettings
 
 logger = get_logger(__name__)
 
@@ -529,7 +528,7 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
     colo_settings.set_tasks_per_node(1)
 
     # Create ensemble of two identical models
-    colo_ensemble: ensemble.Ensemble = exp.create_ensemble(
+    colo_ensemble: Ensemble = exp.create_ensemble(
         "colocated_ens", run_settings=colo_settings, replicas=2
     )
     colo_ensemble.set_path(test_dir)

--- a/tests/test_configs/cov/local_cov.cfg
+++ b/tests/test_configs/cov/local_cov.cfg
@@ -6,6 +6,7 @@ omit =
   *mpirun*
   *alps*
   *lsf*
+  *pals*
   *redis_starter.py*
   */_cli/*
   */_install/*
@@ -47,3 +48,4 @@ exclude_lines=
   launcher == "pbs"
   launcher == "cobalt"
   launcher == "lsf"
+  launcher == "pals"


### PR DESCRIPTION
This PR changes the way `Orchestrator`s are stopped.

Currently, the `Orchestrator` process or job is simply killed: this proved not to be a good technique with some WLMs, where the launcher and the launched process are different. In such cases, it is impossible to stop a running process and orchestrators stay up until the allocation is relinquished.

With this PR, we added the execution of an explicit `shutdown` command for each DB shard, which properly terminates the Orchestrator in all cases.

A few tweaks to the current test suite were also implemented as part of this PR, to make sure that executing them through `mpiexec` on some systems did not fail.