### PR TITLE
Remove references in docs to nonexistent CLI flag

### DIFF
--- a/doc/installation_instructions/site-install.rst
+++ b/doc/installation_instructions/site-install.rst
@@ -12,4 +12,3 @@ from source with the following steps replacing ``COMPILER_VERSION`` and
     module use -a /lus/scratch/smartsim/local/modulefiles
     module load cudatoolkit/11.8 cudnn smartsim-deps/COMPILER_VERSION/SMARTSIM_VERSION
     pip install smartsim[ml-cuda]
-    smart build --only_python_packages --device gpu [--onnx]

--- a/tutorials/ml_inference/Inference-in-SmartSim.ipynb
+++ b/tutorials/ml_inference/Inference-in-SmartSim.ipynb
@@ -38,7 +38,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['tensorflow', 'torch', 'onnxruntime']\n"
+      "{'torch'}\n"
      ]
     }
    ],
@@ -49,35 +49,57 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "e4b21b41-bd2d-412f-b8a7-8011b154d23b",
+   "id": "609884f5-37a0-4559-ad0b-cf3ae65463cb",
    "metadata": {},
    "source": [
     "As you can see, only the Torch backend is built. In order to use the TensorFlow and ONNX backends as well, they need to be built.\n",
     "\n",
-    "The `smart` command line interface can be used to build the backends using the `smart build` command. The output of `smart build --help` is shown below.\n",
-    "\n",
-    "\n",
-    "```text\n",
-    "usage: smart [-h] [-v] [--device DEVICE] [--no_pt] [--no_tf] [--onnx] [--torch_dir TORCH_DIR] [--libtensorflow_dir LIBTENSORFLOW_DIR] [--only_python_packages] [--keydb]\n",
-    "\n",
-    "optional arguments:\n",
-    "  -h, --help            show this help message and exit\n",
-    "  -v                    Enable verbose build process\n",
-    "  --device DEVICE       Device to build ML runtimes for (cpu || gpu)\n",
-    "  --no_pt               Do not build PyTorch backend\n",
-    "  --no_tf               Do not build TensorFlow backend\n",
-    "  --onnx                Build ONNX backend (off by default)\n",
-    "  --torch_dir TORCH_DIR\n",
-    "                        Path to custom <path>/torch/share/cmake/Torch/ directory (ONLY USE IF NEEDED)\n",
-    "  --libtensorflow_dir LIBTENSORFLOW_DIR\n",
-    "                        Path to custom libtensorflow directory (ONLY USED IF NEEDED)\n",
-    "  --only_python_packages\n",
-    "                        If true, only install the python packages (i.e. skip backend builds)\n",
-    "  --keydb               Build KeyDB instead of Redis\n",
-    "```\n",
-    "\n",
+    "The `smart` command line interface can be used to build the backends using the `smart build` command. The output of `smart build --help` is shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a8efd39b-7517-4220-9419-4fb82918e182",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: smart build [-h] [-v] [--device {cpu,gpu}] [--no_pt] [--no_tf] [--onnx]\n",
+      "                   [--torch_dir TORCH_DIR]\n",
+      "                   [--libtensorflow_dir LIBTENSORFLOW_DIR] [--keydb]\n",
+      "\n",
+      "Build SmartSim dependencies (Redis, RedisAI, ML runtimes)\n",
+      "\n",
+      "optional arguments:\n",
+      "  -h, --help            show this help message and exit\n",
+      "  -v                    Enable verbose build process\n",
+      "  --device {cpu,gpu}    Device to build ML runtimes for\n",
+      "  --no_pt               Do not build PyTorch backend\n",
+      "  --no_tf               Do not build TensorFlow backend\n",
+      "  --onnx                Build ONNX backend (off by default)\n",
+      "  --torch_dir TORCH_DIR\n",
+      "                        Path to custom <path>/torch/share/cmake/Torch/\n",
+      "                        directory (ONLY USE IF NEEDED)\n",
+      "  --libtensorflow_dir LIBTENSORFLOW_DIR\n",
+      "                        Path to custom libtensorflow directory (ONLY USE IF\n",
+      "                        NEEDED)\n",
+      "  --keydb               Build KeyDB instead of Redis\n"
+     ]
+    }
+   ],
+   "source": [
+    "!smart build --help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34a6c6f7-b4f5-4e8a-82a7-c3d8376e3374",
+   "metadata": {},
+   "source": [
     "We use `smart clean` first to remove the previous build, and then call `smart build` to build the new backend set. For larger teams, CrayLabs will help setup your system so that the backends do not have to be built by each user.\n",
     "\n",
     "By default, the PyTorch and TensorFlow backends are built. To build all three backends for use on CPU, we issue the following command."
@@ -85,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "a6d157cf-1d2c-49d0-a588-ec99506661fb",
    "metadata": {
     "tags": []
@@ -95,10 +117,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m Successfully removed existing RedisAI installation\n",
+      "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m Successfully removed ML runtimes\n",
       "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m Running SmartSim build process...\n",
       "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m Checking requested versions...\n",
       "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m Checking for build tools...\n",
-      "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m Building Redis version 7.0.5 from https://github.com/redis/redis.git/\n",
       "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m Redis build complete!\n",
       "\n",
       "ML Backends Requested\n",
@@ -110,8 +133,6 @@
       "\n",
       "Building for GPU support: \u001b[31mFalse\u001b[0m\n",
       "\n",
-      "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m ONNX 1.11.0 installed in Python environment\n",
-      "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m TensorFlow 2.8.0 installed in Python environment\n",
       "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m Building RedisAI version 1.2.7 from https://github.com/RedisAI/RedisAI.git/\n",
       "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m ML Backends and RedisAI build complete!\n",
       "\u001b[34m[SmartSim]\u001b[0m \u001b[1;30mINFO\u001b[0m Tensorflow, Torch, Onnxruntime backend(s) built\n",
@@ -158,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "201b9c43-f3e9-476c-ac21-e45f2c621b00",
    "metadata": {
     "tags": []
@@ -179,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "1df7ff13-e292-4c68-a99c-d0b5491be079",
    "metadata": {
     "tags": []
@@ -191,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "7364dbdf-52bf-4107-be3a-78fb541449f8",
    "metadata": {
     "tags": []
@@ -220,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "dde172d9-4f18-4adc-8e78-fc6f71fb405c",
    "metadata": {
     "tags": []
@@ -273,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "e5aa5995-d250-46c4-87f0-0115112560ae",
    "metadata": {
     "tags": []
@@ -317,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "9bdabc3d-31cc-47fc-853b-94fffaa2bf10",
    "metadata": {
     "tags": []
@@ -327,48 +348,48 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SmartRedis Library@14-11-03:WARNING: Environment variable SR_LOG_FILE is not set. Defaulting to stdout\n",
-      "Prediction: [[-2.2562506 -2.2950497 -2.3529804 -2.2746763 -2.3059285 -2.320581\n",
-      "  -2.3129795 -2.2921813 -2.2667074 -2.3534772]\n",
-      " [-2.2778108 -2.2807806 -2.3440359 -2.2767324 -2.2972894 -2.3190188\n",
-      "  -2.3278549 -2.2990303 -2.2504287 -2.357964 ]\n",
-      " [-2.2509592 -2.2798455 -2.352317  -2.2709332 -2.2944198 -2.3347063\n",
-      "  -2.31502   -2.295071  -2.2750957 -2.3636808]\n",
-      " [-2.2574742 -2.3119466 -2.341312  -2.2681162 -2.2946122 -2.3242433\n",
-      "  -2.3163285 -2.291332  -2.2670102 -2.3584895]\n",
-      " [-2.2486675 -2.2828228 -2.364878  -2.2737098 -2.2939532 -2.3366425\n",
-      "  -2.310018  -2.3005655 -2.2670708 -2.354104 ]\n",
-      " [-2.250141  -2.2770994 -2.347671  -2.285967  -2.2989845 -2.328689\n",
-      "  -2.326967  -2.2856352 -2.2700524 -2.360473 ]\n",
-      " [-2.252362  -2.280783  -2.3437886 -2.2762692 -2.2992115 -2.3580222\n",
-      "  -2.2964714 -2.294584  -2.2730415 -2.3575144]\n",
-      " [-2.245837  -2.291739  -2.3584027 -2.2776399 -2.3066337 -2.3340435\n",
-      "  -2.311736  -2.2895567 -2.2612221 -2.3554478]\n",
-      " [-2.2459865 -2.2996356 -2.3338506 -2.2898607 -2.307685  -2.3346071\n",
-      "  -2.317905  -2.2980561 -2.2540336 -2.3493562]\n",
-      " [-2.2529087 -2.2930403 -2.3512032 -2.2746456 -2.3106043 -2.3295555\n",
-      "  -2.3155272 -2.2894013 -2.266762  -2.3472543]\n",
-      " [-2.2470036 -2.2729688 -2.3551106 -2.2901294 -2.3002434 -2.3366578\n",
-      "  -2.3215086 -2.2929873 -2.2667813 -2.3483925]\n",
-      " [-2.2669973 -2.2873788 -2.3541908 -2.2601023 -2.3011842 -2.3344467\n",
-      "  -2.317483  -2.2981677 -2.262123  -2.3492858]\n",
-      " [-2.248778  -2.2711487 -2.361583  -2.281018  -2.2996755 -2.329846\n",
-      "  -2.303838  -2.290069  -2.2745905 -2.3724496]\n",
-      " [-2.2402549 -2.293449  -2.3698947 -2.2756062 -2.3105242 -2.3360207\n",
-      "  -2.308645  -2.2851708 -2.2589154 -2.3550522]\n",
-      " [-2.2549288 -2.2770593 -2.3560512 -2.2750719 -2.3047006 -2.3511765\n",
-      "  -2.3033142 -2.294156  -2.2598014 -2.35641  ]\n",
-      " [-2.2542276 -2.3017535 -2.3593512 -2.2741785 -2.2967863 -2.3129532\n",
-      "  -2.319975  -2.298303  -2.254031  -2.3605437]\n",
-      " [-2.2508793 -2.2827387 -2.3540049 -2.2797506 -2.310697  -2.335204\n",
-      "  -2.3206584 -2.2922928 -2.254721  -2.3511233]\n",
-      " [-2.2455313 -2.2917545 -2.3378956 -2.2886634 -2.3040054 -2.3280408\n",
-      "  -2.3194091 -2.2834039 -2.2780685 -2.3537478]\n",
-      " [-2.2425911 -2.297682  -2.3607512 -2.280452  -2.2881193 -2.3200488\n",
-      "  -2.3227687 -2.283992  -2.2834902 -2.351714 ]\n",
-      " [-2.2554607 -2.3006012 -2.35251   -2.2741659 -2.308275  -2.327199\n",
-      "  -2.3138812 -2.29302   -2.2611406 -2.3445244]]\n",
-      "SmartRedis Library@14-11-03:WARNING: Environment variable SR_LOG_LEVEL is not set. Defaulting to INFO\n"
+      "SmartRedis Library@16-54-13:WARNING: Environment variable SR_LOG_FILE is not set. Defaulting to stdout\n",
+      "SmartRedis Library@16-54-13:WARNING: Environment variable SR_LOG_LEVEL is not set. Defaulting to INFO\n",
+      "Prediction: [[-2.2478018 -2.395631  -2.2669961 -2.400009  -2.2728784 -2.27591\n",
+      "  -2.2906797 -2.3545692 -2.2261484 -2.3114305]\n",
+      " [-2.2480786 -2.3842168 -2.2628386 -2.403884  -2.2832446 -2.2860255\n",
+      "  -2.2994099 -2.375429  -2.2036932 -2.2975397]\n",
+      " [-2.245448  -2.389964  -2.268176  -2.4029608 -2.280573  -2.2878091\n",
+      "  -2.2937536 -2.3574357 -2.2161047 -2.3001926]\n",
+      " [-2.2418973 -2.3858    -2.2578824 -2.3933666 -2.2973359 -2.2910569\n",
+      "  -2.2984695 -2.3671184 -2.2083244 -2.301574 ]\n",
+      " [-2.2591636 -2.3932264 -2.2583983 -2.3987677 -2.2713947 -2.2846944\n",
+      "  -2.3082988 -2.3607285 -2.2154033 -2.2924812]\n",
+      " [-2.2580602 -2.3792613 -2.272383  -2.4011228 -2.272388  -2.2694292\n",
+      "  -2.3032012 -2.365895  -2.2177567 -2.3020668]\n",
+      " [-2.245951  -2.3920639 -2.2689075 -2.407091  -2.267692  -2.2859006\n",
+      "  -2.3037941 -2.3703804 -2.2084582 -2.29459  ]\n",
+      " [-2.253354  -2.3911812 -2.2643569 -2.4074526 -2.285964  -2.2871246\n",
+      "  -2.2955043 -2.375829  -2.2028425 -2.2816033]\n",
+      " [-2.2477372 -2.380954  -2.2610688 -2.392686  -2.282587  -2.2853549\n",
+      "  -2.296441  -2.3648849 -2.2207007 -2.3085098]\n",
+      " [-2.2393162 -2.3921392 -2.2663367 -2.4068065 -2.2845395 -2.290668\n",
+      "  -2.284157  -2.3662543 -2.2121382 -2.3019514]\n",
+      " [-2.2408657 -2.384463  -2.2651308 -2.4005342 -2.2722073 -2.287395\n",
+      "  -2.3110955 -2.3697157 -2.2028828 -2.3101122]\n",
+      " [-2.2389345 -2.390637  -2.2625332 -2.4023867 -2.2838216 -2.289138\n",
+      "  -2.3047955 -2.3756099 -2.2034433 -2.2940078]\n",
+      " [-2.2369158 -2.3936262 -2.2521482 -2.4033504 -2.2768025 -2.2861629\n",
+      "  -2.316517  -2.3730042 -2.210685  -2.296432 ]\n",
+      " [-2.2388594 -2.3964899 -2.26673   -2.4088354 -2.2696297 -2.287068\n",
+      "  -2.3139803 -2.3763204 -2.1987703 -2.290656 ]\n",
+      " [-2.237903  -2.3903239 -2.2650957 -2.4093916 -2.27383   -2.2950318\n",
+      "  -2.299792  -2.3679557 -2.2050626 -2.3010159]\n",
+      " [-2.2392526 -2.4035661 -2.2502809 -2.4051485 -2.279354  -2.2831054\n",
+      "  -2.3016942 -2.3732626 -2.2127666 -2.297947 ]\n",
+      " [-2.2445319 -2.3949418 -2.2569892 -2.414155  -2.268012  -2.2846045\n",
+      "  -2.3016362 -2.3772373 -2.2142422 -2.289995 ]\n",
+      " [-2.2507832 -2.3926392 -2.2597246 -2.40416   -2.2814076 -2.2869318\n",
+      "  -2.2988138 -2.37261   -2.2073905 -2.29012  ]\n",
+      " [-2.249173  -2.3990614 -2.257255  -2.3995957 -2.2756734 -2.2913516\n",
+      "  -2.3009257 -2.3622444 -2.2111323 -2.2974997]\n",
+      " [-2.2522578 -2.3874125 -2.2524507 -2.411776  -2.2802238 -2.2815466\n",
+      "  -2.2947848 -2.3739164 -2.2161126 -2.2940607]]\n"
      ]
     }
    ],
@@ -420,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "267405bf-3144-4219-a82b-15be10cf5125",
    "metadata": {
     "tags": []
@@ -434,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "2e85ced9-e39a-4efb-91db-3919aa4e9489",
    "metadata": {
     "tags": []
@@ -444,46 +465,46 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "U: [[[-0.3603251   0.9078608 ]\n",
-      "  [-0.931906   -0.36054417]\n",
-      "  [-0.04143937  0.21400304]]\n",
+      "U: [[[-0.6023696   0.07311916]\n",
+      "  [-0.49197382 -0.8181777 ]\n",
+      "  [-0.62857985  0.5702971 ]]\n",
       "\n",
-      " [[-0.5435925   0.24445276]\n",
-      "  [-0.41486043 -0.9098768 ]\n",
-      "  [-0.7296559   0.3352117 ]]\n",
+      " [[-0.36903515  0.92125744]\n",
+      "  [-0.43777385 -0.28891826]\n",
+      "  [-0.8198579  -0.2604056 ]]\n",
       "\n",
-      " [[-0.7450588  -0.34492287]\n",
-      "  [-0.5324098  -0.20802858]\n",
-      "  [-0.4017799   0.915288  ]]\n",
+      " [[-0.5127858   0.851067  ]\n",
+      "  [-0.56601447 -0.43397826]\n",
+      "  [-0.64550614 -0.2955465 ]]\n",
       "\n",
-      " [[-0.7874786  -0.07116459]\n",
-      "  [-0.35922554 -0.75416195]\n",
-      "  [-0.5008337   0.6528212 ]]\n",
+      " [[-0.6031817   0.7681344 ]\n",
+      "  [-0.735206   -0.63987494]\n",
+      "  [-0.3092629   0.02300668]]\n",
       "\n",
-      " [[-0.36119708 -0.11288617]\n",
-      "  [-0.7034105  -0.61867595]\n",
-      "  [-0.6121685   0.77749395]]]\n",
+      " [[-0.6514613   0.26648495]\n",
+      "  [-0.4583032  -0.88437456]\n",
+      "  [-0.6046124   0.3832325 ]]]\n",
       "\n",
-      ", S: [[101.74199    6.969097]\n",
-      " [111.11511   42.052715]\n",
-      " [144.33199   37.24619 ]\n",
-      " [145.46298   41.03068 ]\n",
-      " [130.61479   42.729122]]\n",
+      ", S: [[111.77634   46.54085 ]\n",
+      " [114.562614  78.1435  ]\n",
+      " [186.19078   33.83777 ]\n",
+      " [132.62187   57.779224]\n",
+      " [145.16234   20.540234]]\n",
       "\n",
-      ", V: [[[-0.694084    0.71989405]\n",
-      "  [-0.71989405 -0.694084  ]]\n",
+      ", V: [[[-0.91532665  0.40271226]\n",
+      "  [-0.40271226 -0.91532665]]\n",
       "\n",
-      " [[-0.8110061   0.5850375 ]\n",
-      "  [-0.5850375  -0.8110061 ]]\n",
+      " [[-0.9118641  -0.4104923 ]\n",
+      "  [-0.4104923   0.9118641 ]]\n",
       "\n",
-      " [[-0.8134284   0.58166504]\n",
-      "  [-0.58166504 -0.8134284 ]]\n",
+      " [[-0.8434532   0.53720254]\n",
+      "  [-0.53720254 -0.8434532 ]]\n",
       "\n",
-      " [[-0.7416788   0.6707552 ]\n",
-      "  [-0.6707552  -0.7416788 ]]\n",
+      " [[-0.70564145 -0.70856905]\n",
+      "  [-0.70856905  0.70564145]]\n",
       "\n",
-      " [[-0.80283296  0.596204  ]\n",
-      "  [-0.596204   -0.80283296]]]\n",
+      " [[-0.9691591   0.24643579]\n",
+      "  [-0.24643579 -0.9691591 ]]]\n",
       "\n"
      ]
     }
@@ -505,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "55ae0408-7ddb-4a75-912f-7312ee43f79b",
    "metadata": {
     "tags": []
@@ -560,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "400e2a53-74b2-4bf1-a0e8-32222fd968f4",
    "metadata": {
     "tags": []
@@ -570,8 +591,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[0.10704935 0.16225594 0.30719754 0.02026123 0.15856391 0.03571513\n",
-      "  0.02464576 0.05195689 0.07600556 0.05634861]]\n"
+      "[[0.19671488 0.03442806 0.05503438 0.05018509 0.01337491 0.03888546\n",
+      "  0.3835799  0.06959172 0.09724794 0.06095758]]\n"
      ]
     }
    ],
@@ -661,7 +682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "889328a7-2326-476f-a686-f34397f4a210",
    "metadata": {
     "tags": []
@@ -674,7 +695,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "729486bb-ab34-44cb-a36f-7d26cbf6393a",
    "metadata": {
     "tags": []
@@ -724,7 +745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "657b3e7b-067a-4053-92e6-60379e5a6807",
    "metadata": {
     "tags": []
@@ -738,7 +759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "d73f0d5b-e6c2-42b1-8e21-3b6d064d20e4",
    "metadata": {
     "tags": []
@@ -772,7 +793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "ea774e12-956c-4bbe-be57-af416123c307",
    "metadata": {
     "tags": []
@@ -782,7 +803,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "14:12:27 C02G13RYMD6N SmartSim[96297] INFO Stopping model orchestrator_0 with job name orchestrator_0-CRU8GVZCMD2W\n"
+      "16:54:20 C02G13RYMD6N SmartSim[63271] INFO Stopping model orchestrator_0 with job name orchestrator_0-CVD39CHUID8O\n"
      ]
     }
    ],
@@ -792,7 +813,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "15662aeb-1b00-4887-9e47-2c596fdbe941",
    "metadata": {
     "tags": []
@@ -803,18 +824,18 @@
       "text/html": [
        "<table>\n",
        "<thead>\n",
-       "<tr><th>  </th><th>Name          </th><th>Entity-Type  </th><th>JobID  </th><th>RunID  </th><th>Time    </th><th>Status   </th><th>Returncode  </th></tr>\n",
+       "<tr><th>  </th><th>Name          </th><th>Entity-Type  </th><th>JobID  </th><th>RunID  </th><th>Time   </th><th>Status   </th><th>Returncode  </th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td>0 </td><td>orchestrator_0</td><td>DBNode       </td><td>98890  </td><td>0      </td><td>132.3518</td><td>Cancelled</td><td>-9          </td></tr>\n",
+       "<tr><td>0 </td><td>orchestrator_0</td><td>DBNode       </td><td>65343  </td><td>0      </td><td>27.1124</td><td>Cancelled</td><td>-9          </td></tr>\n",
        "</tbody>\n",
        "</table>"
       ],
       "text/plain": [
-       "'<table>\\n<thead>\\n<tr><th>  </th><th>Name          </th><th>Entity-Type  </th><th>JobID  </th><th>RunID  </th><th>Time    </th><th>Status   </th><th>Returncode  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>0 </td><td>orchestrator_0</td><td>DBNode       </td><td>98890  </td><td>0      </td><td>132.3518</td><td>Cancelled</td><td>-9          </td></tr>\\n</tbody>\\n</table>'"
+       "'<table>\\n<thead>\\n<tr><th>  </th><th>Name          </th><th>Entity-Type  </th><th>JobID  </th><th>RunID  </th><th>Time   </th><th>Status   </th><th>Returncode  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>0 </td><td>orchestrator_0</td><td>DBNode       </td><td>65343  </td><td>0      </td><td>27.1124</td><td>Cancelled</td><td>-9          </td></tr>\\n</tbody>\\n</table>'"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -843,7 +864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "030448b9-67f0-4cd4-889e-3fac65ccaeaa",
    "metadata": {
     "tags": []
@@ -860,7 +881,6 @@
     "colo_model.colocate_db_tcp(\n",
     "    port=6780,\n",
     "    db_cpus=1,\n",
-    "    limit_app_cpus=False,\n",
     "    debug=False,\n",
     "    ifname=\"lo\"\n",
     ")"
@@ -868,7 +888,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "f8f30f83-9f93-41f6-8276-c805bc9b6eda",
    "metadata": {
     "tags": []
@@ -878,7 +898,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "14:13:01 C02G13RYMD6N SmartSim[96297] INFO \n",
+      "16:54:20 C02G13RYMD6N SmartSim[63271] INFO \n",
       "\n",
       "=== Launch Summary ===\n",
       "Experiment: Inference-Tutorial\n",
@@ -895,7 +915,7 @@
       "\n",
       "\n",
       "\n",
-      "14:13:13 C02G13RYMD6N SmartSim[96297] INFO colocated_model(99077): Completed\n"
+      "16:54:23 C02G13RYMD6N SmartSim[63271] INFO colocated_model(65381): Completed\n"
      ]
     }
    ],
@@ -905,7 +925,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "87a21608-c1cd-43db-8c11-150ef44d0363",
    "metadata": {
     "tags": []
@@ -916,19 +936,19 @@
       "text/html": [
        "<table>\n",
        "<thead>\n",
-       "<tr><th>  </th><th>Name           </th><th>Entity-Type  </th><th>JobID  </th><th>RunID  </th><th>Time    </th><th>Status   </th><th>Returncode  </th></tr>\n",
+       "<tr><th>  </th><th>Name           </th><th>Entity-Type  </th><th>JobID  </th><th>RunID  </th><th>Time   </th><th>Status   </th><th>Returncode  </th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
-       "<tr><td>0 </td><td>orchestrator_0 </td><td>DBNode       </td><td>98890  </td><td>0      </td><td>132.3518</td><td>Cancelled</td><td>-9          </td></tr>\n",
-       "<tr><td>1 </td><td>colocated_model</td><td>Model        </td><td>99077  </td><td>0      </td><td>2.0025  </td><td>Completed</td><td>0           </td></tr>\n",
+       "<tr><td>0 </td><td>orchestrator_0 </td><td>DBNode       </td><td>65343  </td><td>0      </td><td>27.1124</td><td>Cancelled</td><td>-9          </td></tr>\n",
+       "<tr><td>1 </td><td>colocated_model</td><td>Model        </td><td>65381  </td><td>0      </td><td>3.1831 </td><td>Completed</td><td>0           </td></tr>\n",
        "</tbody>\n",
        "</table>"
       ],
       "text/plain": [
-       "'<table>\\n<thead>\\n<tr><th>  </th><th>Name           </th><th>Entity-Type  </th><th>JobID  </th><th>RunID  </th><th>Time    </th><th>Status   </th><th>Returncode  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>0 </td><td>orchestrator_0 </td><td>DBNode       </td><td>98890  </td><td>0      </td><td>132.3518</td><td>Cancelled</td><td>-9          </td></tr>\\n<tr><td>1 </td><td>colocated_model</td><td>Model        </td><td>99077  </td><td>0      </td><td>2.0025  </td><td>Completed</td><td>0           </td></tr>\\n</tbody>\\n</table>'"
+       "'<table>\\n<thead>\\n<tr><th>  </th><th>Name           </th><th>Entity-Type  </th><th>JobID  </th><th>RunID  </th><th>Time   </th><th>Status   </th><th>Returncode  </th></tr>\\n</thead>\\n<tbody>\\n<tr><td>0 </td><td>orchestrator_0 </td><td>DBNode       </td><td>65343  </td><td>0      </td><td>27.1124</td><td>Cancelled</td><td>-9          </td></tr>\\n<tr><td>1 </td><td>colocated_model</td><td>Model        </td><td>65381  </td><td>0      </td><td>3.1831 </td><td>Completed</td><td>0           </td></tr>\\n</tbody>\\n</table>'"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -954,7 +974,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Remove references in the docs to the (now invalid) `--only_python_pacakges` flag of `smart build`