### PR TITLE
Pretty print error message when onnx wheel not available

### DIFF
--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -399,12 +399,16 @@ def execute(args: argparse.Namespace) -> int:
     backends_str = ", ".join(s.capitalize() for s in backends) if backends else "No"
     logger.info(f"{backends_str} backend(s) built")
 
-    if "torch" in backends:
-        check_py_torch_version(versions, device)
-    if "tensorflow" in backends:
-        check_py_tf_version(versions)
-    if "onnxruntime" in backends:
-        check_py_onnx_version(versions)
+    try:
+        if "torch" in backends:
+            check_py_torch_version(versions, device)
+        if "tensorflow" in backends:
+            check_py_tf_version(versions)
+        if "onnxruntime" in backends:
+            check_py_onnx_version(versions)
+    except SetupError as e:
+        logger.error(str(e))
+        return 1
 
     logger.info("SmartSim build complete!")
     return 0


### PR DESCRIPTION
In the case where a user is using python 3.10 and has requested to build with
```sh
smart build --onnx
```
there is no compliant onnx wheel for python 3.10 for the ORT backend installed by default for RAI. This was leading to a `SetupError` being raised, and eventually exposing itself to the user.

This PR will handle that raised exception and pretty print the error message within, before exiting with a non-zero exit code.