### PR TITLE
Update `cibuildwheel` version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.10.0
+        run: python -m pip install cibuildwheel>=2.12.3
 
       - name: Install build-essentials
         if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
Updates the version of `cibuildwheel` used in the CI to `>=2.12.3`
