### PR TITLE
Publish artifacts from test_output on CI fail

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -133,6 +133,20 @@ jobs:
           echo "SMARTSIM_LOG_LEVEL=debug" >> $GITHUB_ENV
           py.test -s --import-mode=importlib -o log_cli=true --cov=$(smart site) --cov-report=xml --cov-config=./tests/test_configs/cov/local_cov.cfg --ignore=tests/full_wlm/ ./tests/
 
+      # Upload artifacts on failure, ignoring binary files
+      - name: Upload Artifact
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test_artifact
+          path: |
+            tests/test_output
+            !**/*.so
+            !**/*.pb
+            !**/*.pt
+            !**/core
+          retention-days: 5
+
       - name: Upload Pytest coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -92,6 +92,8 @@ def test_orc_active_functions(fileutils, wlmutils):
     with pytest.raises(SmartSimError):
         db.get_address()
 
+    raise Exception("Make this test fail to test artifact upload")
+
 
 def test_multiple_interfaces(fileutils, wlmutils):
     exp_name = "test_multiple_interfaces"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -92,8 +92,6 @@ def test_orc_active_functions(fileutils, wlmutils):
     with pytest.raises(SmartSimError):
         db.get_address()
 
-    raise Exception("Make this test fail to test artifact upload")
-
 
 def test_multiple_interfaces(fileutils, wlmutils):
     exp_name = "test_multiple_interfaces"


### PR DESCRIPTION
When trying to debug tests on the Github CI, the output from pytest is often insufficient because some errors are written to the redirected stderr and stdout of launched applications. This PR uploads the test_output directory as an artifact of the workflow on failure.