### PR TITLE
DBNode: MPMD RunSettings Unification

### DIFF
--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -144,6 +144,17 @@ class Config:
             ) from e
 
     @property
+    def database_file_parse_trials(self) -> int:
+        return int(os.getenv("SMARTSIM_DB_FILE_PARSE_TRIALS", "10"))
+
+    @property
+    def database_file_parse_interval(self) -> t.Optional[int]:
+        interval = os.getenv("SMARTSIM_DB_FILE_PARSE_INTERVAL")
+        # Leave `None` as sentinel value as we currently have branching logic
+        # depending on if launching as a standalone or cluster database
+        return int(interval) if interval is not None else None
+
+    @property
     def log_level(self) -> str:
         return os.environ.get("SMARTSIM_LOG_LEVEL", "info")
 

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -148,11 +148,8 @@ class Config:
         return int(os.getenv("SMARTSIM_DB_FILE_PARSE_TRIALS", "10"))
 
     @property
-    def database_file_parse_interval(self) -> t.Optional[int]:
-        interval = os.getenv("SMARTSIM_DB_FILE_PARSE_INTERVAL")
-        # Leave `None` as sentinel value as we currently have branching logic
-        # depending on if launching as a standalone or cluster database
-        return int(interval) if interval is not None else None
+    def database_file_parse_interval(self) -> int:
+        return int(os.getenv("SMARTSIM_DB_FILE_PARSE_INTERVAL", "2"))
 
     @property
     def log_level(self) -> str:

--- a/smartsim/_core/entrypoints/redis.py
+++ b/smartsim/_core/entrypoints/redis.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
         action="store_true",
         help="Specify if this orchestrator shard is part of a cluster",
     )
-    args = parser.parse_args()
+    args_ = parser.parse_args()
 
     # make sure to register the cleanup before the start
     # the process so our signaller will be able to stop
@@ -189,4 +189,4 @@ if __name__ == "__main__":
     for sig in SIGNALS:
         signal.signal(sig, handle_signal)
 
-    raise SystemExit(main(args))
+    raise SystemExit(main(args_))

--- a/smartsim/_core/entrypoints/redis.py
+++ b/smartsim/_core/entrypoints/redis.py
@@ -25,16 +25,20 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import json
 import os
-import psutil
 import signal
+import textwrap
 import typing as t
-
-from smartsim._core.utils.network import current_ip
-from smartsim.error import SSInternalError
-from smartsim.log import get_logger
 from subprocess import PIPE, STDOUT
 from types import FrameType
+
+import psutil
+
+from smartsim._core.utils.network import current_ip
+from smartsim.entity.dbnode import LaunchedShardData
+from smartsim.error import SSInternalError
+from smartsim.log import get_logger
 
 logger = get_logger(__name__)
 
@@ -42,7 +46,7 @@ logger = get_logger(__name__)
 Redis/KeyDB entrypoint script
 """
 
-DBPID = None
+DBPID: t.Optional[int] = None
 
 # kill is not catchable
 SIGNALS = [signal.SIGINT, signal.SIGQUIT, signal.SIGTERM, signal.SIGABRT]
@@ -54,31 +58,64 @@ def handle_signal(signo: int, _frame: t.Optional[FrameType]) -> None:
     cleanup()
 
 
-def build_bind_args(ip_addresses: t.List[str]) -> t.List[str]:
-    bind_arg = f"--bind {' '.join(ip_addresses)}"
-    # pin source address to avoid random selection by Redis
-    bind_src_arg = f"--bind-source-addr {ip_addresses[0]}"
-    return [bind_arg, bind_src_arg]
+def build_bind_args(source_addr: str, *addrs: str) -> t.Tuple[str, ...]:
+    return (
+        "--bind",
+        source_addr,
+        *addrs,
+        # pin source address to avoid random selection by Redis
+        "--bind-source-addr",
+        source_addr,
+    )
 
 
-def print_summary(cmd: t.List[str], ip_address: str, network_interface: str) -> None:
-    print("-" * 10, "  Running  Command  ", "-" * 10, "\n", flush=True)
-    print(f"COMMAND: {' '.join(cmd)}\n", flush=True)
-    print(f"IPADDRESS: {ip_address}\n", flush=True)
-    print(f"NETWORK: {network_interface}\n", flush=True)
-    print("-" * 30, "\n\n", flush=True)
-    print("-" * 10, "  Output  ", "-" * 10, "\n\n", flush=True)
+def build_cluster_args(shard_data: LaunchedShardData) -> t.Tuple[str, ...]:
+    if cluster_conf_file := shard_data.cluster_conf_file:
+        return ("--cluster-enabled", "yes", "--cluster-config-file", cluster_conf_file)
+    return ()
 
 
-def main(network_interface: str, command: t.List[str]) -> None:
+def print_summary(
+    cmd: t.List[str], network_interface: str, shard_data: LaunchedShardData
+) -> None:
+    print(
+        textwrap.dedent(
+            f"""\
+            ----------- Running Command ----------
+            COMMAND: {' '.join(cmd)}
+            IPADDRESS: {shard_data.hostname}
+            NETWORK: {network_interface}
+            SMARTSIM_ORC_SHARD_INFO: {json.dumps(shard_data.to_dict())}
+            --------------------------------------
+
+            --------------- Output ---------------
+
+            """
+        ),
+        flush=True,
+    )
+
+
+def main(args: argparse.Namespace) -> int:
     global DBPID  # pylint: disable=global-statement
 
+    src_addr, *bind_addrs = (current_ip(net_if) for net_if in args.ifname.split(","))
+    shard_data = LaunchedShardData(
+        name=args.name, hostname=src_addr, port=args.port, cluster=args.cluster
+    )
+
+    cmd = [
+        args.orc_exe,
+        args.conf_file,
+        *args.rai_module,
+        "--port",
+        str(args.port),
+        *build_cluster_args(shard_data),
+        *build_bind_args(src_addr, *bind_addrs),
+    ]
+    print_summary(cmd, args.ifname, shard_data)
+
     try:
-        ip_addresses = [current_ip(net_if) for net_if in network_interface.split(",")]
-        cmd = command + build_bind_args(ip_addresses)
-
-        print_summary(cmd, ip_addresses[0], network_interface)
-
         process = psutil.Popen(cmd, stdout=PIPE, stderr=STDOUT)
         DBPID = process.pid
 
@@ -87,18 +124,17 @@ def main(network_interface: str, command: t.List[str]) -> None:
     except Exception as e:
         cleanup()
         raise SSInternalError("Database process starter raised an exception") from e
+    return 0
 
 
 def cleanup() -> None:
+    logger.debug("Cleaning up database instance")
     try:
-        logger.debug("Cleaning up database instance")
         # attempt to stop the database process
-        db_proc = psutil.Process(DBPID)
-        db_proc.terminate()
-
+        if DBPID is not None:
+            psutil.Process(DBPID).terminate()
     except psutil.NoSuchProcess:
         logger.warning("Couldn't find database process to kill.")
-
     except OSError as e:
         logger.warning(f"Failed to clean up database gracefully: {str(e)}")
 
@@ -110,15 +146,47 @@ if __name__ == "__main__":
         prefix_chars="+", description="SmartSim Process Launcher"
     )
     parser.add_argument(
-        "+ifname", type=str, help="Network Interface name", default="lo"
+        "+orc-exe", type=str, help="Path to the orchestrator executable", required=True
     )
-    parser.add_argument("+command", nargs="+", help="Command to run")
+    parser.add_argument(
+        "+conf-file",
+        type=str,
+        help="Path to the orchestrator configuration file",
+        required=True,
+    )
+    parser.add_argument(
+        "+rai-module",
+        nargs="+",
+        type=str,
+        help=(
+            "Command for the orcestrator to load the Redis AI module with "
+            "symbols seperated by whitespace"
+        ),
+        required=True,
+    )
+    parser.add_argument(
+        "+name", type=str, help="Name to identify the shard", required=True
+    )
+    parser.add_argument(
+        "+port",
+        type=int,
+        help="The port on which to launch the shard of the orchestrator",
+        required=True,
+    )
+    parser.add_argument(
+        "+ifname", type=str, help="Network Interface name", required=True
+    )
+    parser.add_argument(
+        "+cluster",
+        action="store_true",
+        help="Specify if this orchestrator shard is part of a cluster",
+    )
     args = parser.parse_args()
 
     # make sure to register the cleanup before the start
-    # the proecss so our signaller will be able to stop
+    # the process so our signaller will be able to stop
     # the database process.
     for sig in SIGNALS:
         signal.signal(sig, handle_signal)
 
-    main(args.ifname, args.command)
+    raise SystemExit(main(args))

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -719,6 +719,9 @@ class Orchestrator(EntityList[DBNode]):
 
         return erf_rs
 
+    # Old pylint from TF 2.6.x does not understand that this argument list is
+    # equivilent to `(self, **kwargs)`
+    # # pylint: disable-next=arguments-differ
     def _initialize_entities(
         self,
         *,

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -612,7 +612,7 @@ class Orchestrator(EntityList[DBNode]):
         batch_settings = None
 
         if launcher is None:
-            raise ValueError('Expected param `launcher` of type `str`')
+            raise ValueError("Expected param `launcher` of type `str`")
 
         # enter this conditional if user has not specified an allocation to run
         # on or if user specified batch=False (alloc will be found through env)
@@ -725,7 +725,7 @@ class Orchestrator(EntityList[DBNode]):
         db_nodes: int = 1,
         single_cmd: bool = True,
         port: int = 6379,
-        **kwargs: t.Any
+        **kwargs: t.Any,
     ) -> None:
         # TODO: This attr is really a synonym for number of shards underneath
         #       the orchestrator. It is problematic for a number of reasons,
@@ -749,7 +749,8 @@ class Orchestrator(EntityList[DBNode]):
 
         if mpmd_nodes:
             self._initialize_entities_mpmd(
-                db_nodes=db_nodes, single_cmd=single_cmd, port=port, **kwargs)
+                db_nodes=db_nodes, single_cmd=single_cmd, port=port, **kwargs
+            )
         else:
             cluster = self.db_nodes >= 3
 

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -508,9 +508,9 @@ class Orchestrator(EntityList[DBNode]):
         :param frequency: the given number of seconds before the DB saves
         :type frequency: int
         """
-        self.set_db_conf("save", str(frequency) + " 1")
+        self.set_db_conf("save", f"{frequency} 1")
 
-    def set_max_memory(self, mem: int) -> None:
+    def set_max_memory(self, mem: str) -> None:
         """Sets the max memory configuration. By default there is no memory limit.
         Setting max memory to zero also results in no memory limit. Once a limit is
         surpassed, keys will be removed according to the eviction strategy. The
@@ -728,7 +728,7 @@ class Orchestrator(EntityList[DBNode]):
         return erf_rs
 
     # Old pylint from TF 2.6.x does not understand that this argument list is
-    # equivilent to `(self, **kwargs)`
+    # equivalent to `(self, **kwargs)`
     # # pylint: disable-next=arguments-differ
     def _initialize_entities(
         self,
@@ -837,7 +837,7 @@ class Orchestrator(EntityList[DBNode]):
             f"+ifname={','.join(self._interfaces)}",  # pass interface to start script
         ]
         if cluster:
-            cmd.append("+cluster")  # is the shard pard of a cluster
+            cmd.append("+cluster")  # is the shard part of a cluster
         return cmd
 
     def _get_db_hosts(self) -> t.List[str]:

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -423,7 +423,7 @@ class Orchestrator(EntityList[DBNode]):
         elif (
             self.launcher == "pals"
             and isinstance(self.entities[0].run_settings, PalsMpiexecSettings)
-            and self.dbnodes[0].is_mpmd
+            and self.entities[0].is_mpmd
         ):
             # In this case, --hosts is a global option, we only set it to the
             # first run command

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -706,7 +706,7 @@ class Orchestrator(EntityList[DBNode]):
             self._initialize_entities_mpmd(**kwargs)
         else:
             port = kwargs.get("port", 6379)
-            cluster = not bool(self.db_nodes < 3)
+            cluster = self.db_nodes >= 3
 
             for db_id in range(self.db_nodes):
                 db_node_name = "_".join((self.name, str(db_id)))
@@ -770,8 +770,6 @@ class Orchestrator(EntityList[DBNode]):
             raise ValueError(f"Could not build run settings for {self.launcher}")
 
         node = DBNode(self.name, self.path, run_settings, [port], output_files)
-        node.is_mpmd = True
-        node.num_shards = self.db_nodes
         self.entities.append(node)
 
         self.ports = [port]

--- a/smartsim/entity/dbnode.py
+++ b/smartsim/entity/dbnode.py
@@ -185,10 +185,7 @@ class DBNode(SmartSimEntity):
         """
         ips: "t.List[LaunchedShardData]" = []
         trials = CONFIG.database_file_parse_trials
-        interval = CONFIG.database_file_parse_interval or (
-            # Larger sleep time, as this seems to be needed for multihost setups
-            2 if self.num_shards > 1 else 1
-        )
+        interval = CONFIG.database_file_parse_interval
         output_files = [osp.join(self.path, file) for file in self._output_files]
 
         while len(ips) < self.num_shards and trials > 0:

--- a/smartsim/entity/dbnode.py
+++ b/smartsim/entity/dbnode.py
@@ -187,10 +187,8 @@ class DBNode(SmartSimEntity):
     def _parse_db_hosts(self) -> t.List[str]:
         """Parse the database hosts/IPs from the output files
 
-        this uses the RedisIP module that is built as a dependency
         The IP address is preferred, but if hostname is only present
         then a lookup to /etc/hosts is done through the socket library.
-        This function must be called only if ``_mpmd==True``.
 
         :raises SmartSimError: if host/ip could not be found
         :return: ip addresses | hostnames
@@ -211,7 +209,7 @@ class DBNode(SmartSimEntity):
                 ...
 
             if len(ips) < self.num_shards:
-                logger.debug("Waiting for RedisIP files to populate...")
+                logger.debug("Waiting for output files to populate...")
                 # Larger sleep time, as this seems to be needed for
                 # multihost setups
                 time.sleep(2 if self.num_shards > 1 else 1)

--- a/tests/test_dbnode.py
+++ b/tests/test_dbnode.py
@@ -111,7 +111,7 @@ def test_db_node_can_parse_launched_shard_info(limit):
             """
         ).format(*(json.dumps(s.to_dict()) for s in rand_shards))
     ) as stream:
-        parsed_shards = DBNode._parse_launched_shard_info_from_stream(
+        parsed_shards = DBNode._parse_launched_shard_info_from_iterable(
             stream, limit
         )
     if limit is not None:

--- a/tests/test_dbnode.py
+++ b/tests/test_dbnode.py
@@ -49,21 +49,17 @@ def test_hosts(fileutils, wlmutils):
     orc.set_path(test_dir)
     exp.start(orc)
 
-    thrown = False
     hosts = []
     try:
         hosts = orc.hosts
-    except SmartSimError:
-        thrown = True
+        assert len(hosts) == orc.db_nodes == 1
     finally:
         # stop the database even if there is an error raised
         exp.stop(orc)
         orc.remove_stale_files()
-        assert not thrown
-        assert hosts == orc.hosts
 
 
 def test_set_host():
     orc = Orchestrator()
-    orc.entities[0].set_host("host")
-    assert orc.entities[0]._host == "host"
+    orc.entities[0].set_hosts(["host"])
+    assert orc.entities[0].host == "host"

--- a/tests/test_smartredis.py
+++ b/tests/test_smartredis.py
@@ -98,7 +98,6 @@ def test_exchange(fileutils, wlmutils):
     finally:
         # stop the orchestrator
         exp.stop(orc)
-        print(exp.summary())
 
 
 def test_consumer(fileutils, wlmutils):
@@ -148,4 +147,3 @@ def test_consumer(fileutils, wlmutils):
     finally:
         # stop the orchestrator
         exp.stop(orc)
-        print(exp.summary())

--- a/tests/test_smartredis.py
+++ b/tests/test_smartredis.py
@@ -93,14 +93,12 @@ def test_exchange(fileutils, wlmutils):
 
     # get and confirm statuses
     statuses = exp.get_status(ensemble)
-    if not all([stat == status.STATUS_COMPLETED for stat in statuses]):
+    try:
+        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    finally:
+        # stop the orchestrator
         exp.stop(orc)
-        assert False  # client ensemble failed
-
-    # stop the orchestrator
-    exp.stop(orc)
-
-    print(exp.summary())
+        print(exp.summary())
 
 
 def test_consumer(fileutils, wlmutils):
@@ -145,11 +143,9 @@ def test_consumer(fileutils, wlmutils):
 
     # get and confirm statuses
     statuses = exp.get_status(ensemble)
-    if not all([stat == status.STATUS_COMPLETED for stat in statuses]):
+    try:
+        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    finally:
+        # stop the orchestrator
         exp.stop(orc)
-        assert False  # client ensemble failed
-
-    # stop the orchestrator
-    exp.stop(orc)
-
-    print(exp.summary())
+        print(exp.summary())


### PR DESCRIPTION
A general refactor of the `DBNode` class to:
1) Remove the duplicate methods with near identical functionality where one was intended to be called if the underlying `RunSettings` were standard and the other if they were MPMD. This removes undefined behavior when the "wrong" method was called
2) Allow MPMD `DBNode`s to map information "per shard" by scraping output files for a serializable `LaunchedShardData` class.