### PR TITLE
Pin pylint version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ extras_require = {
     "dev": [
         "black>=20.8b1",
         "isort>=5.6.4",
-        "pylint>=2.10.0",
+        "pylint>=2.10.0,<3",
         "pytest>=6.0.0",
         "pytest-cov>=2.10.1",
         "click==8.0.2",


### PR DESCRIPTION
Pylint 3.0.0 was released, but it seems to have some bugs, which are making our actions fail. We are pinning its version to `<3` and will make sure to update it as soon as it is fixed.