### PR TITLE
Serialize launched entities manifest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -380,10 +380,10 @@ def local_db(
     """Yield fixture for startup and teardown of an local orchestrator"""
 
     exp_name = request.function.__name__
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir(
         caller_function=exp_name, caller_fspath=request.fspath
     )
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
     db = Orchestrator(port=wlmutils.get_test_port(), interface="lo")
     db.set_path(test_dir)
     exp.start(db)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,6 +19,7 @@ To be released at some future point in time
 
 Description
 
+- Change signature of `Experiment.summary()`
 - Expose first_device parameter for scripts, functions, models
 - Added support for MINBATCHTIMEOUT in model execution
 - Remove support for RedisAI 1.2.5, use RedisAI 1.2.7 commit
@@ -26,6 +27,8 @@ Description
 
 Detailed Notes
 
+- Change `format` argument to `style` in `Experiment.summary()`, this is
+  an API break (PR391_)
 - Added support for first_device parameter for scripts, functions,
   and models. This causes them to be loaded to the first num_devices
   beginning with first_device (PR394_)
@@ -39,11 +42,15 @@ Detailed Notes
   bug has been fixed. This applies to all operating systems. (PR383_)
 - Add support for creation of multiple databases with unique identifiers. (PR342_)
 
+
+  .. _PR391: https://github.com/CrayLabs/SmartSim/pull/391
+  .. _PR342: https://github.com/CrayLabs/SmartSim/pull/342
   .. _PR394: https://github.com/CrayLabs/SmartSim/pull/394
   .. _PR387: https://github.com/CrayLabs/SmartSim/pull/387
   .. _PR383: https://github.com/CrayLabs/SmartSim/pull/383
   .. _634916c: https://github.com/RedisAI/RedisAI/commit/634916c722e718cc6ea3fad46e63f7d798f9adc2
   .. _PR342: https://github.com/CrayLabs/SmartSim/pull/342
+
 
 0.5.1
 -----

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,11 +19,16 @@ To be released at some future point in time
 
 Description
 
+- Expose first_device parameter for scripts, functions, models
 - Added support for MINBATCHTIMEOUT in model execution
 - Remove support for RedisAI 1.2.5, use RedisAI 1.2.7 commit
+- Add support for multiple databases
 
 Detailed Notes
 
+- Added support for first_device parameter for scripts, functions,
+  and models. This causes them to be loaded to the first num_devices
+  beginning with first_device (PR394_)
 - Added support for MINBATCHTIMEOUT in model execution, which caps the delay
   waiting for a minimium number of model execution operations to accumulate
   before executing them as a batch (PR387_)
@@ -32,10 +37,13 @@ Detailed Notes
   bug which breaks the build process on Mac OSX, it was decided to
   use commit 634916c_ from RedisAI's GitHub repository, where such
   bug has been fixed. This applies to all operating systems. (PR383_)
+- Add support for creation of multiple databases with unique identifiers. (PR342_)
 
+  .. _PR394: https://github.com/CrayLabs/SmartSim/pull/394
   .. _PR387: https://github.com/CrayLabs/SmartSim/pull/387
   .. _PR383: https://github.com/CrayLabs/SmartSim/pull/383
   .. _634916c: https://github.com/RedisAI/RedisAI/commit/634916c722e718cc6ea3fad46e63f7d798f9adc2
+  .. _PR342: https://github.com/CrayLabs/SmartSim/pull/342
 
 0.5.1
 -----
@@ -44,7 +52,6 @@ Released on 14 September, 2023
 
 Description
 
-- Add support for multiple databases
 - Add typehints throughout the SmartSim codebase
 - Provide support for Slurm heterogeneous jobs
 - Provide better support for `PalsMpiexecSettings`
@@ -62,7 +69,6 @@ Description
 
 Detailed Notes
 
-- Add support for creation of multiple databases with unique identifiers. (PR342_)
 - Add methods to allow users to inspect files attached to models and ensembles. (PR352_)
 - Add a `smart info` target to provide rudimentary information about the SmartSim installation. (PR350_)
 - Remove unnecessary generation producing unexpected directories in the test suite. (PR349_)
@@ -86,7 +92,6 @@ Detailed Notes
 - Update pylint dependency, update .pylintrc, mitigate non-breaking issues, suppress api breaks. (PR311_)
 - Refactor the `smart` CLI to use subparsers for better documentation and extension. (PR308_)
 
-.. _PR342: https://github.com/CrayLabs/SmartSim/pull/342
 .. _PR352: https://github.com/CrayLabs/SmartSim/pull/352
 .. _PR351: https://github.com/CrayLabs/SmartSim/pull/351
 .. _PR350: https://github.com/CrayLabs/SmartSim/pull/350

--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -164,7 +164,7 @@ def _make_managed_local_orc(
     exp.start(orc)
     try:
         (client_addr,) = orc.get_address()
-        yield Client(False, address=client_addr)
+        yield Client(address=client_addr, cluster=False)
     finally:
         exp.stop(orc)
 

--- a/smartsim/_core/entrypoints/colocated.py
+++ b/smartsim/_core/entrypoints/colocated.py
@@ -75,7 +75,8 @@ def launch_db_model(client: Client, db_model: t.List[str]) -> str:
     parser.add_argument("--file", type=str)
     parser.add_argument("--backend", type=str)
     parser.add_argument("--device", type=str)
-    parser.add_argument("--devices_per_node", type=int)
+    parser.add_argument("--devices_per_node", type=int, default=1)
+    parser.add_argument("--first_device", type=int, default=0)
     parser.add_argument("--batch_size", type=int, default=0)
     parser.add_argument("--min_batch_size", type=int, default=0)
     parser.add_argument("--min_batch_timeout", type=int, default=0)
@@ -100,7 +101,7 @@ def launch_db_model(client: Client, db_model: t.List[str]) -> str:
             name=name,
             model_file=args.file,
             backend=args.backend,
-            fist_gpu=0,
+            first_gpu=args.first_device,
             num_gpus=args.devices_per_node,
             batch_size=args.batch_size,
             min_batch_size=args.min_batch_size,
@@ -142,7 +143,8 @@ def launch_db_script(client: Client, db_script: t.List[str]) -> str:
     parser.add_argument("--file", type=str)
     parser.add_argument("--backend", type=str)
     parser.add_argument("--device", type=str)
-    parser.add_argument("--devices_per_node", type=int)
+    parser.add_argument("--devices_per_node", type=int, default=1)
+    parser.add_argument("--first_device", type=int, default=0)
     args = parser.parse_args(db_script)
 
     if args.file and args.func:
@@ -151,13 +153,15 @@ def launch_db_script(client: Client, db_script: t.List[str]) -> str:
     if args.func:
         func = args.func.replace("\\n", "\n")
         if args.devices_per_node > 1 and args.device.lower() == "gpu":
-            client.set_script_multigpu(args.name, func, 0, args.devices_per_node)
+            client.set_script_multigpu(
+                args.name, func, args.first_device, args.devices_per_node
+            )
         else:
             client.set_script(args.name, func, args.device)
     elif args.file:
         if args.devices_per_node > 1 and args.device.lower() == "gpu":
             client.set_script_from_file_multigpu(
-                args.name, args.file, 0, args.devices_per_node
+                args.name, args.file, args.first_device, args.devices_per_node
             )
         else:
             client.set_script_from_file(args.name, args.file, args.device)

--- a/smartsim/_core/launcher/colocated.py
+++ b/smartsim/_core/launcher/colocated.py
@@ -218,6 +218,7 @@ def _build_db_model_cmd(db_models: t.List[DBModel]) -> t.List[str]:
         cmd.append(f"--backend={db_model.backend}")
         cmd.append(f"--device={db_model.device}")
         cmd.append(f"--devices_per_node={db_model.devices_per_node}")
+        cmd.append(f"--first_device={db_model.first_device}")
         if db_model.batch_size:
             cmd.append(f"--batch_size={db_model.batch_size}")
         if db_model.min_batch_size:
@@ -254,5 +255,5 @@ def _build_db_script_cmd(db_scripts: t.List[DBScript]) -> t.List[str]:
             cmd.append(f"--file={db_script.file}")
         cmd.append(f"--device={db_script.device}")
         cmd.append(f"--devices_per_node={db_script.devices_per_node}")
-
+        cmd.append(f"--first_device={db_script.first_device}")
     return cmd

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -31,7 +31,7 @@ TStepLaunchMetaData = t.Tuple[
 
 
 def save_launch_manifest(manifest: _Manifest[TStepLaunchMetaData]) -> None:
-    manifest_dir = Path(manifest.metadata.exp_path) / ".smartsim/manifest"
+    manifest_dir = Path(manifest.metadata.exp_path) / ".smartsim/telemetry"
     manifest_dir.mkdir(parents=True, exist_ok=True)
     manifest_file = manifest_dir / "manifest.json"
 
@@ -96,10 +96,11 @@ def _dictify_model(
     return {
         "name": model.name,
         "path": model.path,
+        "exe_args": model.run_settings.exe_args,
         "run_settings": _dictify_run_settings(model.run_settings),
         "batch_settings": _dictify_batch_settings(model.batch_settings)
         if model.batch_settings
-        else None,
+        else {},
         "params": model.params,
         "files": {
             "Symlink": model.files.link,
@@ -134,7 +135,7 @@ def _dictify_model(
             ],
         }
         if colo_settings
-        else None,
+        else {},
         "telemetry_metadata": {
             "status_dir": str(telemetry_data_path / model.name),
             "step_id": step_id,
@@ -142,7 +143,7 @@ def _dictify_model(
             "managed": managed,
         },
         "out_file": out_file,
-        "error_file": err_file,
+        "err_file": err_file,
     }
 
 
@@ -157,7 +158,7 @@ def _dictify_ensemble(
         "batch_settings": _dictify_batch_settings(ens.batch_settings)
         # FIXME: Typehint here is wrong, ``ens.batch_settings`` can
         # also be an empty dict for no discernible reason...
-        if ens.batch_settings else None,
+        if ens.batch_settings else {},
         "models": [
             _dictify_model(
                 model, *launching_metadata, telemetry_data_path / ens.name
@@ -170,7 +171,8 @@ def _dictify_ensemble(
 def _dictify_run_settings(run_settings: RunSettings) -> t.Dict[str, t.Any]:
     return {
         "exe": run_settings.exe,
-        "exe_args": run_settings.exe_args,
+        # TODO: We should try to move this back
+        # "exe_args": run_settings.exe_args,
         "run_command": run_settings.run_command,
         "run_args": run_settings.run_args,
         # TODO: We currently do not have a way to represent MPMD commands!

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -14,6 +14,15 @@ if t.TYPE_CHECKING:
     from smartsim.entity import DBNode, Ensemble, Model
     from smartsim.settings.base import BatchSettings, RunSettings
 
+
+# Many of the required fields for serialization require attrs that protected.
+# I do not want to accidentally expose something to users that should not see
+# for a prototype feature. This suppression should probably be removed before
+# this is officially released!
+#
+# pylint: disable=protected-access
+
+
 _TStepLaunchMetaData = t.Tuple[
     t.Optional[str], t.Optional[str], t.Optional[bool], str, str
 ]
@@ -56,8 +65,8 @@ def save_launch_manifest(
         ],
     }
     try:
-        with open(manifest_file, "r") as fd:
-            manifest_dict = json.load(fd)
+        with open(manifest_file, "r", encoding="utf-8") as file:
+            manifest_dict = json.load(file)
     except (FileNotFoundError, json.JSONDecodeError):
         manifest_dict = {
             "experiment": _dictify_experiment(experiment),
@@ -66,8 +75,8 @@ def save_launch_manifest(
     else:
         manifest_dict["runs"].append(new_run)
     finally:
-        with open(manifest_file, "w") as fd:
-            json.dump(manifest_dict, fd, indent=2)
+        with open(manifest_file, "w", encoding="utf-8") as file:
+            json.dump(manifest_dict, file, indent=2)
 
 
 def _dictify_experiment(exp: Experiment) -> t.Dict[str, str]:
@@ -189,7 +198,7 @@ def _dictify_db(
     if db_path:
         db_type, _ = db_path.name.split("-", 1)
     else:
-        db_type = "Unkown"
+        db_type = "Unknown"
     return {
         "name": db.name,
         "type": db_type,

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -202,8 +202,9 @@ def _dictify_db(
                 "out_file": out_file,
                 "err_file": err_file,
                 "telemetry_metadata": {
-                    "status_dir": telemetry_data_path
-                    / f"database/{db.name}/{dbnode.name}",
+                    "status_dir": str(
+                        telemetry_data_path / f"database/{db.name}/{dbnode.name}"
+                    ),
                     "step_id": step_id,
                     "task_id": task_id,
                     "managed": managed,

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import time
+import typing as t
+from pathlib import Path
+
+import smartsim._core._cli.utils as _utils
+
+if t.TYPE_CHECKING:
+    from smartsim import Experiment
+    from smartsim._core.control.manifest import LaunchedManifest as _Manifest
+    from smartsim.database.orchestrator import Orchestrator
+    from smartsim.entity import DBNode, Ensemble, Model
+    from smartsim.settings.base import BatchSettings, RunSettings
+
+_TStepLaunchMetaData = t.Tuple[
+    t.Optional[str], t.Optional[str], t.Optional[bool], str, str
+]
+
+
+def save_launch_manifest(
+    experiment: Experiment, manifest: _Manifest[_TStepLaunchMetaData]
+) -> None:
+    manifest_dir = Path(experiment.exp_path) / ".smartsim/manifest"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_file = manifest_dir / "manifest.json"
+
+    # FIXME: Did we decide on if this should be uuid/literal count of the
+    #        runs/time since epoch/etc.? Whatever it is, it probably should not
+    #        be secs since epoch as this could lead to conflicts if many
+    #        non-blocking runs are made in quick succession.
+    run_id = int(time.time())
+
+    new_run = {
+        "run_id": run_id,
+        "model": [
+            _dictify_model(
+                model,
+                *telemetry_metadata,
+                manifest_dir / f"{experiment.name}/{run_id}/model",
+            )
+            for model, telemetry_metadata in manifest.models
+        ],
+        "orchestrator": [
+            _dictify_db(
+                db, nodes_info, manifest_dir / f"{experiment.name}/{run_id}/database"
+            )
+            for db, nodes_info in manifest.database
+        ],
+        "ensemble": [
+            _dictify_ensemble(
+                ens, member_info, manifest_dir / f"{experiment.name}/{run_id}/ensemble"
+            )
+            for ens, member_info in manifest.ensembles
+        ],
+    }
+    try:
+        with open(manifest_file, "r") as fd:
+            manifest_dict = json.load(fd)
+    except (FileNotFoundError, json.JSONDecodeError):
+        manifest_dict = {
+            "experiment": _dictify_experiment(experiment),
+            "runs": [new_run],
+        }
+    else:
+        manifest_dict["runs"].append(new_run)
+    finally:
+        with open(manifest_file, "w") as fd:
+            json.dump(manifest_dict, fd, indent=2)
+
+
+def _dictify_experiment(exp: Experiment) -> t.Dict[str, str]:
+    return {
+        "name": exp.name,
+        "path": exp.exp_path,
+        "launcher": exp._launcher,
+    }
+
+
+def _dictify_model(
+    model: Model,
+    step_id: t.Optional[str],
+    task_id: t.Optional[str],
+    managed: t.Optional[bool],
+    out_file: str,
+    err_file: str,
+    telemetry_data_path: Path,
+) -> t.Dict[str, t.Any]:
+    return {
+        "name": model.name,
+        "path": model.path,
+        "run_settings": _dictify_run_settings(model.run_settings),
+        "batch_settings": _dictify_batch_settings(model.batch_settings)
+        if model.batch_settings
+        else None,
+        "params": model.params,
+        "files": {
+            "Symlink": model.files.link,
+            "Configure": model.files.tagged,
+            "Copy": model.files.copy,
+        }
+        if model.files
+        else {
+            "Symlink": [],
+            "Configure": [],
+            "Copy": [],
+        },
+        "colocated_db": {
+            "settings": model.run_settings.colocated_db_settings,
+            "scripts": [
+                {
+                    script.name: {
+                        "backend": "TORCH",
+                        "device": script.device,
+                    }
+                }
+                for script in model._db_scripts
+            ],
+            "models": [
+                {
+                    model.name: {
+                        "backend": model.backend,
+                        "device": model.device,
+                    }
+                }
+                for model in model._db_models
+            ],
+        }
+        if model.run_settings.colocated_db_settings
+        else None,
+        "telemetry_metadata": {
+            "status_dir": str(telemetry_data_path / model.name),
+            "step_id": step_id,
+            "task_id": task_id,
+            "managed": managed,
+        },
+        "out_file": out_file,
+        "error_file": err_file,
+    }
+
+
+def _dictify_ensemble(
+    ens: Ensemble,
+    members: t.List[t.Tuple[Model, _TStepLaunchMetaData]],
+    telemetry_data_path: Path,
+) -> t.Dict[str, t.Any]:
+    return {
+        "name": ens.name,
+        "params": ens.params,
+        "batch_settings": _dictify_batch_settings(ens.batch_settings)
+        # FIXME: Typehint here is wrong, ``ens.batch_settings`` can
+        # also be an empty dict for no discernible reason...
+        if ens.batch_settings else None,
+        "models": [
+            _dictify_model(
+                model, *launching_metadata, telemetry_data_path / f"ensemble/{ens.name}"
+            )
+            for model, launching_metadata in members
+        ],
+    }
+
+
+def _dictify_run_settings(run_settings: RunSettings) -> t.Dict[str, t.Any]:
+    return {
+        "exe": run_settings.exe[0],
+        "exe_args": run_settings.exe_args,
+        "run_command": run_settings.run_command,
+        "run_args": run_settings.run_args,
+        # TODO: We currently do not have a way to represent MPMD commands!
+        #       Maybe add a ``"mpmd"`` key here that is a
+        #       ``list[TDictifiedRunSettings]``?
+    }
+
+
+def _dictify_batch_settings(batch_settings: BatchSettings) -> t.Dict[str, t.Any]:
+    return {
+        "batch_command": batch_settings.batch_cmd,
+        "batch_args": batch_settings.batch_args,
+    }
+
+
+def _dictify_db(
+    db: Orchestrator,
+    nodes: t.List[t.Tuple[DBNode, _TStepLaunchMetaData]],
+    telemetry_data_path: Path,
+) -> t.Dict[str, t.Any]:
+    db_path = _utils.get_db_path()
+    if db_path:
+        db_type, _ = db_path.name.split("-", 1)
+    else:
+        db_type = "Unkown"
+    return {
+        "name": db.name,
+        "type": db_type,
+        "interface": db._interfaces,
+        "shards": [
+            {
+                # FIXME: very sloppy, make this comprehension a fn
+                **shard.to_dict(),
+                "conf_file": shard.cluster_conf_file,
+                "out_file": out_file,
+                "err_file": err_file,
+                "telemetry_metadata": {
+                    "status_dir": telemetry_data_path
+                    / f"database/{db.name}/{dbnode.name}",
+                    "step_id": step_id,
+                    "task_id": task_id,
+                    "managed": managed,
+                },
+            }
+            for dbnode, (step_id, task_id, managed, out_file, err_file) in nodes
+            for shard in dbnode.get_launched_shard_info()
+        ],
+    }

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -163,7 +163,7 @@ def _dictify_ensemble(
 
 def _dictify_run_settings(run_settings: RunSettings) -> t.Dict[str, t.Any]:
     return {
-        "exe": run_settings.exe[0],
+        "exe": run_settings.exe,
         "exe_args": run_settings.exe_args,
         "run_command": run_settings.run_command,
         "run_args": run_settings.run_args,

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -362,6 +362,7 @@ class Ensemble(EntityList[Model]):
         model_path: t.Optional[str] = None,
         device: t.Literal["CPU", "GPU"] = "CPU",
         devices_per_node: int = 1,
+        first_device: int = 0,
         batch_size: int = 0,
         min_batch_size: int = 0,
         min_batch_timeout: int = 0,
@@ -388,6 +389,12 @@ class Ensemble(EntityList[Model]):
         :type backend: str
         :param device: name of device for execution, defaults to "CPU"
         :type device: str, optional
+        :param devices_per_node: number of GPUs per node in multiGPU nodes,
+                                 defaults to 1
+        :type devices_per_node: int, optional
+        :param first_device: first device in multi-GPU nodes to use for execution,
+                             defaults to 0; ignored if devices_per_node is 1
+        :type first_device: int, optional
         :param batch_size: batch size for execution, defaults to 0
         :type batch_size: int, optional
         :param min_batch_size: minimum batch size for model execution, defaults to 0
@@ -408,6 +415,7 @@ class Ensemble(EntityList[Model]):
             model_file=model_path,
             device=device,
             devices_per_node=devices_per_node,
+            first_device=first_device,
             batch_size=batch_size,
             min_batch_size=min_batch_size,
             min_batch_timeout=min_batch_timeout,
@@ -426,6 +434,7 @@ class Ensemble(EntityList[Model]):
         script_path: t.Optional[str] = None,
         device: t.Literal["CPU", "GPU"] = "CPU",
         devices_per_node: int = 1,
+        first_device: int = 0,
     ) -> None:
         """TorchScript to launch with every entity belonging to this ensemble
 
@@ -452,6 +461,8 @@ class Ensemble(EntityList[Model]):
         :type device: str, optional
         :param devices_per_node: number of devices on each host
         :type devices_per_node: int
+        :param first_device: first device to use on each host
+        :type first_device: int
         """
         db_script = DBScript(
             name=name,
@@ -459,6 +470,7 @@ class Ensemble(EntityList[Model]):
             script_path=script_path,
             device=device,
             devices_per_node=devices_per_node,
+            first_device=first_device,
         )
         self._db_scripts.append(db_script)
         for entity in self.models:
@@ -470,6 +482,7 @@ class Ensemble(EntityList[Model]):
         function: t.Optional[str] = None,
         device: t.Literal["CPU", "GPU"] = "CPU",
         devices_per_node: int = 1,
+        first_device: int = 0,
     ) -> None:
         """TorchScript function to launch with every entity belonging to this ensemble
 
@@ -483,7 +496,9 @@ class Ensemble(EntityList[Model]):
         present, a number can be passed for specification e.g. "GPU:1".
 
         Setting ``devices_per_node=N``, with N greater than one will result
-        in the model being stored in the first N devices of type ``device``.
+        in the script being stored in the first N devices of type ``device``;
+        alternatively, setting ``first_device=M`` will result in the script
+        being stored on nodes M through M + N - 1.
 
         :param name: key to store function under
         :type name: str
@@ -493,9 +508,12 @@ class Ensemble(EntityList[Model]):
         :type device: str, optional
         :param devices_per_node: number of devices on each host
         :type devices_per_node: int
+        :param first_device: first device to use on each host
+        :type first_device: int
         """
         db_script = DBScript(
-            name=name, script=function, device=device, devices_per_node=devices_per_node
+            name=name, script=function, device=device,
+            devices_per_node=devices_per_node, first_device=first_device
         )
         self._db_scripts.append(db_script)
         for entity in self.models:

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -453,6 +453,7 @@ class Model(SmartSimEntity):
         model_path: t.Optional[str] = None,
         device: t.Literal["CPU", "GPU"] = "CPU",
         devices_per_node: int = 1,
+        first_device: int = 0,
         batch_size: int = 0,
         min_batch_size: int = 0,
         min_batch_timeout: int = 0,
@@ -481,8 +482,12 @@ class Model(SmartSimEntity):
         :type device: str, optional
         :param devices_per_node: The number of GPU devices available on the host.
                This parameter only applies to GPU devices and will be ignored if device
-               is specified as GPU.
+               is specified as CPU.
         :type devices_per_node: int
+        :param first_device: The first GPU device to use on the host.
+               This parameter only applies to GPU devices and will be ignored if device
+               is specified as CPU.
+        :type first_device: int
         :param batch_size: batch size for execution, defaults to 0
         :type batch_size: int, optional
         :param min_batch_size: minimum batch size for model execution, defaults to 0
@@ -503,6 +508,7 @@ class Model(SmartSimEntity):
             model_file=model_path,
             device=device,
             devices_per_node=devices_per_node,
+            first_device=first_device,
             batch_size=batch_size,
             min_batch_size=min_batch_size,
             min_batch_timeout=min_batch_timeout,
@@ -519,6 +525,7 @@ class Model(SmartSimEntity):
         script_path: t.Optional[str] = None,
         device: t.Literal["CPU", "GPU"] = "CPU",
         devices_per_node: int = 1,
+        first_device: int = 0,
     ) -> None:
         """TorchScript to launch with this Model instance
 
@@ -530,7 +537,9 @@ class Model(SmartSimEntity):
         present, a number can be passed for specification e.g. "GPU:1".
 
         Setting ``devices_per_node=N``, with N greater than one will result
-        in the model being stored in the first N devices of type ``device``.
+        in the script being stored in the first N devices of type ``device``;
+        alternatively, setting ``first_device=M`` will result in the script
+        being stored on nodes M through M + N - 1.
 
         One of either script (in memory string representation) or script_path (file)
         must be provided
@@ -545,8 +554,12 @@ class Model(SmartSimEntity):
         :type device: str, optional
         :param devices_per_node: The number of GPU devices available on the host.
                This parameter only applies to GPU devices and will be ignored if device
-               is specified as GPU.
+               is specified as CPU.
         :type devices_per_node: int
+        :param first_device: The first GPU device to use on the host.
+               This parameter only applies to GPU devices and will be ignored if device
+               is specified as CPU.
+        :type first_device: int
         """
         db_script = DBScript(
             name=name,
@@ -554,6 +567,7 @@ class Model(SmartSimEntity):
             script_path=script_path,
             device=device,
             devices_per_node=devices_per_node,
+            first_device=first_device,
         )
         self.add_script_object(db_script)
 
@@ -563,6 +577,7 @@ class Model(SmartSimEntity):
         function: t.Optional[str] = None,
         device: t.Literal["CPU", "GPU"] = "CPU",
         devices_per_node: int = 1,
+        first_device: int = 0,
     ) -> None:
         """TorchScript function to launch with this Model instance
 
@@ -586,11 +601,16 @@ class Model(SmartSimEntity):
         :type device: str, optional
         :param devices_per_node: The number of GPU devices available on the host.
                This parameter only applies to GPU devices and will be ignored if device
-               is specified as GPU.
+               is specified as CPU.
         :type devices_per_node: int
+        :param first_device: The first GPU device to use on the host.
+               This parameter only applies to GPU devices and will be ignored if device
+               is specified as CPU.
+        :type first_device: int
         """
         db_script = DBScript(
-            name=name, script=function, device=device, devices_per_node=devices_per_node
+            name=name, script=function, device=device,
+            devices_per_node=devices_per_node, first_device=first_device
         )
         self.add_script_object(db_script)
 

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -791,18 +791,17 @@ class Experiment:
             logger.error(e)
             raise
 
-    # pylint: disable-next=redefined-builtin
-    def summary(self, format: str = "github") -> str:
+    def summary(self, style: str = "github") -> str:
         """Return a summary of the ``Experiment``
 
         The summary will show each instance that has been
         launched and completed in this ``Experiment``
 
-        :param format: the style in which the summary table is formatted,
+        :param style: the style in which the summary table is formatted,
                        for a full list of styles see:
                        https://github.com/astanin/python-tabulate#table-format,
                        defaults to "github"
-        :type format: str, optional
+        :type style: str, optional
         :return: tabulate string of ``Experiment`` history
         :rtype: str
         """
@@ -833,7 +832,7 @@ class Experiment:
             values,
             headers,
             showindex=True,
-            tablefmt=format,
+            tablefmt=style,
             missingval="None",
             disable_numparse=True,
         )

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -193,7 +193,7 @@ class Experiment:
         try:
             if summary:
                 self._launch_summary(start_manifest)
-            self._control.start(
+            launched = self._control.start(
                 manifest=start_manifest,
                 block=block,
                 kill_on_interrupt=kill_on_interrupt,

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -31,7 +31,7 @@ from os import getcwd
 from tabulate import tabulate
 
 from ._core import Controller, Generator, Manifest
-from ._core.utils import init_default, serialize
+from ._core.utils import init_default
 from .database import Orchestrator
 from .entity import Ensemble, Model, SmartSimEntity
 from .error import SmartSimError
@@ -193,23 +193,16 @@ class Experiment:
         try:
             if summary:
                 self._launch_summary(start_manifest)
-            launched = self._control.start(
+            self._control.start(
+                exp_name=self.name,
+                exp_path=self.exp_path,
                 manifest=start_manifest,
-                block=False,
+                block=block,
                 kill_on_interrupt=kill_on_interrupt,
             )
         except SmartSimError as e:
             logger.error(e)
             raise
-
-        serialize.save_launch_manifest(self, launched)
-
-        # TODO: remove this temporary hack to move blocking ``poll`` call here
-        # to allow the the run to be serialized (bc we need a ref to the exp).
-        if block:
-            # poll handles its own keyboard interrupt as
-            # it may be called seperately
-            self.poll(5, True, kill_on_interrupt=kill_on_interrupt)
 
     def stop(self, *args: t.Any) -> None:
         """Stop specific instances launched by this ``Experiment``

--- a/smartsim/ml/data.py
+++ b/smartsim/ml/data.py
@@ -180,7 +180,7 @@ class TrainingDataUploader:
         if not sample_name:
             raise ValueError("Sample name can not be empty")
 
-        self.client = Client(cluster, address=address)
+        self.client = Client(address=address, cluster=cluster)
         self.verbose = verbose
         self.batch_idx = 0
         self.rank = rank

--- a/smartsim/settings/mpiSettings.py
+++ b/smartsim/settings/mpiSettings.py
@@ -81,6 +81,7 @@ class _BaseMPISettings(RunSettings):
             **kwargs,
         )
         self.mpmd: t.List[RunSettings] = []
+        self.affinity_script: t.List[str] = []
 
         if not shutil.which(self._run_command):
             msg = (

--- a/smartsim/settings/palsSettings.py
+++ b/smartsim/settings/palsSettings.py
@@ -182,6 +182,16 @@ class PalsMpiexecSettings(_BaseMPISettings):
         """
         logger.warning("set_walltime not supported under PALS")
 
+    def set_gpu_affinity_script(self, affinity: str, *args: t.Any) -> None:
+        """ Set the GPU affinity through a bash script
+
+        :param affinity: path to the affinity script
+        :type affinity: str
+        """
+        self.affinity_script.append(str(affinity))
+        for arg in args:
+            self.affinity_script.append(str(arg))
+
     def format_run_args(self) -> t.List[str]:
         """Return a list of MPI-standard formatted run arguments
 
@@ -199,6 +209,10 @@ class PalsMpiexecSettings(_BaseMPISettings):
                     args += [prefix + opt]
                 else:
                     args += [prefix + opt, str(value)]
+
+        if self.affinity_script:
+            args += self.affinity_script
+
         return args
 
     def format_env_vars(self) -> t.List[str]:

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -186,6 +186,7 @@ def test_tf_db_model(fileutils, wlmutils, mlutils):
         model=model,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         inputs=inputs,
         outputs=outputs,
         tag="test",
@@ -196,6 +197,7 @@ def test_tf_db_model(fileutils, wlmutils, mlutils):
         model_path=model_file2,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         inputs=inputs2,
         outputs=outputs2,
         tag="test",
@@ -260,6 +262,7 @@ def test_pt_db_model(fileutils, wlmutils, mlutils):
         model_path=model_path,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         tag="test",
     )
 
@@ -329,6 +332,7 @@ def test_db_model_ensemble(fileutils, wlmutils, mlutils):
         model=model,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         inputs=inputs,
         outputs=outputs
     )
@@ -342,6 +346,7 @@ def test_db_model_ensemble(fileutils, wlmutils, mlutils):
             model_path=model_file2,
             device=test_device,
             devices_per_node=test_num_gpus,
+            first_device=0,
             inputs=inputs2,
             outputs=outputs2,
         )
@@ -357,6 +362,7 @@ def test_db_model_ensemble(fileutils, wlmutils, mlutils):
         model_path=model_file2,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         inputs=inputs2,
         outputs=outputs2,
     )
@@ -420,6 +426,7 @@ def test_colocated_db_model_tf(fileutils, wlmutils, mlutils):
         model_path=model_file,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         inputs=inputs,
         outputs=outputs
     )
@@ -429,6 +436,7 @@ def test_colocated_db_model_tf(fileutils, wlmutils, mlutils):
         model_path=model_file2,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         inputs=inputs2,
         outputs=outputs2,
     )
@@ -487,7 +495,8 @@ def test_colocated_db_model_pytorch(fileutils, wlmutils, mlutils):
                             "TORCH",
                             model_path=model_file,
                             device=test_device,
-                            devices_per_node=test_num_gpus)
+                            devices_per_node=test_num_gpus,
+                            first_device=0)
 
     # Assert we have added both models
     assert len(colo_model._db_models) == 1
@@ -563,6 +572,7 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
             model_path=model_file2,
             device=test_device,
             devices_per_node=test_num_gpus,
+            first_device=0,
             inputs=inputs2,
             outputs=outputs2,
         )
@@ -574,6 +584,7 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
         model_path=model_file,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         inputs=inputs,
         outputs=outputs,
         tag="test",
@@ -589,6 +600,7 @@ def test_colocated_db_model_ensemble(fileutils, wlmutils, mlutils):
         model_path=model_file2,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         inputs=inputs2,
         outputs=outputs2,
     )
@@ -649,6 +661,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
         model_path=model_file,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         inputs=inputs,
         outputs=outputs
     )
@@ -669,6 +682,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
             model_path=model_file2,
             device=test_device,
             devices_per_node=test_num_gpus,
+            first_device=0,
             inputs=inputs2,
             outputs=outputs2,
         )
@@ -690,6 +704,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
         model_path=model_file2,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
         inputs=inputs2,
         outputs=outputs2,
     )
@@ -745,7 +760,8 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
     with pytest.raises(SSUnsupportedError):
         colo_model.add_ml_model(
             "cnn", "TF", model=model, device=test_device,
-            devices_per_node=test_num_gpus, inputs=inputs, outputs=outputs
+            devices_per_node=test_num_gpus, first_device=0,
+            inputs=inputs, outputs=outputs
         )
 
     # Create an ensemble with two identical replicas
@@ -768,7 +784,8 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
     with pytest.raises(SSUnsupportedError):
         colo_ensemble.add_ml_model(
             "cnn", "TF", model=model, device=test_device,
-            devices_per_node=test_num_gpus, inputs=inputs, outputs=outputs
+            devices_per_node=test_num_gpus, first_device=0,
+            inputs=inputs, outputs=outputs
         )
 
     # Check error is still thrown if an in-memory model is used
@@ -786,7 +803,8 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
     colo_ensemble2.set_path(test_dir)
     colo_ensemble2.add_ml_model(
         "cnn", "TF", model=model, device=test_device,
-            devices_per_node=test_num_gpus, inputs=inputs, outputs=outputs
+            devices_per_node=test_num_gpus, first_device=0,
+            inputs=inputs, outputs=outputs
     )
     for i, entity in enumerate(colo_ensemble2):
         with pytest.raises(SSUnsupportedError):
@@ -813,6 +831,7 @@ def test_inconsistent_params_db_model():
             model=model,
             device="CPU",
             devices_per_node=2,
+            first_device=0,
             tag="test",
             inputs=inputs,
             outputs=outputs,

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -398,7 +398,7 @@ def test_colocated_db_model_tf(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
 
     # Create SmartSim Experience
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -469,7 +469,7 @@ def test_colocated_db_model_pytorch(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_pt_dbmodel_smartredis.py")
 
     # Create the SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -633,7 +633,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
 
     # Create the SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -735,7 +735,7 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -817,6 +817,7 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
 
     with pytest.raises(SSUnsupportedError):
         colo_ensemble.add_model(colo_model)
+
 
 @pytest.mark.skipif(not should_run_tf, reason="Test needs TensorFlow to run")
 def test_inconsistent_params_db_model():

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -99,6 +99,7 @@ def test_db_script(fileutils, wlmutils, mlutils):
         script_path=torch_script,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Add script via string
@@ -107,6 +108,7 @@ def test_db_script(fileutils, wlmutils, mlutils):
         script=torch_script_str,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Add script function
@@ -115,6 +117,7 @@ def test_db_script(fileutils, wlmutils, mlutils):
         function=timestwo,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Assert we have all three scripts
@@ -177,6 +180,7 @@ def test_db_script_ensemble(fileutils, wlmutils, mlutils):
         script_path=torch_script,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Add script via string for each ensemble entity
@@ -187,6 +191,7 @@ def test_db_script_ensemble(fileutils, wlmutils, mlutils):
             script=torch_script_str,
             device=test_device,
             devices_per_node=test_num_gpus,
+            first_device=0,
         )
 
     # Add script via function
@@ -195,6 +200,7 @@ def test_db_script_ensemble(fileutils, wlmutils, mlutils):
         function=timestwo,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Add an additional ensemble member and attach a script to the new member
@@ -204,6 +210,7 @@ def test_db_script_ensemble(fileutils, wlmutils, mlutils):
         script=torch_script_str,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Assert we have added both models to the ensemble
@@ -261,6 +268,7 @@ def test_colocated_db_script(fileutils, wlmutils, mlutils):
         script_path=torch_script,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
     # Add script via string
     colo_model.add_script(
@@ -268,6 +276,7 @@ def test_colocated_db_script(fileutils, wlmutils, mlutils):
         script=torch_script_str,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Assert we have added both models
@@ -337,6 +346,7 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
             script_path=torch_script,
             device=test_device,
             devices_per_node=test_num_gpus,
+            first_device=0,
         )
 
     # Colocate a db with the non-ensemble Model
@@ -354,6 +364,7 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
         script=torch_script_str,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Add the third SmartSim model to the ensemble
@@ -365,6 +376,7 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
         script_path=torch_script,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Assert we have added one model to the ensemble
@@ -424,6 +436,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
         script=torch_script_str,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Add a colocated database to the ensemble members
@@ -442,6 +455,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
             script_path=torch_script,
             device=test_device,
             devices_per_node=test_num_gpus,
+            first_device=0,
         )
 
     # Add a colocated database to the non-ensemble SmartSim Model
@@ -460,6 +474,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
         script_path=torch_script,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Assert we have added one model to the ensemble
@@ -519,6 +534,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
             function=timestwo,
             device=test_device,
             devices_per_node=test_num_gpus,
+            first_device=0,
         )
 
     # Create ensemble with two identical SmartSim Model entities
@@ -545,6 +561,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
             function=timestwo,
             device=test_device,
             devices_per_node=test_num_gpus,
+            first_device=0,
         )
 
     # Create an ensemble with two identical SmartSim Model entities
@@ -560,6 +577,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
         function=timestwo,
         device=test_device,
         devices_per_node=test_num_gpus,
+        first_device=0,
     )
 
     # Check that an error is raised when trying to add
@@ -580,19 +598,31 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
     with pytest.raises(SSUnsupportedError):
         colo_ensemble.add_model(colo_model)
 
-
 def test_inconsistent_params_db_script(fileutils):
     """Test error when devices_per_node>1 and when devices is set to CPU in DBScript constructor"""
 
     torch_script = fileutils.get_test_conf_path("torchscript.py")
     with pytest.raises(SSUnsupportedError) as ex:
-        db_script = DBScript(
+        _ = DBScript(
             name="test_script_db",
             script_path=torch_script,
             device="CPU",
             devices_per_node=2,
+            first_device=0,
         )
     assert (
-        ex.value.args[0]
-        == "Cannot set devices_per_node>1 if CPU is specified under devices"
-    )
+            ex.value.args[0]
+            == "Cannot set devices_per_node>1 if CPU is specified under devices"
+        )
+    with pytest.raises(SSUnsupportedError) as ex:
+        _ = DBScript(
+            name="test_script_db",
+            script_path=torch_script,
+            device="CPU",
+            devices_per_node=1,
+            first_device=5,
+        )
+    assert (
+            ex.value.args[0]
+            == "Cannot set first_device>0 if CPU is specified under devices"
+        )

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -245,7 +245,7 @@ def test_colocated_db_script(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create the SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -313,7 +313,7 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -412,7 +412,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -509,7 +509,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create SmartSim experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)

--- a/tests/on_wlm/test_simple_entity_launch.py
+++ b/tests/on_wlm/test_simple_entity_launch.py
@@ -103,7 +103,7 @@ def test_summary(fileutils, wlmutils):
     assert exp.get_status(bad)[0] == status.STATUS_FAILED
     assert exp.get_status(sleep)[0] == status.STATUS_COMPLETED
 
-    summary_str = exp.summary(format="plain")
+    summary_str = exp.summary(style="plain")
     print(summary_str)
 
     rows = [s.split() for s in summary_str.split("\n")]

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -45,7 +45,8 @@ def test_macosx_warning(fileutils, coloutils):
     db_args = {"custom_pinning": [1]}
     db_type = "uds"  # Test is insensitive to choice of db
 
-    exp = Experiment("colocated_model_defaults", launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher="local", exp_path=test_dir)
     with pytest.warns(
         RuntimeWarning,
         match="CPU pinning is not supported on MacOSX. Ignoring pinning specification.",
@@ -63,7 +64,8 @@ def test_unsupported_limit_app(fileutils, coloutils):
     db_args = {"limit_app_cpus": True}
     db_type = "uds"  # Test is insensitive to choice of db
 
-    exp = Experiment("colocated_model_defaults", launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher="local", exp_path=test_dir)
     with pytest.raises(SSUnsupportedError):
         coloutils.setup_test_colo(
             fileutils,
@@ -80,7 +82,8 @@ def test_unsupported_custom_pinning(fileutils, coloutils, custom_pinning):
     db_type = "uds"  # Test is insensitive to choice of db
     db_args = {"custom_pinning": custom_pinning}
 
-    exp = Experiment("colocated_model_defaults", launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher="local", exp_path=test_dir)
     with pytest.raises(TypeError):
         coloutils.setup_test_colo(
             fileutils,
@@ -116,7 +119,8 @@ def test_launch_colocated_model_defaults(
 
     db_args = {}
 
-    exp = Experiment("colocated_model_defaults", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher=launcher, exp_path=test_dir)
     colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
@@ -146,12 +150,12 @@ def test_launch_colocated_model_defaults(
 def test_launch_multiple_colocated_models(
     fileutils, coloutils, wlmutils, db_type, launcher="local"
 ):
-    """Test the concurrent launch of two models with a colocated database and local launcher
-    """
+    """Test the concurrent launch of two models with a colocated database and local launcher"""
 
     db_args = {}
 
-    exp = Experiment("multi_colo_models", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("multi_colo_models", launcher=launcher, exp_path=test_dir)
     colo_models = [
         coloutils.setup_test_colo(
             fileutils,
@@ -187,7 +191,10 @@ def test_launch_multiple_colocated_models(
 def test_colocated_model_disable_pinning(
     fileutils, coloutils, db_type, launcher="local"
 ):
-    exp = Experiment("colocated_model_pinning_auto_1cpu", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_auto_1cpu", launcher=launcher, exp_path=test_dir
+    )
     db_args = {
         "db_cpus": 1,
         "custom_pinning": [],
@@ -210,7 +217,10 @@ def test_colocated_model_disable_pinning(
 def test_colocated_model_pinning_auto_2cpu(
     fileutils, coloutils, db_type, launcher="local"
 ):
-    exp = Experiment("colocated_model_pinning_auto_2cpu", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_auto_2cpu", launcher=launcher, exp_path=test_dir
+    )
 
     db_args = {
         "db_cpus": 2,
@@ -241,7 +251,10 @@ def test_colocated_model_pinning_auto_2cpu(
 def test_colocated_model_pinning_range(fileutils, coloutils, db_type, launcher="local"):
     # Check to make sure that the CPU mask was correctly generated
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual", launcher=launcher, exp_path=test_dir
+    )
 
     db_args = {"db_cpus": 2, "custom_pinning": range(2)}
 
@@ -263,7 +276,10 @@ def test_colocated_model_pinning_range(fileutils, coloutils, db_type, launcher="
 def test_colocated_model_pinning_list(fileutils, coloutils, db_type, launcher="local"):
     # Check to make sure that the CPU mask was correctly generated
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual", launcher=launcher, exp_path=test_dir
+    )
 
     db_args = {"db_cpus": 1, "custom_pinning": [1]}
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,40 @@
+import pytest
+
+from smartsim._core.control.controller import Controller
+from smartsim.settings.slurmSettings import SbatchSettings, SrunSettings
+from smartsim._core.launcher.step import Step
+from smartsim.entity.ensemble import Ensemble
+from smartsim.database.orchestrator import Orchestrator
+
+controller = Controller()
+
+rs = SrunSettings('echo', ['spam', 'eggs'])
+bs = SbatchSettings()
+
+ens = Ensemble("ens", params={}, run_settings=rs, batch_settings=bs, replicas=3)
+orc = Orchestrator(db_nodes=3, batch=True, launcher="slurm", run_command="srun")
+
+class MockStep(Step):
+    @staticmethod
+    def _create_unique_name(name):
+        return name
+
+    def add_to_batch(self, step):
+        ...
+
+    def get_launch_cmd(self):
+        return []
+
+@pytest.mark.parametrize("collection", [
+    pytest.param(ens, id="Ensemble"),
+    pytest.param(orc, id="Database"),
+])
+def test_controller_batch_step_creation_preserves_entity_order(collection, monkeypatch):
+    monkeypatch.setattr(controller._launcher, "create_step",
+                        lambda name, path, settings: MockStep(name, path, settings))
+    entity_names = [x.name for x in collection.entities]
+    assert len(entity_names) == len(set(entity_names))
+    _, steps = controller._create_batch_job_step(collection)
+    assert entity_names == [step.name for step in steps]
+
+    

--- a/tests/test_controller_errors.py
+++ b/tests/test_controller_errors.py
@@ -97,7 +97,7 @@ def test_wrong_orchestrator(wlmutils):
     cont = Controller(launcher="local")
     manifest = Manifest(orc)
     with pytest.raises(SmartSimError):
-        cont._launch(manifest)
+        cont._launch("exp_name", "exp_path", manifest)
 
 
 def test_bad_orc_checkpoint():

--- a/tests/test_dbnode.py
+++ b/tests/test_dbnode.py
@@ -48,8 +48,8 @@ def test_parse_db_host_error():
 
 def test_hosts(fileutils, wlmutils):
     exp_name = "test_hosts"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
 
     orc = Orchestrator(port=wlmutils.get_test_port(), interface="lo", launcher="local")
     orc.set_path(test_dir)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -110,8 +110,8 @@ def test_bad_ensemble_init_no_rs_bs():
 
 def test_stop_entity(fileutils):
     exp_name = "test_stop_entity"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
     m = exp.create_model("model", path=test_dir, run_settings=RunSettings("sleep", "5"))
     exp.start(m, block=False)
     assert exp.finished(m) == False
@@ -122,8 +122,8 @@ def test_stop_entity(fileutils):
 def test_poll(fileutils):
     # Ensure that a SmartSimError is not raised
     exp_name = "test_exp_poll"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
     model = exp.create_model(
         "model", path=test_dir, run_settings=RunSettings("sleep", "5")
     )
@@ -134,8 +134,8 @@ def test_poll(fileutils):
 
 def test_summary(fileutils):
     exp_name = "test_exp_summary"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
     m = exp.create_model(
         "model", path=test_dir, run_settings=RunSettings("echo", "Hello")
     )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -140,7 +140,7 @@ def test_summary(fileutils):
         "model", path=test_dir, run_settings=RunSettings("echo", "Hello")
     )
     exp.start(m)
-    summary_str = exp.summary(format="plain")
+    summary_str = exp.summary(style="plain")
     print(summary_str)
 
     summary_lines = summary_str.split("\n")

--- a/tests/test_launch_errors.py
+++ b/tests/test_launch_errors.py
@@ -45,8 +45,8 @@ def test_unsupported_run_settings():
 
 def test_model_failure(fileutils):
     exp_name = "test-model-failure"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("bad.py")
     settings = RunSettings("python", f"{script} --time=3")
@@ -61,8 +61,8 @@ def test_model_failure(fileutils):
 def test_orchestrator_relaunch(fileutils, wlmutils):
     """Test when users try to launch second orchestrator"""
     exp_name = "test-orc-on-relaunch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     orc = Orchestrator(port=wlmutils.get_test_port())
     orc.set_path(test_dir)

--- a/tests/test_local_launch.py
+++ b/tests/test_local_launch.py
@@ -34,8 +34,8 @@ Test the launch of simple entity types with local launcher
 
 def test_models(fileutils):
     exp_name = "test-models-local-launch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")
@@ -50,8 +50,8 @@ def test_models(fileutils):
 
 def test_ensemble(fileutils):
     exp_name = "test-ensemble-launch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")

--- a/tests/test_local_multi_run.py
+++ b/tests/test_local_multi_run.py
@@ -34,8 +34,8 @@ Test the launch of simple entity types with local launcher
 
 def test_models(fileutils):
     exp_name = "test-models-local-launch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=5")

--- a/tests/test_local_restart.py
+++ b/tests/test_local_restart.py
@@ -35,8 +35,8 @@ Test restarting ensembles and models.
 def test_restart(fileutils):
 
     exp_name = "test-models-local-restart"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")
@@ -55,8 +55,8 @@ def test_restart(fileutils):
 
 def test_ensemble(fileutils):
     exp_name = "test-ensemble-restart"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -109,7 +109,7 @@ def test_launched_manifest_transform_data():
     ensembles = [(ensemble, [(m, i) for i, m in enumerate(ensemble.entities)])]
     dbs = [(orc, [(n, i) for i, n in enumerate(orc.entities)])]
     launched = LaunchedManifest(
-        metadata=LaunchedManifestMetadata("naem", "path", "launcher"),
+        metadata=LaunchedManifestMetadata("name", "path", "launcher"),
         models=models,
         ensembles=ensembles,
         databases=dbs,

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -30,7 +30,12 @@ from copy import deepcopy
 import pytest
 
 from smartsim import Experiment
-from smartsim._core.control import Manifest
+from smartsim._core.control.manifest import (
+    Manifest,
+    LaunchedManifest,
+    LaunchedManifestBuilder,
+    _LaunchedManifestMetadata as LaunchedManifestMetadata,
+)
 from smartsim.database import Orchestrator
 from smartsim.error import SmartSimError
 from smartsim.settings import RunSettings
@@ -49,7 +54,6 @@ exp = Experiment("util-test", launcher="local")
 model = exp.create_model("model_1", run_settings=rs)
 model_2 = exp.create_model("model_1", run_settings=rs)
 ensemble = exp.create_ensemble("ensemble", run_settings=rs, replicas=1)
-
 
 orc = Orchestrator()
 orc_1 = deepcopy(orc)
@@ -99,3 +103,48 @@ def test_corner_case():
     p = Person()
     with pytest.raises(TypeError):
         _ = Manifest(p)
+
+def test_launched_manifest_transform_data():
+    models = [(model, 1), (model_2, 2)]
+    ensembles = [(ensemble, [(m, i) for i, m in enumerate(ensemble.entities)])]
+    dbs = [(orc, [(n, i) for i, n in enumerate(orc.entities)])]
+    launched = LaunchedManifest(
+        metadata=LaunchedManifestMetadata("naem", "path", "launcher"),
+        models=models,
+        ensembles=ensembles,
+        databases=dbs,
+    )
+    transformed = launched.map(lambda x: str(x))
+    assert transformed.models == tuple((m, str(i)) for m, i in models)
+    assert transformed.ensembles[0][1] == tuple((m, str(i)) for m, i in ensembles[0][1])
+    assert transformed.databases[0][1] == tuple((n, str(i)) for n, i in dbs[0][1])
+
+
+def test_launched_manifest_builder_correctly_maps_data():
+    lmb = LaunchedManifestBuilder()
+    lmb.add_model(model, 1)
+    lmb.add_model(model_2, 1)
+    lmb.add_ensemble(ensemble, [i for i in range(len(ensemble.entities))])
+    lmb.add_database(orc, [i for i in range(len(orc.entities))])
+
+    manifest = lmb.finalize("name", "path", "launcher name")
+    assert len(manifest.models) == 2
+    assert len(manifest.ensembles) == 1
+    assert len(manifest.databases) == 1
+
+
+def test_launced_manifest_builder_raises_if_lens_do_not_match():
+    lmb = LaunchedManifestBuilder()
+    with pytest.raises(ValueError):
+        lmb.add_ensemble(ensemble, list(range(123)))
+    with pytest.raises(ValueError):
+        lmb.add_database(orc, list(range(123)))
+
+
+def test_launched_manifest_builer_raises_if_attaching_data_to_empty_collection(
+    monkeypatch
+):
+    lmb = LaunchedManifestBuilder()
+    monkeypatch.setattr(ensemble, "entities", [])
+    with pytest.raises(ValueError):
+        lmb.add_ensemble(ensemble, [])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -28,6 +28,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim._core.launcher.step import SbatchStep, SrunStep
+from smartsim._core.control.manifest import LaunchedManifestBuilder
 from smartsim.entity import Ensemble, Model
 from smartsim.error import EntityExistsError, SSUnsupportedError
 from smartsim.settings import RunSettings, SbatchSettings, SrunSettings
@@ -85,8 +86,10 @@ def monkeypatch_exp_controller(monkeypatch):
     def _monkeypatch_exp_controller(exp):
         entity_steps = []
 
-        def start_wo_job_manager(self, manifest, block=True, kill_on_interrupt=True):
-            self._launch(manifest)
+        def start_wo_job_manager(self, exp_name, exp_path, manifest,
+                                 block=True, kill_on_interrupt=True):
+            self._launch(exp_name, exp_path, manifest)
+            return LaunchedManifestBuilder().finalize("name", "path", "launcher")
 
         def launch_step_nop(self, step, entity):
             entity_steps.append((step, entity))

--- a/tests/test_multidb.py
+++ b/tests/test_multidb.py
@@ -62,7 +62,7 @@ def test_db_identifier_standard_then_colo(fileutils, wlmutils, coloutils, db_typ
     test_script = fileutils.get_test_conf_path("smartredis/db_id_err.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # create regular database
     orc = exp.create_database(
@@ -132,7 +132,7 @@ def test_db_identifier_colo_then_standard(fileutils, wlmutils, coloutils, db_typ
     test_script = fileutils.get_test_conf_path("smartredis/db_id_err.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create run settings
     colo_settings = exp.create_run_settings("python", test_script)
@@ -175,7 +175,7 @@ def test_db_identifier_colo_then_standard(fileutils, wlmutils, coloutils, db_typ
     exp.stop(orc)
 
 
-def test_db_identifier_standard_twice_not_unique(wlmutils):
+def test_db_identifier_standard_twice_not_unique(wlmutils, fileutils):
     """Test uniqueness of db_identifier several calls to create_database, with non unique names,
     checking error is raised before exp start is called"""
 
@@ -186,9 +186,10 @@ def test_db_identifier_standard_twice_not_unique(wlmutils):
     test_launcher = wlmutils.get_test_launcher()
     test_interface = wlmutils.get_test_interface()
     test_port = wlmutils.get_test_port()
+    test_dir = fileutils.make_test_dir()
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # CREATE DATABASE with db_identifier
     orc = exp.create_database(
@@ -300,7 +301,9 @@ def test_multidb_colo_once(fileutils, wlmutils, coloutils, db_type):
     test_script = fileutils.get_test_conf_path("smartredis/dbid.py")
 
     # start a new Experiment for this section
-    exp = Experiment("test_multidb_colo_once", launcher=test_launcher)
+    exp = Experiment("test_multidb_colo_once",
+                     launcher=test_launcher,
+                     exp_path=test_dir)
 
     # create run settings
     run_settings = exp.create_run_settings("python", test_script)
@@ -466,8 +469,8 @@ def test_launch_cluster_orc_single_dbid(fileutils, wlmutils):
 
     exp_name = "test_launch_cluster_orc_single_dbid"
     launcher = wlmutils.get_test_launcher()
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -67,8 +67,8 @@ def test_inactive_orc_get_address():
 
 def test_orc_active_functions(fileutils, wlmutils):
     exp_name = "test_orc_active_functions"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     db = Orchestrator(port=wlmutils.get_test_port())
     db.set_path(test_dir)
@@ -95,8 +95,8 @@ def test_orc_active_functions(fileutils, wlmutils):
 
 def test_multiple_interfaces(fileutils, wlmutils):
     exp_name = "test_multiple_interfaces"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     net_if_addrs = psutil.net_if_addrs()
     net_if_addrs = [

--- a/tests/test_pals_settings.py
+++ b/tests/test_pals_settings.py
@@ -54,6 +54,11 @@ default_kwargs = {"fail_if_missing_exec": False}
 #    with pytest.raises(SSUnsupportedError):
 #        func(None)
 
+def test_affinity_script():
+    settings = PalsMpiexecSettings(default_exe, **default_kwargs)
+    settings.set_gpu_affinity_script("/path/to/set_affinity_gpu.sh", 1, 2)
+    assert settings.format_run_args() == ["/path/to/set_affinity_gpu.sh", "1", "2"]
+
 
 def test_cpu_binding_type():
     settings = PalsMpiexecSettings(default_exe, **default_kwargs)

--- a/tests/test_reconnect_orchestrator.py
+++ b/tests/test_reconnect_orchestrator.py
@@ -41,8 +41,8 @@ def test_local_orchestrator(fileutils, wlmutils):
     """Test launching orchestrator locally"""
     global first_dir
     exp_name = "test-orc-launch-local"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
     first_dir = test_dir
 
     orc = Orchestrator(port=wlmutils.get_test_port())
@@ -57,12 +57,13 @@ def test_local_orchestrator(fileutils, wlmutils):
     exp._control._launcher.task_manager.actively_monitoring = False
 
 
-def test_reconnect_local_orc():
+def test_reconnect_local_orc(fileutils):
     """Test reconnecting to orchestrator from first experiment"""
     global first_dir
     # start new experiment
     exp_name = "test-orc-local-reconnect-2nd"
-    exp_2 = Experiment(exp_name, launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp_2 = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     checkpoint = osp.join(first_dir, "smartsim_db.dat")
     reloaded_orc = exp_2.reconnect_orchestrator(checkpoint)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import json
+
+from smartsim import Experiment
+from smartsim._core.utils import serialize
+from smartsim._core.control.manifest import LaunchedManifestBuilder
+
+
+def test_serialize_creates_a_maifest_json_file_if_dne(fileutils):
+    test_dir = fileutils.get_test_dir()
+    lmb = LaunchedManifestBuilder()
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    manifest_json = Path(test_dir) / ".smartsim/manifest/manifest.json"
+
+    assert manifest_json.is_file()
+    with open(manifest_json, 'r') as f:
+        manifest = json.load(f)
+        assert manifest["experiment"]["name"] == "exp"
+        assert manifest["experiment"]["launcher"] == "launcher"
+        assert isinstance(manifest["runs"], list)
+        assert len(manifest["runs"]) == 1
+
+
+def test_serialize_appends_a_manifest_json_exists(fileutils):
+    test_dir = fileutils.get_test_dir()
+    lmb = LaunchedManifestBuilder()
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    manifest_json = Path(test_dir) / ".smartsim/manifest/manifest.json"
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+
+    assert manifest_json.is_file()
+    with open(manifest_json, 'r') as f:
+        manifest = json.load(f)
+        assert isinstance(manifest["runs"], list)
+        assert len(manifest["runs"]) == 3
+
+
+def test_serialize_overwites_file_if_not_json(fileutils):
+    test_dir = fileutils.get_test_dir()
+    manifest_json = Path(test_dir) / ".smartsim/manifest/manifest.json"
+    manifest_json.parent.mkdir(parents=True, exist_ok=True)
+    with open(manifest_json, 'w') as f:
+        f.write("This is not a json\n")
+
+    lmb = LaunchedManifestBuilder()
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    with open(manifest_json, 'r') as f:
+        assert isinstance(json.load(f), dict)
+
+
+def test_started_entities_are_serialized(fileutils):
+    exp_name = "test-exp"
+    test_dir = Path(fileutils.make_test_dir()) / exp_name
+    test_dir.mkdir(parents=True)
+    exp = Experiment(exp_name, exp_path=str(test_dir), launcher="local")
+
+    rs1 = exp.create_run_settings("echo", ["hello", "world"])
+    rs2 = exp.create_run_settings("echo", ["spam", "eggs"])
+
+    hello_world_model = exp.create_model("echo-hello", run_settings=rs1)
+    spam_eggs_model = exp.create_model("echo-spam", run_settings=rs2)
+    hello_ensemble = exp.create_ensemble('echo-ensemble', run_settings=rs1, replicas=3)
+
+    exp.generate(hello_world_model, spam_eggs_model, hello_ensemble)
+    exp.start(hello_world_model, spam_eggs_model, block=False)
+    exp.start(hello_ensemble, block=False)
+
+    manifest_json = Path(exp.exp_path) / ".smartsim/manifest/manifest.json"
+    try:
+        with open(manifest_json, 'r') as f:
+            manifest = json.load(f)
+            assert len(manifest["runs"]) == 2
+            assert len(manifest["runs"][0]["model"]) == 2
+            assert len(manifest["runs"][0]["ensemble"]) == 0
+            assert len(manifest["runs"][1]["model"]) == 0
+            assert len(manifest["runs"][1]["ensemble"]) == 1
+            assert len(manifest["runs"][1]["ensemble"][0]["models"]) == 3
+    finally:
+        exp.stop(hello_world_model, spam_eggs_model, hello_ensemble)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -6,7 +6,7 @@ from smartsim._core.utils import serialize
 from smartsim._core.control.manifest import LaunchedManifestBuilder
 
 
-def test_serialize_creates_a_maifest_json_file_if_dne(fileutils):
+def test_serialize_creates_a_manifest_json_file_if_dne(fileutils):
     test_dir = fileutils.get_test_dir()
     lmb = LaunchedManifestBuilder()
     serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))


### PR DESCRIPTION
Bare bones, rough draft implementation of how SmartSim may be able to serialize information about launched entities and/or collections of entities and dump that information to a file so that external or third party tools may be able to display and monitor jobs outside of the process running the python interpreter that ran a driver script.

So far this has been tested by hand and seems to be working for local and slurm launchers for models/ensembles/databases on both interactive and batch jobs.

TODO:
- [x] TESTS!! (unit and integration)
- [ ] Run against other WLMs (mainly PBS)
- [x] Address and remove numerous ``TODO`` and ``FIXME`` comments