### PR TITLE
Switch to `style`

### DIFF
--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -781,18 +781,17 @@ class Experiment:
             logger.error(e)
             raise
 
-    # pylint: disable-next=redefined-builtin
-    def summary(self, format: str = "github") -> str:
+    def summary(self, style: str = "github") -> str:
         """Return a summary of the ``Experiment``
 
         The summary will show each instance that has been
         launched and completed in this ``Experiment``
 
-        :param format: the style in which the summary table is formatted,
+        :param style: the style in which the summary table is formatted,
                        for a full list of styles see:
                        https://github.com/astanin/python-tabulate#table-format,
                        defaults to "github"
-        :type format: str, optional
+        :type style: str, optional
         :return: tabulate string of ``Experiment`` history
         :rtype: str
         """
@@ -823,7 +822,7 @@ class Experiment:
             values,
             headers,
             showindex=True,
-            tablefmt=format,
+            tablefmt=style,
             missingval="None",
             disable_numparse=True,
         )

--- a/tests/on_wlm/test_simple_entity_launch.py
+++ b/tests/on_wlm/test_simple_entity_launch.py
@@ -103,7 +103,7 @@ def test_summary(fileutils, wlmutils):
     assert exp.get_status(bad)[0] == status.STATUS_FAILED
     assert exp.get_status(sleep)[0] == status.STATUS_COMPLETED
 
-    summary_str = exp.summary(format="plain")
+    summary_str = exp.summary(style="plain")
     print(summary_str)
 
     rows = [s.split() for s in summary_str.split("\n")]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -140,7 +140,7 @@ def test_summary(fileutils):
         "model", path=test_dir, run_settings=RunSettings("echo", "Hello")
     )
     exp.start(m)
-    summary_str = exp.summary(format="plain")
+    summary_str = exp.summary(style="plain")
     print(summary_str)
 
     summary_lines = summary_str.split("\n")


### PR DESCRIPTION
This PR addresses the shadowing of the builitin symbol `format` in the signature of the `Experiment.summary()` member function.

A lint pragma instruction could be removed, following renaming of `format` to `style`. As the argument name changes, this has to be considered and API break.