### PR TITLE
Serialize launched entities manifest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -380,10 +380,10 @@ def local_db(
     """Yield fixture for startup and teardown of an local orchestrator"""
 
     exp_name = request.function.__name__
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir(
         caller_function=exp_name, caller_fspath=request.fspath
     )
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
     db = Orchestrator(port=wlmutils.get_test_port(), interface="lo")
     db.set_path(test_dir)
     exp.start(db)
@@ -402,10 +402,10 @@ def db(
     launcher = wlmutils.get_test_launcher()
 
     exp_name = request.function.__name__
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir(
         caller_function=exp_name, caller_fspath=request.fspath
     )
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
     db = wlmutils.get_orchestrator()
     db.set_path(test_dir)
     exp.start(db)
@@ -427,10 +427,10 @@ def db_cluster(
     launcher = wlmutils.get_test_launcher()
 
     exp_name = request.function.__name__
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir(
         caller_function=exp_name, caller_fspath=request.fspath
     )
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
     db = wlmutils.get_orchestrator(nodes=3)
     db.set_path(test_dir)
     exp.start(db)

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -64,9 +64,13 @@ def unpack_colo_db_identifier(db_id: str) -> str:
     return "_" + db_id if db_id else ""
 
 
+def create_short_id_str() -> str:
+    return str(uuid.uuid4())[:7]
+
+
 def create_lockfile_name() -> str:
     """Generate a unique lock filename using UUID"""
-    lock_suffix = str(uuid.uuid4())[:7]
+    lock_suffix = create_short_id_str()
     return f"smartsim-{lock_suffix}.lock"
 
 

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -31,7 +31,7 @@ TStepLaunchMetaData = t.Tuple[
 
 
 def save_launch_manifest(manifest: _Manifest[TStepLaunchMetaData]) -> None:
-    manifest_dir = Path(manifest.metadata.exp_path) / ".smartsim/manifest"
+    manifest_dir = Path(manifest.metadata.exp_path) / ".smartsim/telemetry"
     manifest_dir.mkdir(parents=True, exist_ok=True)
     manifest_file = manifest_dir / "manifest.json"
 
@@ -96,10 +96,11 @@ def _dictify_model(
     return {
         "name": model.name,
         "path": model.path,
+        "exe_args": model.run_settings.exe_args,
         "run_settings": _dictify_run_settings(model.run_settings),
         "batch_settings": _dictify_batch_settings(model.batch_settings)
         if model.batch_settings
-        else None,
+        else {},
         "params": model.params,
         "files": {
             "Symlink": model.files.link,
@@ -134,7 +135,7 @@ def _dictify_model(
             ],
         }
         if colo_settings
-        else None,
+        else {},
         "telemetry_metadata": {
             "status_dir": str(telemetry_data_path / model.name),
             "step_id": step_id,
@@ -142,7 +143,7 @@ def _dictify_model(
             "managed": managed,
         },
         "out_file": out_file,
-        "error_file": err_file,
+        "err_file": err_file,
     }
 
 
@@ -157,7 +158,7 @@ def _dictify_ensemble(
         "batch_settings": _dictify_batch_settings(ens.batch_settings)
         # FIXME: Typehint here is wrong, ``ens.batch_settings`` can
         # also be an empty dict for no discernible reason...
-        if ens.batch_settings else None,
+        if ens.batch_settings else {},
         "models": [
             _dictify_model(
                 model, *launching_metadata, telemetry_data_path / ens.name
@@ -170,7 +171,8 @@ def _dictify_ensemble(
 def _dictify_run_settings(run_settings: RunSettings) -> t.Dict[str, t.Any]:
     return {
         "exe": run_settings.exe,
-        "exe_args": run_settings.exe_args,
+        # TODO: We should try to move this back
+        # "exe_args": run_settings.exe_args,
         "run_command": run_settings.run_command,
         "run_args": run_settings.run_args,
         # TODO: We currently do not have a way to represent MPMD commands!

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -14,6 +14,15 @@ if t.TYPE_CHECKING:
     from smartsim.entity import DBNode, Ensemble, Model
     from smartsim.settings.base import BatchSettings, RunSettings
 
+
+# Many of the required fields for serialization require attrs that protected.
+# I do not want to accidentally expose something to users that should not see
+# for a prototype feature. This suppression should probably be removed before
+# this is officially released!
+#
+# pylint: disable=protected-access
+
+
 _TStepLaunchMetaData = t.Tuple[
     t.Optional[str], t.Optional[str], t.Optional[bool], str, str
 ]
@@ -56,8 +65,8 @@ def save_launch_manifest(
         ],
     }
     try:
-        with open(manifest_file, "r") as fd:
-            manifest_dict = json.load(fd)
+        with open(manifest_file, "r", encoding="utf-8") as file:
+            manifest_dict = json.load(file)
     except (FileNotFoundError, json.JSONDecodeError):
         manifest_dict = {
             "experiment": _dictify_experiment(experiment),
@@ -66,8 +75,8 @@ def save_launch_manifest(
     else:
         manifest_dict["runs"].append(new_run)
     finally:
-        with open(manifest_file, "w") as fd:
-            json.dump(manifest_dict, fd, indent=2)
+        with open(manifest_file, "w", encoding="utf-8") as file:
+            json.dump(manifest_dict, file, indent=2)
 
 
 def _dictify_experiment(exp: Experiment) -> t.Dict[str, str]:
@@ -189,7 +198,7 @@ def _dictify_db(
     if db_path:
         db_type, _ = db_path.name.split("-", 1)
     else:
-        db_type = "Unkown"
+        db_type = "Unknown"
     return {
         "name": db.name,
         "type": db_type,

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -202,8 +202,9 @@ def _dictify_db(
                 "out_file": out_file,
                 "err_file": err_file,
                 "telemetry_metadata": {
-                    "status_dir": telemetry_data_path
-                    / f"database/{db.name}/{dbnode.name}",
+                    "status_dir": str(
+                        telemetry_data_path / f"database/{db.name}/{dbnode.name}"
+                    ),
                     "step_id": step_id,
                     "task_id": task_id,
                     "managed": managed,

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import time
+import typing as t
+from pathlib import Path
+
+import smartsim._core._cli.utils as _utils
+
+if t.TYPE_CHECKING:
+    from smartsim import Experiment
+    from smartsim._core.control.manifest import LaunchedManifest as _Manifest
+    from smartsim.database.orchestrator import Orchestrator
+    from smartsim.entity import DBNode, Ensemble, Model
+    from smartsim.settings.base import BatchSettings, RunSettings
+
+_TStepLaunchMetaData = t.Tuple[
+    t.Optional[str], t.Optional[str], t.Optional[bool], str, str
+]
+
+
+def save_launch_manifest(
+    experiment: Experiment, manifest: _Manifest[_TStepLaunchMetaData]
+) -> None:
+    manifest_dir = Path(experiment.exp_path) / ".smartsim/manifest"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_file = manifest_dir / "manifest.json"
+
+    # FIXME: Did we decide on if this should be uuid/literal count of the
+    #        runs/time since epoch/etc.? Whatever it is, it probably should not
+    #        be secs since epoch as this could lead to conflicts if many
+    #        non-blocking runs are made in quick succession.
+    run_id = int(time.time())
+
+    new_run = {
+        "run_id": run_id,
+        "model": [
+            _dictify_model(
+                model,
+                *telemetry_metadata,
+                manifest_dir / f"{experiment.name}/{run_id}/model",
+            )
+            for model, telemetry_metadata in manifest.models
+        ],
+        "orchestrator": [
+            _dictify_db(
+                db, nodes_info, manifest_dir / f"{experiment.name}/{run_id}/database"
+            )
+            for db, nodes_info in manifest.database
+        ],
+        "ensemble": [
+            _dictify_ensemble(
+                ens, member_info, manifest_dir / f"{experiment.name}/{run_id}/ensemble"
+            )
+            for ens, member_info in manifest.ensembles
+        ],
+    }
+    try:
+        with open(manifest_file, "r") as fd:
+            manifest_dict = json.load(fd)
+    except (FileNotFoundError, json.JSONDecodeError):
+        manifest_dict = {
+            "experiment": _dictify_experiment(experiment),
+            "runs": [new_run],
+        }
+    else:
+        manifest_dict["runs"].append(new_run)
+    finally:
+        with open(manifest_file, "w") as fd:
+            json.dump(manifest_dict, fd, indent=2)
+
+
+def _dictify_experiment(exp: Experiment) -> t.Dict[str, str]:
+    return {
+        "name": exp.name,
+        "path": exp.exp_path,
+        "launcher": exp._launcher,
+    }
+
+
+def _dictify_model(
+    model: Model,
+    step_id: t.Optional[str],
+    task_id: t.Optional[str],
+    managed: t.Optional[bool],
+    out_file: str,
+    err_file: str,
+    telemetry_data_path: Path,
+) -> t.Dict[str, t.Any]:
+    return {
+        "name": model.name,
+        "path": model.path,
+        "run_settings": _dictify_run_settings(model.run_settings),
+        "batch_settings": _dictify_batch_settings(model.batch_settings)
+        if model.batch_settings
+        else None,
+        "params": model.params,
+        "files": {
+            "Symlink": model.files.link,
+            "Configure": model.files.tagged,
+            "Copy": model.files.copy,
+        }
+        if model.files
+        else {
+            "Symlink": [],
+            "Configure": [],
+            "Copy": [],
+        },
+        "colocated_db": {
+            "settings": model.run_settings.colocated_db_settings,
+            "scripts": [
+                {
+                    script.name: {
+                        "backend": "TORCH",
+                        "device": script.device,
+                    }
+                }
+                for script in model._db_scripts
+            ],
+            "models": [
+                {
+                    model.name: {
+                        "backend": model.backend,
+                        "device": model.device,
+                    }
+                }
+                for model in model._db_models
+            ],
+        }
+        if model.run_settings.colocated_db_settings
+        else None,
+        "telemetry_metadata": {
+            "status_dir": str(telemetry_data_path / model.name),
+            "step_id": step_id,
+            "task_id": task_id,
+            "managed": managed,
+        },
+        "out_file": out_file,
+        "error_file": err_file,
+    }
+
+
+def _dictify_ensemble(
+    ens: Ensemble,
+    members: t.List[t.Tuple[Model, _TStepLaunchMetaData]],
+    telemetry_data_path: Path,
+) -> t.Dict[str, t.Any]:
+    return {
+        "name": ens.name,
+        "params": ens.params,
+        "batch_settings": _dictify_batch_settings(ens.batch_settings)
+        # FIXME: Typehint here is wrong, ``ens.batch_settings`` can
+        # also be an empty dict for no discernible reason...
+        if ens.batch_settings else None,
+        "models": [
+            _dictify_model(
+                model, *launching_metadata, telemetry_data_path / f"ensemble/{ens.name}"
+            )
+            for model, launching_metadata in members
+        ],
+    }
+
+
+def _dictify_run_settings(run_settings: RunSettings) -> t.Dict[str, t.Any]:
+    return {
+        "exe": run_settings.exe[0],
+        "exe_args": run_settings.exe_args,
+        "run_command": run_settings.run_command,
+        "run_args": run_settings.run_args,
+        # TODO: We currently do not have a way to represent MPMD commands!
+        #       Maybe add a ``"mpmd"`` key here that is a
+        #       ``list[TDictifiedRunSettings]``?
+    }
+
+
+def _dictify_batch_settings(batch_settings: BatchSettings) -> t.Dict[str, t.Any]:
+    return {
+        "batch_command": batch_settings.batch_cmd,
+        "batch_args": batch_settings.batch_args,
+    }
+
+
+def _dictify_db(
+    db: Orchestrator,
+    nodes: t.List[t.Tuple[DBNode, _TStepLaunchMetaData]],
+    telemetry_data_path: Path,
+) -> t.Dict[str, t.Any]:
+    db_path = _utils.get_db_path()
+    if db_path:
+        db_type, _ = db_path.name.split("-", 1)
+    else:
+        db_type = "Unkown"
+    return {
+        "name": db.name,
+        "type": db_type,
+        "interface": db._interfaces,
+        "shards": [
+            {
+                # FIXME: very sloppy, make this comprehension a fn
+                **shard.to_dict(),
+                "conf_file": shard.cluster_conf_file,
+                "out_file": out_file,
+                "err_file": err_file,
+                "telemetry_metadata": {
+                    "status_dir": telemetry_data_path
+                    / f"database/{db.name}/{dbnode.name}",
+                    "step_id": step_id,
+                    "task_id": task_id,
+                    "managed": managed,
+                },
+            }
+            for dbnode, (step_id, task_id, managed, out_file, err_file) in nodes
+            for shard in dbnode.get_launched_shard_info()
+        ],
+    }

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -163,7 +163,7 @@ def _dictify_ensemble(
 
 def _dictify_run_settings(run_settings: RunSettings) -> t.Dict[str, t.Any]:
     return {
-        "exe": run_settings.exe[0],
+        "exe": run_settings.exe,
         "exe_args": run_settings.exe_args,
         "run_command": run_settings.run_command,
         "run_args": run_settings.run_args,

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -1,3 +1,29 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from __future__ import annotations
 
 import json

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -193,7 +193,7 @@ class Experiment:
         try:
             if summary:
                 self._launch_summary(start_manifest)
-            self._control.start(
+            launched = self._control.start(
                 manifest=start_manifest,
                 block=block,
                 kill_on_interrupt=kill_on_interrupt,

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -31,7 +31,7 @@ from os import getcwd
 from tabulate import tabulate
 
 from ._core import Controller, Generator, Manifest
-from ._core.utils import init_default, serialize
+from ._core.utils import init_default
 from .database import Orchestrator
 from .entity import Ensemble, Model, SmartSimEntity
 from .error import SmartSimError
@@ -193,23 +193,16 @@ class Experiment:
         try:
             if summary:
                 self._launch_summary(start_manifest)
-            launched = self._control.start(
+            self._control.start(
+                exp_name=self.name,
+                exp_path=self.exp_path,
                 manifest=start_manifest,
-                block=False,
+                block=block,
                 kill_on_interrupt=kill_on_interrupt,
             )
         except SmartSimError as e:
             logger.error(e)
             raise
-
-        serialize.save_launch_manifest(self, launched)
-
-        # TODO: remove this temporary hack to move blocking ``poll`` call here
-        # to allow the the run to be serialized (bc we need a ref to the exp).
-        if block:
-            # poll handles its own keyboard interrupt as
-            # it may be called seperately
-            self.poll(5, True, kill_on_interrupt=kill_on_interrupt)
 
     def stop(self, *args: t.Any) -> None:
         """Stop specific instances launched by this ``Experiment``

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -398,7 +398,7 @@ def test_colocated_db_model_tf(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
 
     # Create SmartSim Experience
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -469,7 +469,7 @@ def test_colocated_db_model_pytorch(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_pt_dbmodel_smartredis.py")
 
     # Create the SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -633,7 +633,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
 
     # Create the SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -735,7 +735,7 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -817,6 +817,7 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
 
     with pytest.raises(SSUnsupportedError):
         colo_ensemble.add_model(colo_model)
+
 
 @pytest.mark.skipif(not should_run_tf, reason="Test needs TensorFlow to run")
 def test_inconsistent_params_db_model():

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -245,7 +245,7 @@ def test_colocated_db_script(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create the SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -313,7 +313,7 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -412,7 +412,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -509,7 +509,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create SmartSim experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)

--- a/tests/full_wlm/test_generic_batch_launch.py
+++ b/tests/full_wlm/test_generic_batch_launch.py
@@ -39,8 +39,10 @@ def test_batch_model(fileutils, wlmutils):
     """Test the launch of a manually construced batch model"""
 
     exp_name = "test-batch-model"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     batch_settings = exp.create_batch_settings(nodes=1, time="00:01:00")
@@ -64,8 +66,10 @@ def test_batch_ensemble(fileutils, wlmutils):
     """Test the launch of a manually constructed batch ensemble"""
 
     exp_name = "test-batch-ensemble"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = wlmutils.get_run_settings("python", f"{script} --time=5")
@@ -89,8 +93,10 @@ def test_batch_ensemble(fileutils, wlmutils):
 
 def test_batch_ensemble_replicas(fileutils, wlmutils):
     exp_name = "test-batch-ensemble-replicas"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = wlmutils.get_run_settings("python", f"{script} --time=5")

--- a/tests/full_wlm/test_generic_orc_launch_batch.py
+++ b/tests/full_wlm/test_generic_orc_launch_batch.py
@@ -41,8 +41,8 @@ def test_launch_orc_auto_batch(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-orc-batch"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -77,8 +77,8 @@ def test_launch_cluster_orc_batch_single(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-cluster-orc-batch-single"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -116,8 +116,8 @@ def test_launch_cluster_orc_batch_multi(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-cluster-orc-batch-multi"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -153,8 +153,8 @@ def test_launch_cluster_orc_reconnect(fileutils, wlmutils):
     """test reconnecting to clustered 3-node orchestrator"""
     launcher = wlmutils.get_test_launcher()
     exp_name = "test-launch-cluster-orc-batch-reconect"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()

--- a/tests/full_wlm/test_mpmd.py
+++ b/tests/full_wlm/test_mpmd.py
@@ -61,7 +61,8 @@ def test_mpmd(fileutils, wlmutils):
         "cobalt": ["mpirun"],
     }
 
-    exp = Experiment(exp_name, launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     def prune_commands(launcher):
         available_commands = []
@@ -77,7 +78,6 @@ def test_mpmd(fileutils, wlmutils):
             f"MPMD on {launcher} only supported for run commands {by_launcher[launcher]}"
         )
 
-    test_dir = fileutils.make_test_dir()
     for run_command in run_commands:
         script = fileutils.get_test_conf_path("sleep.py")
         settings = exp.create_run_settings(

--- a/tests/on_wlm/test_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_base_settings_on_wlm.py
@@ -42,8 +42,10 @@ if pytest.test_launcher not in pytest.wlm_options:
 
 def test_model_on_wlm(fileutils, wlmutils):
     exp_name = "test-base-settings-model-launch"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings1 = wlmutils.get_base_run_settings("python", f"{script} --time=5")
@@ -60,8 +62,10 @@ def test_model_on_wlm(fileutils, wlmutils):
 
 def test_model_stop_on_wlm(fileutils, wlmutils):
     exp_name = "test-base-settings-model-stop"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings1 = wlmutils.get_base_run_settings("python", f"{script} --time=5")

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -47,7 +47,8 @@ def test_launch_colocated_model_defaults(fileutils, coloutils, db_type):
 
     db_args = { }
 
-    exp = Experiment("colocated_model_defaults", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher=launcher, exp_path=test_dir)
     colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
@@ -69,7 +70,12 @@ def test_launch_colocated_model_defaults(fileutils, coloutils, db_type):
 @pytest.mark.parametrize("db_type", supported_dbs)
 def test_colocated_model_disable_pinning(fileutils, coloutils, db_type):
 
-    exp = Experiment("colocated_model_pinning_auto_1cpu", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_auto_1cpu",
+        launcher=launcher,
+        exp_path=test_dir
+    )
     db_args = {
         "db_cpus": 1,
         "custom_pinning": [],
@@ -91,7 +97,12 @@ def test_colocated_model_disable_pinning(fileutils, coloutils, db_type):
 @pytest.mark.parametrize("db_type", supported_dbs)
 def test_colocated_model_pinning_auto_2cpu(fileutils, coloutils, db_type):
 
-    exp = Experiment("colocated_model_pinning_auto_2cpu", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_auto_2cpu",
+        launcher=launcher,
+        exp_path=test_dir,
+    )
 
     db_args = {
         "db_cpus": 2,
@@ -115,7 +126,12 @@ def test_colocated_model_pinning_range(fileutils, coloutils, db_type):
     # Check to make sure that the CPU mask was correctly generated
     # Assume that there are at least 4 cpus on the node
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual",
+        launcher=launcher,
+        exp_path=test_dir,
+    )
 
     db_args = {
         "db_cpus": 4,
@@ -139,7 +155,12 @@ def test_colocated_model_pinning_list(fileutils, coloutils, db_type):
     # Check to make sure that the CPU mask was correctly generated
     # note we presume that this has more than 2 CPUs on the supercomputer node
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual",
+        launcher=launcher,
+        exp_path=test_dir,
+    )
 
     db_args = {
         "db_cpus": 2,
@@ -163,7 +184,12 @@ def test_colocated_model_pinning_mixed(fileutils, coloutils, db_type):
     # Check to make sure that the CPU mask was correctly generated
     # note we presume that this at least 4 CPUs on the supercomputer node
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual",
+        launcher=launcher,
+        exp_path=test_dir,
+    )
 
     db_args = {
         "db_cpus": 2,

--- a/tests/on_wlm/test_generic_orc_launch.py
+++ b/tests/on_wlm/test_generic_orc_launch.py
@@ -38,8 +38,8 @@ def test_launch_orc_auto(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-orc"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -71,8 +71,8 @@ def test_launch_cluster_orc_single(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-cluster-orc-single"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -105,8 +105,8 @@ def test_launch_cluster_orc_multi(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-cluster-orc-multi"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()

--- a/tests/on_wlm/test_launch_errors.py
+++ b/tests/on_wlm/test_launch_errors.py
@@ -40,8 +40,10 @@ def test_failed_status(fileutils, wlmutils):
     """Test when a failure occurs deep into model execution"""
 
     exp_name = "test-report-failure"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name,
+            launcher=wlmutils.get_test_launcher(),
+            exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("bad.py")
     settings = exp.create_run_settings(
@@ -69,8 +71,8 @@ def test_bad_run_command_args(fileutils, wlmutils):
         pytest.skip(f"Only fails with slurm. Launcher is {launcher}")
 
     exp_name = "test-bad-run-command-args"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("bad.py")
 

--- a/tests/on_wlm/test_launch_ompi_lsf.py
+++ b/tests/on_wlm/test_launch_ompi_lsf.py
@@ -39,8 +39,8 @@ def test_launch_openmpi_lsf(wlmutils, fileutils):
     if launcher != "lsf":
         pytest.skip("Test only runs on systems with LSF as WLM")
     exp_name = "test-launch-openmpi-lsf"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", script, "mpirun")

--- a/tests/on_wlm/test_restart.py
+++ b/tests/on_wlm/test_restart.py
@@ -38,8 +38,10 @@ if pytest.test_launcher not in pytest.wlm_options:
 def test_restart(fileutils, wlmutils):
 
     exp_name = "test-restart"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name,
+            launcher=wlmutils.get_test_launcher(),
+            exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=5")

--- a/tests/on_wlm/test_simple_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_simple_base_settings_on_wlm.py
@@ -56,8 +56,10 @@ def test_simple_model_on_wlm(fileutils, wlmutils):
         )
 
     exp_name = "test-simplebase-settings-model-launch"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = RunSettings("python", exe_args=f"{script} --time=5")
@@ -77,8 +79,10 @@ def test_simple_model_stop_on_wlm(fileutils, wlmutils):
         )
 
     exp_name = "test-simplebase-settings-model-stop"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = RunSettings("python", exe_args=f"{script} --time=5")

--- a/tests/on_wlm/test_simple_entity_launch.py
+++ b/tests/on_wlm/test_simple_entity_launch.py
@@ -48,8 +48,10 @@ if pytest.test_launcher not in pytest.wlm_options:
 
 def test_models(fileutils, wlmutils):
     exp_name = "test-models-launch"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=5")
@@ -65,8 +67,10 @@ def test_models(fileutils, wlmutils):
 
 def test_ensemble(fileutils, wlmutils):
     exp_name = "test-ensemble-launch"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=5")
@@ -84,8 +88,10 @@ def test_summary(fileutils, wlmutils):
     """Fairly rudimentary test of the summary dataframe"""
 
     exp_name = "test-launch-summary"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     sleep = fileutils.get_test_conf_path("sleep.py")
     bad = fileutils.get_test_conf_path("bad.py")

--- a/tests/on_wlm/test_stop.py
+++ b/tests/on_wlm/test_stop.py
@@ -44,8 +44,10 @@ if pytest.test_launcher not in pytest.wlm_options:
 
 def test_stop_entity(fileutils, wlmutils):
     exp_name = "test-launch-stop-model"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=10")
@@ -62,8 +64,10 @@ def test_stop_entity(fileutils, wlmutils):
 def test_stop_entity_list(fileutils, wlmutils):
 
     exp_name = "test-launch-stop-ensemble"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=10")

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -45,7 +45,8 @@ def test_macosx_warning(fileutils, coloutils):
     db_args = {"custom_pinning": [1]}
     db_type = "uds"  # Test is insensitive to choice of db
 
-    exp = Experiment("colocated_model_defaults", launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher="local", exp_path=test_dir)
     with pytest.warns(
         RuntimeWarning,
         match="CPU pinning is not supported on MacOSX. Ignoring pinning specification.",
@@ -63,7 +64,8 @@ def test_unsupported_limit_app(fileutils, coloutils):
     db_args = {"limit_app_cpus": True}
     db_type = "uds"  # Test is insensitive to choice of db
 
-    exp = Experiment("colocated_model_defaults", launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher="local", exp_path=test_dir)
     with pytest.raises(SSUnsupportedError):
         coloutils.setup_test_colo(
             fileutils,
@@ -80,7 +82,8 @@ def test_unsupported_custom_pinning(fileutils, coloutils, custom_pinning):
     db_type = "uds"  # Test is insensitive to choice of db
     db_args = {"custom_pinning": custom_pinning}
 
-    exp = Experiment("colocated_model_defaults", launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher="local", exp_path=test_dir)
     with pytest.raises(TypeError):
         coloutils.setup_test_colo(
             fileutils,
@@ -116,7 +119,8 @@ def test_launch_colocated_model_defaults(
 
     db_args = {}
 
-    exp = Experiment("colocated_model_defaults", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher=launcher, exp_path=test_dir)
     colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
@@ -146,12 +150,12 @@ def test_launch_colocated_model_defaults(
 def test_launch_multiple_colocated_models(
     fileutils, coloutils, wlmutils, db_type, launcher="local"
 ):
-    """Test the concurrent launch of two models with a colocated database and local launcher
-    """
+    """Test the concurrent launch of two models with a colocated database and local launcher"""
 
     db_args = {}
 
-    exp = Experiment("multi_colo_models", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("multi_colo_models", launcher=launcher, exp_path=test_dir)
     colo_models = [
         coloutils.setup_test_colo(
             fileutils,
@@ -187,7 +191,10 @@ def test_launch_multiple_colocated_models(
 def test_colocated_model_disable_pinning(
     fileutils, coloutils, db_type, launcher="local"
 ):
-    exp = Experiment("colocated_model_pinning_auto_1cpu", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_auto_1cpu", launcher=launcher, exp_path=test_dir
+    )
     db_args = {
         "db_cpus": 1,
         "custom_pinning": [],
@@ -210,7 +217,10 @@ def test_colocated_model_disable_pinning(
 def test_colocated_model_pinning_auto_2cpu(
     fileutils, coloutils, db_type, launcher="local"
 ):
-    exp = Experiment("colocated_model_pinning_auto_2cpu", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_auto_2cpu", launcher=launcher, exp_path=test_dir
+    )
 
     db_args = {
         "db_cpus": 2,
@@ -241,7 +251,10 @@ def test_colocated_model_pinning_auto_2cpu(
 def test_colocated_model_pinning_range(fileutils, coloutils, db_type, launcher="local"):
     # Check to make sure that the CPU mask was correctly generated
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual", launcher=launcher, exp_path=test_dir
+    )
 
     db_args = {"db_cpus": 2, "custom_pinning": range(2)}
 
@@ -263,7 +276,10 @@ def test_colocated_model_pinning_range(fileutils, coloutils, db_type, launcher="
 def test_colocated_model_pinning_list(fileutils, coloutils, db_type, launcher="local"):
     # Check to make sure that the CPU mask was correctly generated
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual", launcher=launcher, exp_path=test_dir
+    )
 
     db_args = {"db_cpus": 1, "custom_pinning": [1]}
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,3 +1,29 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import pytest
 
 from smartsim._core.control.controller import Controller

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,40 @@
+import pytest
+
+from smartsim._core.control.controller import Controller
+from smartsim.settings.slurmSettings import SbatchSettings, SrunSettings
+from smartsim._core.launcher.step import Step
+from smartsim.entity.ensemble import Ensemble
+from smartsim.database.orchestrator import Orchestrator
+
+controller = Controller()
+
+rs = SrunSettings('echo', ['spam', 'eggs'])
+bs = SbatchSettings()
+
+ens = Ensemble("ens", params={}, run_settings=rs, batch_settings=bs, replicas=3)
+orc = Orchestrator(db_nodes=3, batch=True, launcher="slurm", run_command="srun")
+
+class MockStep(Step):
+    @staticmethod
+    def _create_unique_name(name):
+        return name
+
+    def add_to_batch(self, step):
+        ...
+
+    def get_launch_cmd(self):
+        return []
+
+@pytest.mark.parametrize("collection", [
+    pytest.param(ens, id="Ensemble"),
+    pytest.param(orc, id="Database"),
+])
+def test_controller_batch_step_creation_preserves_entity_order(collection, monkeypatch):
+    monkeypatch.setattr(controller._launcher, "create_step",
+                        lambda name, path, settings: MockStep(name, path, settings))
+    entity_names = [x.name for x in collection.entities]
+    assert len(entity_names) == len(set(entity_names))
+    _, steps = controller._create_batch_job_step(collection)
+    assert entity_names == [step.name for step in steps]
+
+    

--- a/tests/test_controller_errors.py
+++ b/tests/test_controller_errors.py
@@ -97,7 +97,7 @@ def test_wrong_orchestrator(wlmutils):
     cont = Controller(launcher="local")
     manifest = Manifest(orc)
     with pytest.raises(SmartSimError):
-        cont._launch(manifest)
+        cont._launch("exp_name", "exp_path", manifest)
 
 
 def test_bad_orc_checkpoint():

--- a/tests/test_dbnode.py
+++ b/tests/test_dbnode.py
@@ -48,8 +48,8 @@ def test_parse_db_host_error():
 
 def test_hosts(fileutils, wlmutils):
     exp_name = "test_hosts"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
 
     orc = Orchestrator(port=wlmutils.get_test_port(), interface="lo", launcher="local")
     orc.set_path(test_dir)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -110,8 +110,8 @@ def test_bad_ensemble_init_no_rs_bs():
 
 def test_stop_entity(fileutils):
     exp_name = "test_stop_entity"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
     m = exp.create_model("model", path=test_dir, run_settings=RunSettings("sleep", "5"))
     exp.start(m, block=False)
     assert exp.finished(m) == False
@@ -122,8 +122,8 @@ def test_stop_entity(fileutils):
 def test_poll(fileutils):
     # Ensure that a SmartSimError is not raised
     exp_name = "test_exp_poll"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
     model = exp.create_model(
         "model", path=test_dir, run_settings=RunSettings("sleep", "5")
     )
@@ -134,8 +134,8 @@ def test_poll(fileutils):
 
 def test_summary(fileutils):
     exp_name = "test_exp_summary"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
     m = exp.create_model(
         "model", path=test_dir, run_settings=RunSettings("echo", "Hello")
     )

--- a/tests/test_launch_errors.py
+++ b/tests/test_launch_errors.py
@@ -45,8 +45,8 @@ def test_unsupported_run_settings():
 
 def test_model_failure(fileutils):
     exp_name = "test-model-failure"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("bad.py")
     settings = RunSettings("python", f"{script} --time=3")
@@ -61,8 +61,8 @@ def test_model_failure(fileutils):
 def test_orchestrator_relaunch(fileutils, wlmutils):
     """Test when users try to launch second orchestrator"""
     exp_name = "test-orc-on-relaunch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     orc = Orchestrator(port=wlmutils.get_test_port())
     orc.set_path(test_dir)

--- a/tests/test_local_launch.py
+++ b/tests/test_local_launch.py
@@ -34,8 +34,8 @@ Test the launch of simple entity types with local launcher
 
 def test_models(fileutils):
     exp_name = "test-models-local-launch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")
@@ -50,8 +50,8 @@ def test_models(fileutils):
 
 def test_ensemble(fileutils):
     exp_name = "test-ensemble-launch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")

--- a/tests/test_local_multi_run.py
+++ b/tests/test_local_multi_run.py
@@ -34,8 +34,8 @@ Test the launch of simple entity types with local launcher
 
 def test_models(fileutils):
     exp_name = "test-models-local-launch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=5")

--- a/tests/test_local_restart.py
+++ b/tests/test_local_restart.py
@@ -35,8 +35,8 @@ Test restarting ensembles and models.
 def test_restart(fileutils):
 
     exp_name = "test-models-local-restart"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")
@@ -55,8 +55,8 @@ def test_restart(fileutils):
 
 def test_ensemble(fileutils):
     exp_name = "test-ensemble-restart"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -109,7 +109,7 @@ def test_launched_manifest_transform_data():
     ensembles = [(ensemble, [(m, i) for i, m in enumerate(ensemble.entities)])]
     dbs = [(orc, [(n, i) for i, n in enumerate(orc.entities)])]
     launched = LaunchedManifest(
-        metadata=LaunchedManifestMetadata("naem", "path", "launcher"),
+        metadata=LaunchedManifestMetadata("name", "path", "launcher"),
         models=models,
         ensembles=ensembles,
         databases=dbs,

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -30,7 +30,12 @@ from copy import deepcopy
 import pytest
 
 from smartsim import Experiment
-from smartsim._core.control import Manifest
+from smartsim._core.control.manifest import (
+    Manifest,
+    LaunchedManifest,
+    LaunchedManifestBuilder,
+    _LaunchedManifestMetadata as LaunchedManifestMetadata,
+)
 from smartsim.database import Orchestrator
 from smartsim.error import SmartSimError
 from smartsim.settings import RunSettings
@@ -49,7 +54,6 @@ exp = Experiment("util-test", launcher="local")
 model = exp.create_model("model_1", run_settings=rs)
 model_2 = exp.create_model("model_1", run_settings=rs)
 ensemble = exp.create_ensemble("ensemble", run_settings=rs, replicas=1)
-
 
 orc = Orchestrator()
 orc_1 = deepcopy(orc)
@@ -99,3 +103,48 @@ def test_corner_case():
     p = Person()
     with pytest.raises(TypeError):
         _ = Manifest(p)
+
+def test_launched_manifest_transform_data():
+    models = [(model, 1), (model_2, 2)]
+    ensembles = [(ensemble, [(m, i) for i, m in enumerate(ensemble.entities)])]
+    dbs = [(orc, [(n, i) for i, n in enumerate(orc.entities)])]
+    launched = LaunchedManifest(
+        metadata=LaunchedManifestMetadata("naem", "path", "launcher"),
+        models=models,
+        ensembles=ensembles,
+        databases=dbs,
+    )
+    transformed = launched.map(lambda x: str(x))
+    assert transformed.models == tuple((m, str(i)) for m, i in models)
+    assert transformed.ensembles[0][1] == tuple((m, str(i)) for m, i in ensembles[0][1])
+    assert transformed.databases[0][1] == tuple((n, str(i)) for n, i in dbs[0][1])
+
+
+def test_launched_manifest_builder_correctly_maps_data():
+    lmb = LaunchedManifestBuilder()
+    lmb.add_model(model, 1)
+    lmb.add_model(model_2, 1)
+    lmb.add_ensemble(ensemble, [i for i in range(len(ensemble.entities))])
+    lmb.add_database(orc, [i for i in range(len(orc.entities))])
+
+    manifest = lmb.finalize("name", "path", "launcher name")
+    assert len(manifest.models) == 2
+    assert len(manifest.ensembles) == 1
+    assert len(manifest.databases) == 1
+
+
+def test_launced_manifest_builder_raises_if_lens_do_not_match():
+    lmb = LaunchedManifestBuilder()
+    with pytest.raises(ValueError):
+        lmb.add_ensemble(ensemble, list(range(123)))
+    with pytest.raises(ValueError):
+        lmb.add_database(orc, list(range(123)))
+
+
+def test_launched_manifest_builer_raises_if_attaching_data_to_empty_collection(
+    monkeypatch
+):
+    lmb = LaunchedManifestBuilder()
+    monkeypatch.setattr(ensemble, "entities", [])
+    with pytest.raises(ValueError):
+        lmb.add_ensemble(ensemble, [])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -28,6 +28,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim._core.launcher.step import SbatchStep, SrunStep
+from smartsim._core.control.manifest import LaunchedManifestBuilder
 from smartsim.entity import Ensemble, Model
 from smartsim.error import EntityExistsError, SSUnsupportedError
 from smartsim.settings import RunSettings, SbatchSettings, SrunSettings
@@ -85,8 +86,10 @@ def monkeypatch_exp_controller(monkeypatch):
     def _monkeypatch_exp_controller(exp):
         entity_steps = []
 
-        def start_wo_job_manager(self, manifest, block=True, kill_on_interrupt=True):
-            self._launch(manifest)
+        def start_wo_job_manager(self, exp_name, exp_path, manifest,
+                                 block=True, kill_on_interrupt=True):
+            self._launch(exp_name, exp_path, manifest)
+            return LaunchedManifestBuilder().finalize("name", "path", "launcher")
 
         def launch_step_nop(self, step, entity):
             entity_steps.append((step, entity))

--- a/tests/test_multidb.py
+++ b/tests/test_multidb.py
@@ -62,7 +62,7 @@ def test_db_identifier_standard_then_colo(fileutils, wlmutils, coloutils, db_typ
     test_script = fileutils.get_test_conf_path("smartredis/db_id_err.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # create regular database
     orc = exp.create_database(
@@ -132,7 +132,7 @@ def test_db_identifier_colo_then_standard(fileutils, wlmutils, coloutils, db_typ
     test_script = fileutils.get_test_conf_path("smartredis/db_id_err.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create run settings
     colo_settings = exp.create_run_settings("python", test_script)
@@ -175,7 +175,7 @@ def test_db_identifier_colo_then_standard(fileutils, wlmutils, coloutils, db_typ
     exp.stop(orc)
 
 
-def test_db_identifier_standard_twice_not_unique(wlmutils):
+def test_db_identifier_standard_twice_not_unique(wlmutils, fileutils):
     """Test uniqueness of db_identifier several calls to create_database, with non unique names,
     checking error is raised before exp start is called"""
 
@@ -186,9 +186,10 @@ def test_db_identifier_standard_twice_not_unique(wlmutils):
     test_launcher = wlmutils.get_test_launcher()
     test_interface = wlmutils.get_test_interface()
     test_port = wlmutils.get_test_port()
+    test_dir = fileutils.make_test_dir()
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # CREATE DATABASE with db_identifier
     orc = exp.create_database(
@@ -300,7 +301,9 @@ def test_multidb_colo_once(fileutils, wlmutils, coloutils, db_type):
     test_script = fileutils.get_test_conf_path("smartredis/dbid.py")
 
     # start a new Experiment for this section
-    exp = Experiment("test_multidb_colo_once", launcher=test_launcher)
+    exp = Experiment("test_multidb_colo_once",
+                     launcher=test_launcher,
+                     exp_path=test_dir)
 
     # create run settings
     run_settings = exp.create_run_settings("python", test_script)
@@ -466,8 +469,8 @@ def test_launch_cluster_orc_single_dbid(fileutils, wlmutils):
 
     exp_name = "test_launch_cluster_orc_single_dbid"
     launcher = wlmutils.get_test_launcher()
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -67,8 +67,8 @@ def test_inactive_orc_get_address():
 
 def test_orc_active_functions(fileutils, wlmutils):
     exp_name = "test_orc_active_functions"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     db = Orchestrator(port=wlmutils.get_test_port())
     db.set_path(test_dir)
@@ -95,8 +95,8 @@ def test_orc_active_functions(fileutils, wlmutils):
 
 def test_multiple_interfaces(fileutils, wlmutils):
     exp_name = "test_multiple_interfaces"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     net_if_addrs = psutil.net_if_addrs()
     net_if_addrs = [

--- a/tests/test_reconnect_orchestrator.py
+++ b/tests/test_reconnect_orchestrator.py
@@ -41,8 +41,8 @@ def test_local_orchestrator(fileutils, wlmutils):
     """Test launching orchestrator locally"""
     global first_dir
     exp_name = "test-orc-launch-local"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
     first_dir = test_dir
 
     orc = Orchestrator(port=wlmutils.get_test_port())
@@ -57,12 +57,13 @@ def test_local_orchestrator(fileutils, wlmutils):
     exp._control._launcher.task_manager.actively_monitoring = False
 
 
-def test_reconnect_local_orc():
+def test_reconnect_local_orc(fileutils):
     """Test reconnecting to orchestrator from first experiment"""
     global first_dir
     # start new experiment
     exp_name = "test-orc-local-reconnect-2nd"
-    exp_2 = Experiment(exp_name, launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp_2 = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     checkpoint = osp.join(first_dir, "smartsim_db.dat")
     reloaded_orc = exp_2.reconnect_orchestrator(checkpoint)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import json
+
+from smartsim import Experiment
+from smartsim._core.utils import serialize
+from smartsim._core.control.manifest import LaunchedManifestBuilder
+
+
+def test_serialize_creates_a_maifest_json_file_if_dne(fileutils):
+    test_dir = fileutils.get_test_dir()
+    lmb = LaunchedManifestBuilder()
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    manifest_json = Path(test_dir) / ".smartsim/manifest/manifest.json"
+
+    assert manifest_json.is_file()
+    with open(manifest_json, 'r') as f:
+        manifest = json.load(f)
+        assert manifest["experiment"]["name"] == "exp"
+        assert manifest["experiment"]["launcher"] == "launcher"
+        assert isinstance(manifest["runs"], list)
+        assert len(manifest["runs"]) == 1
+
+
+def test_serialize_appends_a_manifest_json_exists(fileutils):
+    test_dir = fileutils.get_test_dir()
+    lmb = LaunchedManifestBuilder()
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    manifest_json = Path(test_dir) / ".smartsim/manifest/manifest.json"
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+
+    assert manifest_json.is_file()
+    with open(manifest_json, 'r') as f:
+        manifest = json.load(f)
+        assert isinstance(manifest["runs"], list)
+        assert len(manifest["runs"]) == 3
+
+
+def test_serialize_overwites_file_if_not_json(fileutils):
+    test_dir = fileutils.get_test_dir()
+    manifest_json = Path(test_dir) / ".smartsim/manifest/manifest.json"
+    manifest_json.parent.mkdir(parents=True, exist_ok=True)
+    with open(manifest_json, 'w') as f:
+        f.write("This is not a json\n")
+
+    lmb = LaunchedManifestBuilder()
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    with open(manifest_json, 'r') as f:
+        assert isinstance(json.load(f), dict)
+
+
+def test_started_entities_are_serialized(fileutils):
+    exp_name = "test-exp"
+    test_dir = Path(fileutils.make_test_dir()) / exp_name
+    test_dir.mkdir(parents=True)
+    exp = Experiment(exp_name, exp_path=str(test_dir), launcher="local")
+
+    rs1 = exp.create_run_settings("echo", ["hello", "world"])
+    rs2 = exp.create_run_settings("echo", ["spam", "eggs"])
+
+    hello_world_model = exp.create_model("echo-hello", run_settings=rs1)
+    spam_eggs_model = exp.create_model("echo-spam", run_settings=rs2)
+    hello_ensemble = exp.create_ensemble('echo-ensemble', run_settings=rs1, replicas=3)
+
+    exp.generate(hello_world_model, spam_eggs_model, hello_ensemble)
+    exp.start(hello_world_model, spam_eggs_model, block=False)
+    exp.start(hello_ensemble, block=False)
+
+    manifest_json = Path(exp.exp_path) / ".smartsim/manifest/manifest.json"
+    try:
+        with open(manifest_json, 'r') as f:
+            manifest = json.load(f)
+            assert len(manifest["runs"]) == 2
+            assert len(manifest["runs"][0]["model"]) == 2
+            assert len(manifest["runs"][0]["ensemble"]) == 0
+            assert len(manifest["runs"][1]["model"]) == 0
+            assert len(manifest["runs"][1]["ensemble"]) == 1
+            assert len(manifest["runs"][1]["ensemble"][0]["models"]) == 3
+    finally:
+        exp.stop(hello_world_model, spam_eggs_model, hello_ensemble)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -5,12 +5,14 @@ from smartsim import Experiment
 from smartsim._core.utils import serialize
 from smartsim._core.control.manifest import LaunchedManifestBuilder
 
+_REL_MANIFEST_PATH = ".smartsim/telemetry/manifest.json"
+
 
 def test_serialize_creates_a_maifest_json_file_if_dne(fileutils):
     test_dir = fileutils.get_test_dir()
     lmb = LaunchedManifestBuilder()
     serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
-    manifest_json = Path(test_dir) / ".smartsim/manifest/manifest.json"
+    manifest_json = Path(test_dir) / _REL_MANIFEST_PATH
 
     assert manifest_json.is_file()
     with open(manifest_json, 'r') as f:
@@ -25,7 +27,7 @@ def test_serialize_appends_a_manifest_json_exists(fileutils):
     test_dir = fileutils.get_test_dir()
     lmb = LaunchedManifestBuilder()
     serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
-    manifest_json = Path(test_dir) / ".smartsim/manifest/manifest.json"
+    manifest_json = Path(test_dir) / _REL_MANIFEST_PATH
     serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
     serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
 
@@ -38,7 +40,7 @@ def test_serialize_appends_a_manifest_json_exists(fileutils):
 
 def test_serialize_overwites_file_if_not_json(fileutils):
     test_dir = fileutils.get_test_dir()
-    manifest_json = Path(test_dir) / ".smartsim/manifest/manifest.json"
+    manifest_json = Path(test_dir) / _REL_MANIFEST_PATH
     manifest_json.parent.mkdir(parents=True, exist_ok=True)
     with open(manifest_json, 'w') as f:
         f.write("This is not a json\n")
@@ -66,7 +68,7 @@ def test_started_entities_are_serialized(fileutils):
     exp.start(hello_world_model, spam_eggs_model, block=False)
     exp.start(hello_ensemble, block=False)
 
-    manifest_json = Path(exp.exp_path) / ".smartsim/manifest/manifest.json"
+    manifest_json = Path(exp.exp_path) / _REL_MANIFEST_PATH
     try:
         with open(manifest_json, 'r') as f:
             manifest = json.load(f)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,3 +1,29 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from pathlib import Path
 import json
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -8,7 +8,7 @@ from smartsim._core.control.manifest import LaunchedManifestBuilder
 _REL_MANIFEST_PATH = ".smartsim/telemetry/manifest.json"
 
 
-def test_serialize_creates_a_maifest_json_file_if_dne(fileutils):
+def test_serialize_creates_a_manifest_json_file_if_dne(fileutils):
     test_dir = fileutils.get_test_dir()
     lmb = LaunchedManifestBuilder()
     serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))


### PR DESCRIPTION
Bare bones, rough draft implementation of how SmartSim may be able to serialize information about launched entities and/or collections of entities and dump that information to a file so that external or third party tools may be able to display and monitor jobs outside of the process running the python interpreter that ran a driver script.

So far this has been tested by hand and seems to be working for local and slurm launchers for models/ensembles/databases on both interactive and batch jobs.

TODO:
- [x] TESTS!! (unit and integration)
- [x] Run against other WLMs (mainly PBS)
- [x] Address and remove numerous ``TODO`` and ``FIXME`` comments