### PR TITLE
Fixes to multi-db introspection

### DIFF
--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -313,8 +313,8 @@ class JobManager:
         :rtype: Dict[str, list]"""
 
         address_dict = {}
-        addresses = []
         for db_job in self.db_jobs.values():
+            addresses = []
             if isinstance(db_job.entity, (DBNode, Orchestrator)):
                 db_entity = db_job.entity
                 for combine in itertools.product(db_job.hosts, db_entity.ports):

--- a/smartsim/_core/control/manifest.py
+++ b/smartsim/_core/control/manifest.py
@@ -180,8 +180,6 @@ class Manifest:
             return len(list(entity.db_scripts)) > 0
 
         has_db_objects = False
-        for model in self.models:
-            has_db_objects |= hasattr(model, "_db_models")
 
         # Check if any model has either a DBModel or a DBScript
         # we update has_db_objects so that as soon as one check


### PR DESCRIPTION
This PR fixes a bug encountered when launching more than one DB from a driver script. Addresses of running DBs could get mixed and some internal checks would incorrectly fail.