### PR TITLE
Pin version of types-tensorflow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ extras_require = {
         "types-redis",
         "types-tabulate",
         "types-tqdm",
-        "types-tensorflow",
+        "types-tensorflow==2.12.0.9",
         "types-setuptools",
     ],
     # see smartsim/_core/_install/buildenv.py for more details


### PR DESCRIPTION
With the last update of `types-tensorflow` (2.12.0.10), some types are not defined anymore, and this causes mypy to fail.

This PR pins the version number to `2.12.0.9`, which is the last compatible with TF `2.8.x`.