### PR TITLE
Add cooldown period to avoid immediate termination of telemetry monitor

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -48,6 +48,9 @@ from smartsim._core.config import CONFIG
 from smartsim.error import SSConfigError
 from subprocess import run
 import sys
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
 import typing as t
 
 
@@ -666,6 +669,18 @@ class MLUtils:
     def get_test_num_gpus() -> int:
         return test_num_gpus
 
+    @staticmethod
+    def save_torch_cnn(path: str, file_name: str):
+        """Create a simple torch CNN and save to file specified by path and file_name"""
+        model = PyTorchNet()
+        example_forward_input = torch.rand(1, 1, 28, 28)
+        module = torch.jit.trace(model, example_forward_input)
+
+        output_path = path + "/" + file_name
+        torch.jit.save(module, output_path)
+
+        return output_path
+
 
 @pytest.fixture
 def coloutils() -> t.Type[ColoUtils]:
@@ -716,3 +731,29 @@ class ColoUtils:
         assert colo_model.colocated
         # Check to make sure that limit_db_cpus made it into the colo settings
         return colo_model
+
+
+class PyTorchNet(nn.Module):
+    def __init__(self):
+        super(PyTorchNet, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -212,6 +212,10 @@ class Config:
     def telemetry_enabled(self) -> bool:
         return bool(os.environ.get("SMARTSIM_FLAG_TELEMETRY", 1))
 
+    @property
+    def telemetry_cooldown(self) -> int:
+        return int(os.environ.get("SMARTSIM_TELEMETRY_COOLDOWN", 90))
+
 @lru_cache(maxsize=128, typed=False)
 def get_config() -> Config:
     # wrap into a function with a cached result

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -821,21 +821,25 @@ class Controller:
             self._telemetry_monitor is None
             or self._telemetry_monitor.returncode is not None
         ):
+            cmd = [
+                sys.executable,
+                "-m",
+                "smartsim._core.entrypoints.telemetrymonitor",
+                "-exp_dir",
+                exp_dir,
+                "-frequency",
+                str(frequency),
+                "-cooldown",
+                str(CONFIG.telemetry_cooldown),
+            ]
             # pylint: disable-next=consider-using-with
             self._telemetry_monitor = subprocess.Popen(
-                [
-                    sys.executable,
-                    "-m",
-                    "smartsim._core.entrypoints.telemetrymonitor",
-                    "-exp_dir",
-                    exp_dir,
-                    "-frequency",
-                    str(frequency),
-                ],
+                cmd,
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 cwd=str(pathlib.Path(__file__).parent.parent.parent),
                 shell=False,
+                # start_new_session=True,
             )
 
 

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -835,8 +835,8 @@ class Controller:
             # pylint: disable-next=consider-using-with
             self._telemetry_monitor = subprocess.Popen(
                 cmd,
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
+                stderr=sys.stderr,
+                stdout=sys.stdout,
                 cwd=str(pathlib.Path(__file__).parent.parent.parent),
                 shell=False,
             )

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -839,7 +839,6 @@ class Controller:
                 stdout=subprocess.PIPE,
                 cwd=str(pathlib.Path(__file__).parent.parent.parent),
                 shell=False,
-                # start_new_session=True,
             )
 
 

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -310,7 +310,7 @@ class ManifestEventHandler(PatternMatchingEventHandler):
         self._tracked_jobs: t.Dict[_JobKey, JobEntity] = {}
         self._completed_jobs: t.Dict[_JobKey, JobEntity] = {}
         self._launcher: t.Optional[Launcher] = None
-        self.job_manager: JobManager = JobManager(threading.RLock())
+        self.job_manager = JobManager(threading.RLock())
         self._launcher_map: t.Dict[str, t.Type[Launcher]] = {
             "slurm": SlurmLauncher,
             "pbs": PBSLauncher,
@@ -643,7 +643,13 @@ if __name__ == "__main__":
     parser = get_parser()
     args = parser.parse_args()
 
-    log = logging.getLogger()
+    log = logging.getLogger(f"{__name__}.TelemetryMonitor")
+    log.setLevel(logging.DEBUG)
+    log.propagate = False
+
+    log_path = os.path.join(args.exp_dir, TELMON_SUBDIR, "telemetrymonitor.log")
+    fh = logging.FileHandler(log_path, 'a')
+    log.addHandler(fh)
 
     # Must register cleanup before the main loop is running
     register_signal_handlers()

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -322,7 +322,7 @@ class ManifestEventHandler(PatternMatchingEventHandler):
         self._tracked_jobs: t.Dict[_JobKey, JobEntity] = {}
         self._completed_jobs: t.Dict[_JobKey, JobEntity] = {}
         self._launcher: t.Optional[Launcher] = None
-        self.job_manager = JobManager(threading.RLock())
+        self.job_manager: JobManager = JobManager(threading.RLock())
         self._launcher_map: t.Dict[str, t.Type[Launcher]] = {
             "slurm": SlurmLauncher,
             "pbs": PBSLauncher,

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -360,7 +360,8 @@ class ManifestEventHandler(PatternMatchingEventHandler):
             self._logger.error("Manifest content error", exc_info=True)
             return
 
-        self.set_launcher(manifest.launcher)
+        if self._launcher is None:
+            self.set_launcher(manifest.launcher)
 
         if not self._launcher:
             raise SmartSimError(f"Unable to set launcher from {manifest_path}")

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -509,7 +509,7 @@ def can_shutdown(action_handler: ManifestEventHandler, logger: logging.Logger) -
     if has_jobs:
         logger.debug(f"telemetry monitor is monitoring {len(jobs)} jobs")
     if has_dbs:
-        logger.debug(f"telemetry monitor is monitoring {len(jobs)} dbs")
+        logger.debug(f"telemetry monitor is monitoring {len(db_jobs)} dbs")
 
     return not has_running_jobs
 

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -641,7 +641,7 @@ def get_parser() -> argparse.ArgumentParser:
     arg_parser.add_argument(
         "-cooldown",
         type=int,
-        help="Default lifetime of telemetry monitor (in seconds)) before auto-shutdown",
+        help="Default lifetime of telemetry monitor (in seconds) before auto-shutdown",
         default=CONFIG.telemetry_cooldown,
     )
     return arg_parser

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -608,7 +608,7 @@ def get_parser() -> argparse.ArgumentParser:
     arg_parser = argparse.ArgumentParser(description="SmartSim Telemetry Monitor")
     arg_parser.add_argument(
         "-frequency",
-        type=str,
+        type=int,
         help="Frequency of telemetry updates (in seconds))",
         required=True,
     )

--- a/tests/test_configs/printing_model.py
+++ b/tests/test_configs/printing_model.py
@@ -1,0 +1,18 @@
+import time
+import sys
+
+
+def main() -> int:
+    print(";START;")
+    time.sleep(20)
+    print(";MID;")
+    print("This is an error msg", file=sys.stderr)
+    time.sleep(20)
+    print(";END;")
+
+    print("yay!!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -294,9 +294,11 @@ def test_shutdown_conditions():
     job_entity1.step_id = "123"
     job_entity1.task_id = ""
 
+    logger = logging.getLogger()
+
     # show that an event handler w/no monitored jobs can shutdown
     mani_handler = ManifestEventHandler("xyz", logger)
-    assert can_shutdown(mani_handler)
+    assert can_shutdown(mani_handler, logger)
 
     # show that an event handler w/a monitored job cannot shutdown
     mani_handler = ManifestEventHandler("xyz", logger)
@@ -304,7 +306,7 @@ def test_shutdown_conditions():
                                      job_entity1.step_id,
                                      job_entity1,
                                      False)
-    assert not can_shutdown(mani_handler)
+    assert not can_shutdown(mani_handler, logger)
     assert not bool(mani_handler.job_manager.db_jobs)
     assert bool(mani_handler.job_manager.jobs)
 
@@ -315,7 +317,7 @@ def test_shutdown_conditions():
                                      job_entity1.step_id,
                                      job_entity1,
                                      False)
-    assert not can_shutdown(mani_handler)
+    assert not can_shutdown(mani_handler, logger)
     assert bool(mani_handler.job_manager.db_jobs)
     assert not bool(mani_handler.job_manager.jobs)
 
@@ -336,17 +338,17 @@ def test_shutdown_conditions():
                                     job_entity2.step_id,
                                     job_entity2,
                                     False)
-    assert not can_shutdown(mani_handler)
+    assert not can_shutdown(mani_handler, logger)
     assert bool(mani_handler.job_manager.db_jobs)
     assert bool(mani_handler.job_manager.jobs)
 
     # ... now, show that removing 1 of 2 jobs still doesn't shutdown
     mani_handler.job_manager.db_jobs.popitem()
-    assert not can_shutdown(mani_handler)
+    assert not can_shutdown(mani_handler, logger)
 
     # ... now, show that removing final job will allow shutdown
     mani_handler.job_manager.jobs.popitem()
-    assert can_shutdown(mani_handler)
+    assert can_shutdown(mani_handler, logger)
 
 
 def test_auto_shutdown():

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -830,7 +830,7 @@ def test_telemetry_autoshutdown(fileutils, wlmutils, monkeypatch, frequency, coo
             time.sleep(3)
 
         assert popen.returncode is not None
-        assert stop_time >= (start_time + cooldown - 3)
+        assert stop_time >= (start_time + cooldown)
 
 
 class MockStep(Step):

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -978,7 +978,7 @@ def test_multistart_experiment(mlutils: MLUtils,
     model = exp.create_model("my-model", run_settings=rs_m)
     model.colocate_db_tcp(port=5757, db_identifier="COLO")
 
-    model_file = mlutils.save_torch_cnn(test_dir, "model1.pt")
+    model_file = mlutils.save_torch_cnn(test_dir, f"model_{uuid.uuid4()}.pt")
     model.add_ml_model(
             "cnn",
             "TORCH",

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -100,7 +100,7 @@ def test_parser():
     parser = get_parser()
 
     test_dir = "/foo/bar"
-    test_freq = "123"
+    test_freq = 123
 
     cmd = f"-exp_dir {test_dir} -frequency {test_freq}"
     args = cmd.split()

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -656,7 +656,7 @@ def test_telemetry_db_only_without_generate(fileutils, wlmutils, monkeypatch):
         finally:
             exp.stop(orc)
         
-        snooze_nonblocking(test_dir, max_delay=60, post_data_delay=30)
+        snooze_nonblocking(test_dir, max_delay=60, post_data_delay=10)
         assert exp.get_status(orc)[0] == STATUS_CANCELLED
 
         stop_events = list(telemetry_output_path.rglob("stop.json"))
@@ -689,8 +689,6 @@ def test_telemetry_db_and_model(fileutils, wlmutils, monkeypatch):
         orc = exp.create_database(port=test_port, interface=test_interface)
         try:
             exp.start(orc)
-
-            snooze_nonblocking(test_dir, max_delay=60, post_data_delay=30)
 
             # create run settings
             app_settings = exp.create_run_settings("python", test_script)

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -1091,11 +1091,13 @@ def test_faux_rc(status_in: str, expected_out: t.Optional[int]):
         pytest.param(STATUS_RUNNING, None, True, id="failure on running"),
     ],
 )
-def test_wlm_completion_handling(fileutils: FileUtils, 
-                                 monkeypatch: pytest.MonkeyPatch,
-                                 status_in: str,
-                                 expected_out: t.Optional[int],
-                                 expected_has_jobs: bool):
+def test_wlm_completion_handling(
+    fileutils: FileUtils,
+    monkeypatch: pytest.MonkeyPatch,
+    status_in: str,
+    expected_out: t.Optional[int],
+    expected_has_jobs: bool,
+):
     test_dir = fileutils.make_test_dir(sub_dir=str(uuid.uuid4()))
 
     def get_faux_update(status: str) -> t.Callable:
@@ -1114,14 +1116,14 @@ def test_wlm_completion_handling(fileutils: FileUtils,
 
         # prep a fake job to request updates for
         job_entity = JobEntity()
-        job_entity.name="faux-name"
-        job_entity.step_id="faux-step-id"
-        job_entity.task_id=1234
-        job_entity.status_dir=test_dir
+        job_entity.name = "faux-name"
+        job_entity.step_id = "faux-step-id"
+        job_entity.task_id = 1234
+        job_entity.status_dir = test_dir
         job_entity.type = "orchestrator"
 
         job = Job(job_entity.name, job_entity.step_id, job_entity, "slurm", True)
-        
+
         # populate our tracking collections
         mani_handler._tracked_jobs = {job_entity.key: job_entity}
         mani_handler.job_manager.jobs[job.name] = job
@@ -1134,8 +1136,7 @@ def test_wlm_completion_handling(fileutils: FileUtils,
 
         # see that the event was properly written
         stop_event_path = pathlib.Path(test_dir) / "stop.json"
-        
+
         # if a status wasn't terminal, no stop event should have been written
         should_have_stop_event = False if expected_out is None else True
         assert should_have_stop_event == stop_event_path.exists()
-

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -809,6 +809,8 @@ def test_telemetry_autoshutdown(fileutils, wlmutils, monkeypatch, frequency, coo
         # Create SmartSim Experiment
         exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
+        start_time = get_ts()
+        stop_time = start_time
         exp.start(block=False)
 
         telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
@@ -822,11 +824,13 @@ def test_telemetry_autoshutdown(fileutils, wlmutils, monkeypatch, frequency, coo
         # give some leeway during testing for the cooldown to get hit
         for i in range(10):
             if popen.poll() is not None:
+                stop_time = get_ts()
                 print(f"Completed polling for telemetry shutdown after {i} attempts")
                 break
             time.sleep(3)
 
         assert popen.returncode is not None
+        assert stop_time >= (start_time + cooldown - 3)
 
 
 class MockStep(Step):

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -35,18 +35,31 @@ import typing as t
 import time
 import uuid
 from conftest import FileUtils, MLUtils, WLMUtils
+import smartsim
 
-from smartsim._core.control.job import Job, JobEntity
+from smartsim._core.control.jobmanager import JobManager
+from smartsim._core.control.job import Job, JobEntity, _JobKey
 from smartsim._core.launcher.launcher import WLMLauncher
+from smartsim._core.launcher.slurm.slurmLauncher import SlurmLauncher
 from smartsim._core.launcher.step.step import Step, proxyable_launch_cmd
+from smartsim._core.launcher.stepInfo import StepInfo
 from smartsim.error.errors import UnproxyableStepError
 from smartsim.settings.base import RunSettings
-from smartsim.status import STATUS_COMPLETED, STATUS_CANCELLED
+from smartsim.status import (
+    STATUS_COMPLETED,
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_NEW,
+    STATUS_PAUSED,
+    STATUS_RUNNING,
+    TERMINAL_STATUSES,
+)
 import smartsim._core.config.config as cfg
 
 from smartsim._core.entrypoints.telemetrymonitor import (
     can_shutdown,
     event_loop,
+    faux_return_code,
     get_parser,
     get_ts,
     track_event,
@@ -63,9 +76,10 @@ PROXY_ENTRY_POINT = "smartsim._core.entrypoints.indirect"
 CFG_TM_ENABLED_ATTR = "telemetry_enabled"
 
 
-for_all_wlm_launchers = pytest.mark.parametrize("wlm_launcher", [
-    pytest.param(cls(), id=cls.__name__) for cls in WLMLauncher.__subclasses__()
-])
+for_all_wlm_launchers = pytest.mark.parametrize(
+    "wlm_launcher",
+    [pytest.param(cls(), id=cls.__name__) for cls in WLMLauncher.__subclasses__()],
+)
 
 
 logger = logging.getLogger()
@@ -135,12 +149,8 @@ def test_ts():
 @pytest.mark.parametrize(
     ["etype", "task_id", "step_id", "timestamp", "evt_type"],
     [
-        pytest.param(
-            "ensemble", "", "123", get_ts(), "start", id="start event"
-        ),
-        pytest.param(
-            "ensemble", "", "123", get_ts(), "start", id="stop event"
-        ),
+        pytest.param("ensemble", "", "123", get_ts(), "start", id="start event"),
+        pytest.param("ensemble", "", "123", get_ts(), "start", id="stop event"),
     ],
 )
 def test_track_event(
@@ -169,7 +179,9 @@ def test_load_manifest(fileutils: FileUtils):
     assert sample_manifest.exists()
 
     test_manifest_path = fileutils.make_test_file(
-        serialize.MANIFEST_FILENAME, serialize.TELMON_SUBDIR, sample_manifest.read_text()
+        serialize.MANIFEST_FILENAME,
+        serialize.TELMON_SUBDIR,
+        sample_manifest.read_text(),
     )
     test_manifest = pathlib.Path(test_manifest_path)
     assert test_manifest.exists()
@@ -196,7 +208,10 @@ def test_load_manifest_colo_model(fileutils: FileUtils):
 
     manifest = load_manifest(sample_manifest_path)
     assert manifest.name == "my-exp"
-    assert str(manifest.path) == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp"
+    assert (
+        str(manifest.path)
+        == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp"
+    )
     assert manifest.launcher == "Slurm"
     assert len(manifest.runs) == 1
 
@@ -212,7 +227,10 @@ def test_load_manifest_serial_models(fileutils: FileUtils):
 
     manifest = load_manifest(sample_manifest_path)
     assert manifest.name == "my-exp"
-    assert str(manifest.path) == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp"
+    assert (
+        str(manifest.path)
+        == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp"
+    )
     assert manifest.launcher == "Slurm"
     assert len(manifest.runs) == 1
 
@@ -228,7 +246,10 @@ def test_load_manifest_db_and_models(fileutils: FileUtils):
 
     manifest = load_manifest(sample_manifest_path)
     assert manifest.name == "my-exp"
-    assert str(manifest.path) == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp"
+    assert (
+        str(manifest.path)
+        == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp"
+    )
     assert manifest.launcher == "Slurm"
     assert len(manifest.runs) == 2
 
@@ -239,13 +260,18 @@ def test_load_manifest_db_and_models(fileutils: FileUtils):
 def test_load_manifest_db_and_models_1run(fileutils: FileUtils):
     """Ensure that the runtime manifest loads correctly when containing models & orchestrator"""
     # NOTE: for regeneration, this manifest can use `test_telemetry_colo`
-    sample_manifest_path = fileutils.get_test_conf_path("telemetry/db_and_model_1run.json")
+    sample_manifest_path = fileutils.get_test_conf_path(
+        "telemetry/db_and_model_1run.json"
+    )
     sample_manifest = pathlib.Path(sample_manifest_path)
     assert sample_manifest.exists()
 
     manifest = load_manifest(sample_manifest_path)
     assert manifest.name == "my-exp"
-    assert str(manifest.path) == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp"
+    assert (
+        str(manifest.path)
+        == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp"
+    )
     assert manifest.launcher == "Slurm"
     assert len(manifest.runs) == 1
 
@@ -301,7 +327,6 @@ def test_deserialize_ensemble(fileutils: FileUtils):
     assert len(manifest.runs[0].models) == 8
 
 
-
 def test_shutdown_conditions():
     """Ensure conditions to shutdown telemetry monitor are correctly evaluated"""
     job_entity1 = JobEntity()
@@ -317,10 +342,9 @@ def test_shutdown_conditions():
 
     # show that an event handler w/a monitored job cannot shutdown
     mani_handler = ManifestEventHandler("xyz", logger)
-    mani_handler.job_manager.add_job(job_entity1.name,
-                                     job_entity1.step_id,
-                                     job_entity1,
-                                     False)
+    mani_handler.job_manager.add_job(
+        job_entity1.name, job_entity1.step_id, job_entity1, False
+    )
     assert not can_shutdown(mani_handler, logger)
     assert not bool(mani_handler.job_manager.db_jobs)
     assert bool(mani_handler.job_manager.jobs)
@@ -328,10 +352,9 @@ def test_shutdown_conditions():
     # show that an event handler w/a monitored db cannot shutdown
     mani_handler = ManifestEventHandler("xyz", logger)
     job_entity1.type = "orchestrator"
-    mani_handler.job_manager.add_job(job_entity1.name,
-                                     job_entity1.step_id,
-                                     job_entity1,
-                                     False)
+    mani_handler.job_manager.add_job(
+        job_entity1.name, job_entity1.step_id, job_entity1, False
+    )
     assert not can_shutdown(mani_handler, logger)
     assert bool(mani_handler.job_manager.db_jobs)
     assert not bool(mani_handler.job_manager.jobs)
@@ -344,15 +367,13 @@ def test_shutdown_conditions():
 
     mani_handler = ManifestEventHandler("xyz", logger)
     job_entity1.type = "orchestrator"
-    mani_handler.job_manager.add_job(job_entity1.name,
-                                     job_entity1.step_id,
-                                     job_entity1,
-                                     False)
+    mani_handler.job_manager.add_job(
+        job_entity1.name, job_entity1.step_id, job_entity1, False
+    )
 
-    mani_handler.job_manager.add_job(job_entity2.name,
-                                    job_entity2.step_id,
-                                    job_entity2,
-                                    False)
+    mani_handler.job_manager.add_job(
+        job_entity2.name, job_entity2.step_id, job_entity2, False
+    )
     assert not can_shutdown(mani_handler, logger)
     assert bool(mani_handler.job_manager.db_jobs)
     assert bool(mani_handler.job_manager.jobs)
@@ -368,6 +389,7 @@ def test_shutdown_conditions():
 
 def test_auto_shutdown():
     """Ensure that the cooldown timer is respected"""
+
     class FauxObserver:
         def __init__(self):
             self.stop_count = 0
@@ -380,14 +402,14 @@ def test_auto_shutdown():
                 return False
 
             return True
-    
+
     job_entity1 = JobEntity()
     job_entity1.name = "xyz"
     job_entity1.step_id = "123"
     job_entity1.task_id = ""
 
     frequency = 1
-    
+
     # show that an event handler w/out a monitored task will automatically stop
     mani_handler = ManifestEventHandler("xyz", logger)
     observer = FauxObserver()
@@ -448,7 +470,7 @@ def test_telemetry_single_model(fileutils, wlmutils):
 
 
 def test_telemetry_single_model_nonblocking(fileutils, wlmutils, monkeypatch):
-    """Ensure that the telemetry monitor logs exist when the experiment 
+    """Ensure that the telemetry monitor logs exist when the experiment
     is non-blocking"""
     with monkeypatch.context() as ctx:
         ctx.setattr(cfg.Config, "telemetry_frequency", 1)
@@ -510,10 +532,14 @@ def test_telemetry_serial_models(fileutils, wlmutils, monkeypatch):
         app_settings.set_tasks_per_node(1)
 
         #  # Create the SmartSim Model
-        smartsim_models = [ exp.create_model(f"perroquet_{i}", app_settings) for i in range(5) ]
+        smartsim_models = [
+            exp.create_model(f"perroquet_{i}", app_settings) for i in range(5)
+        ]
         exp.generate(*smartsim_models)
         exp.start(*smartsim_models, block=True)
-        assert all([status == STATUS_COMPLETED for status in exp.get_status(*smartsim_models)])
+        assert all(
+            [status == STATUS_COMPLETED for status in exp.get_status(*smartsim_models)]
+        )
 
         telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
         start_events = list(telemetry_output_path.rglob("start.json"))
@@ -530,7 +556,7 @@ def test_telemetry_serial_models_nonblocking(fileutils, wlmutils, monkeypatch):
     """
     with monkeypatch.context() as ctx:
         ctx.setattr(cfg.Config, "telemetry_frequency", 1)
-    
+
         # Set experiment name
         exp_name = "telemetry_serial_models"
 
@@ -548,13 +574,17 @@ def test_telemetry_serial_models_nonblocking(fileutils, wlmutils, monkeypatch):
         app_settings.set_tasks_per_node(1)
 
         #  # Create the SmartSim Model
-        smartsim_models = [ exp.create_model(f"perroquet_{i}", app_settings) for i in range(5) ]
+        smartsim_models = [
+            exp.create_model(f"perroquet_{i}", app_settings) for i in range(5)
+        ]
         exp.generate(*smartsim_models)
         exp.start(*smartsim_models)
 
         snooze_nonblocking(test_dir, max_delay=60, post_data_delay=10)
 
-        assert all([status == STATUS_COMPLETED for status in exp.get_status(*smartsim_models)])
+        assert all(
+            [status == STATUS_COMPLETED for status in exp.get_status(*smartsim_models)]
+        )
 
         telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
         start_events = list(telemetry_output_path.rglob("start.json"))
@@ -641,7 +671,7 @@ def test_telemetry_db_only_without_generate(fileutils, wlmutils, monkeypatch):
             assert len(stop_events) == 0
         finally:
             exp.stop(orc)
-        
+
         snooze_nonblocking(test_dir, max_delay=60, post_data_delay=10)
         assert exp.get_status(orc)[0] == STATUS_CANCELLED
 
@@ -686,7 +716,7 @@ def test_telemetry_db_and_model(fileutils, wlmutils, monkeypatch):
             exp.start(smartsim_model, block=True)
         finally:
             exp.stop(orc)
-            
+
         snooze_nonblocking(test_dir, max_delay=60, post_data_delay=30)
 
         assert exp.get_status(orc)[0] == STATUS_CANCELLED
@@ -771,7 +801,9 @@ def test_telemetry_colo(fileutils, wlmutils, coloutils, monkeypatch):
 
         exp.generate(smartsim_model)
         exp.start(smartsim_model, block=True)
-        assert all([status == STATUS_COMPLETED for status in exp.get_status(smartsim_model)])
+        assert all(
+            [status == STATUS_COMPLETED for status in exp.get_status(smartsim_model)]
+        )
 
         telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
         start_events = list(telemetry_output_path.rglob("start.json"))
@@ -782,12 +814,13 @@ def test_telemetry_colo(fileutils, wlmutils, coloutils, monkeypatch):
         assert len(stop_events) == 1
 
 
-@pytest.mark.parametrize("frequency, cooldown",
-        [
-            pytest.param(1, 1, id="1s shutdown"),
-            pytest.param(1, 5, id="5s shutdown"),
-            pytest.param(1, 15, id="15s shutdown"),
-        ]
+@pytest.mark.parametrize(
+    "frequency, cooldown",
+    [
+        pytest.param(1, 1, id="1s shutdown"),
+        pytest.param(1, 5, id="5s shutdown"),
+        pytest.param(1, 15, id="15s shutdown"),
+    ],
 )
 def test_telemetry_autoshutdown(fileutils, wlmutils, monkeypatch, frequency, cooldown):
     """
@@ -837,6 +870,7 @@ class MockStep(Step):
     """Mock step to implement any abstract methods so that it can be
     instanced for test purposes
     """
+
     def get_launch_cmd(self):
         return ["spam", "eggs"]
 
@@ -854,15 +888,13 @@ def mock_step_meta_dict(fileutils):
 @pytest.fixture
 def mock_step(fileutils, mock_step_meta_dict):
     test_dir = fileutils.make_test_dir()
-    rs = RunSettings('echo')
-    step =  MockStep('mock-step', test_dir, rs)
+    rs = RunSettings("echo")
+    step = MockStep("mock-step", test_dir, rs)
     step.meta = mock_step_meta_dict
     yield step
 
 
-def test_proxy_launch_cmd_decorator_reformats_cmds(
-    mock_step, monkeypatch
-):
+def test_proxy_launch_cmd_decorator_reformats_cmds(mock_step, monkeypatch):
     monkeypatch.setattr(cfg.Config, CFG_TM_ENABLED_ATTR, True)
     get_launch_cmd = proxyable_launch_cmd(lambda step: ["some", "cmd", "list"])
     cmd = get_launch_cmd(mock_step)
@@ -897,12 +929,12 @@ def test_unmanaged_steps_are_proxyed_through_indirect(
     monkeypatch.setattr(cfg.Config, CFG_TM_ENABLED_ATTR, True)
     test_dir = fileutils.make_test_dir()
     rs = RunSettings("echo", ["hello", "world"])
-    step = wlm_launcher.create_step('test-step', test_dir, rs)
+    step = wlm_launcher.create_step("test-step", test_dir, rs)
     step.meta = mock_step_meta_dict
     assert isinstance(step, Step)
     assert not step.managed
     cmd = step.get_launch_cmd()
-    assert  sys.executable in cmd
+    assert sys.executable in cmd
     assert PROXY_ENTRY_POINT in cmd
     assert "hello" not in cmd
     assert "world" not in cmd
@@ -915,7 +947,7 @@ def test_unmanaged_steps_are_not_proxied_if_the_telemetry_monitor_is_disabled(
     monkeypatch.setattr(cfg.Config, CFG_TM_ENABLED_ATTR, False)
     test_dir = fileutils.make_test_dir()
     rs = RunSettings("echo", ["hello", "world"])
-    step = wlm_launcher.create_step('test-step', test_dir, rs)
+    step = wlm_launcher.create_step("test-step", test_dir, rs)
     step.meta = mock_step_meta_dict
     assert isinstance(step, Step)
     assert not step.managed
@@ -926,21 +958,23 @@ def test_unmanaged_steps_are_not_proxied_if_the_telemetry_monitor_is_disabled(
 
 
 @pytest.mark.parametrize(
-        "run_command, num_db_nodes, launcher",
-        [
-            pytest.param("auto", 1, "local", id="use auto"),
-            pytest.param("mpirun", 1, "local", id="use mpirun"),
-            pytest.param("srun", 1, "slurm", id="use srun"),
-            pytest.param("srun", 2, "slurm", id="use srun w/2 db"),
-        ]
+    "run_command, num_db_nodes, launcher",
+    [
+        pytest.param("auto", 1, "local", id="use auto"),
+        pytest.param("mpirun", 1, "local", id="use mpirun"),
+        pytest.param("srun", 1, "slurm", id="use srun"),
+        pytest.param("srun", 2, "slurm", id="use srun w/2 db"),
+    ],
 )
-def test_multistart_experiment(mlutils: MLUtils, 
-                               wlmutils: WLMUtils,
-                               fileutils: FileUtils,
-                               monkeypatch: pytest.MonkeyPatch,
-                               run_command: str,
-                               num_db_nodes: int,
-                               launcher: str):
+def test_multistart_experiment(
+    mlutils: MLUtils,
+    wlmutils: WLMUtils,
+    fileutils: FileUtils,
+    monkeypatch: pytest.MonkeyPatch,
+    run_command: str,
+    num_db_nodes: int,
+    launcher: str,
+):
     """Run an experiment with multiple start calls to ensure that telemetry is
     saved correctly for each run"""
     test_dir = fileutils.make_test_dir()
@@ -950,11 +984,10 @@ def test_multistart_experiment(mlutils: MLUtils,
         return
 
     exp_name = "my-exp"
-    exp = Experiment(exp_name, 
-                     launcher=launcher,
-                     exp_path=test_dir)
-    rs_e = exp.create_run_settings(sys.executable, ["printing_model.py"],
-                                   run_command=run_command)
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
+    rs_e = exp.create_run_settings(
+        sys.executable, ["printing_model.py"], run_command=run_command
+    )
     rs_e.set_nodes(1)
     rs_e.set_tasks(1)
     ens = exp.create_ensemble(
@@ -971,32 +1004,28 @@ def test_multistart_experiment(mlutils: MLUtils,
     yo_path = fileutils.get_test_conf_path("printing_model.py")
     ens.attach_generator_files(to_configure=[yo_path])
 
-    rs_m = exp.create_run_settings("echo", ["hello", "world"],
-                                   run_command=run_command)
+    rs_m = exp.create_run_settings("echo", ["hello", "world"], run_command=run_command)
     rs_m.set_nodes(1)
     rs_m.set_tasks(1)
     model = exp.create_model("my-model", run_settings=rs_m)
     model.colocate_db_tcp(port=5757, db_identifier="COLO")
 
     model_file = mlutils.save_torch_cnn(test_dir, f"model_{uuid.uuid4()}.pt")
-    model.add_ml_model(
-            "cnn",
-            "TORCH",
-            model_path=model_file,
-            device="CPU")
+    model.add_ml_model("cnn", "TORCH", model_path=model_file, device="CPU")
 
-    db = exp.create_database(db_nodes=num_db_nodes,  #  if USE_SLURM else 1,
-                             port=wlmutils.get_test_port(),
-                             interface=wlmutils.get_test_interface(),  # "ipogif0" if _launcher != "local" else "lo",
-                             single_cmd=False)
+    db = exp.create_database(
+        db_nodes=num_db_nodes,  #  if USE_SLURM else 1,
+        port=wlmutils.get_test_port(),
+        interface=wlmutils.get_test_interface(),  # "ipogif0" if _launcher != "local" else "lo",
+        single_cmd=False,
+    )
 
     exp.generate(db, ens, model, overwrite=True)
-
 
     with monkeypatch.context() as ctx:
         ctx.setattr(cfg.Config, "telemetry_frequency", 1)
         ctx.setattr(cfg.Config, "telemetry_cooldown", 45)
-        
+
         exp.start(model, block=False)
 
         # track PID to see that telmon cooldown avoids restarting process
@@ -1015,7 +1044,7 @@ def test_multistart_experiment(mlutils: MLUtils,
     assert True, "TODO: check telemetry output"
 
     telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
-    
+
     db_start_events = list(telemetry_output_path.rglob("database/**/start.json"))
     db_stop_events = list(telemetry_output_path.rglob("database/**/stop.json"))
     assert len(db_start_events) == num_db_nodes
@@ -1030,3 +1059,83 @@ def test_multistart_experiment(mlutils: MLUtils,
     m_stop_events = list(telemetry_output_path.rglob("ensemble/**/stop.json"))
     assert len(m_start_events) == 8
     assert len(m_stop_events) == 8
+
+
+@pytest.mark.parametrize(
+    "status_in, expected_out",
+    [
+        pytest.param(STATUS_CANCELLED, 1, id="failure on cancellation"),
+        pytest.param(STATUS_COMPLETED, 0, id="success on completion"),
+        pytest.param(STATUS_FAILED, 1, id="failure on failed"),
+        pytest.param(STATUS_NEW, None, id="failure on new"),
+        pytest.param(STATUS_PAUSED, None, id="failure on paused"),
+        pytest.param(STATUS_RUNNING, None, id="failure on running"),
+    ],
+)
+def test_faux_rc(status_in: str, expected_out: t.Optional[int]):
+    """Ensure faux response codes match expectations."""
+    step_info = StepInfo(status=status_in)
+
+    rc = faux_return_code(step_info)
+    assert rc == expected_out
+
+
+@pytest.mark.parametrize(
+    "status_in, expected_out, expected_has_jobs",
+    [
+        pytest.param(STATUS_CANCELLED, 1, False, id="failure on cancellation"),
+        pytest.param(STATUS_COMPLETED, 0, False, id="success on completion"),
+        pytest.param(STATUS_FAILED, 1, False, id="failure on failed"),
+        pytest.param(STATUS_NEW, None, True, id="failure on new"),
+        pytest.param(STATUS_PAUSED, None, True, id="failure on paused"),
+        pytest.param(STATUS_RUNNING, None, True, id="failure on running"),
+    ],
+)
+def test_wlm_completion_handling(fileutils: FileUtils, 
+                                 monkeypatch: pytest.MonkeyPatch,
+                                 status_in: str,
+                                 expected_out: t.Optional[int],
+                                 expected_has_jobs: bool):
+    test_dir = fileutils.make_test_dir(sub_dir=str(uuid.uuid4()))
+
+    def get_faux_update(status: str) -> t.Callable:
+        def _faux_updates(_self: WLMLauncher, _names: t.List[str]) -> t.List[StepInfo]:
+            return [("faux-name", StepInfo(status=status))]
+        return _faux_updates
+
+    ts = get_ts()
+    with monkeypatch.context() as ctx:
+        # don't actually start a job manager
+        ctx.setattr(JobManager, "start", lambda x: ...)
+        ctx.setattr(SlurmLauncher, "get_step_update", get_faux_update(status_in))
+
+        mani_handler = ManifestEventHandler("xyz", logger)
+        mani_handler.set_launcher("slurm")
+
+        # prep a fake job to request updates for
+        job_entity = JobEntity()
+        job_entity.name="faux-name"
+        job_entity.step_id="faux-step-id"
+        job_entity.task_id=1234
+        job_entity.status_dir=test_dir
+        job_entity.type = "orchestrator"
+
+        job = Job(job_entity.name, job_entity.step_id, job_entity, "slurm", True)
+        
+        # populate our tracking collections
+        mani_handler._tracked_jobs = {job_entity.key: job_entity}
+        mani_handler.job_manager.jobs[job.name] = job
+
+        mani_handler.on_timestep(ts)
+
+        # see that the job queue was properly manipulated
+        has_jobs = bool(mani_handler._tracked_jobs)
+        assert expected_has_jobs == has_jobs
+
+        # see that the event was properly written
+        stop_event_path = pathlib.Path(test_dir) / "stop.json"
+        
+        # if a status wasn't terminal, no stop event should have been written
+        should_have_stop_event = False if expected_out is None else True
+        assert should_have_stop_event == stop_event_path.exists()
+


### PR DESCRIPTION
The initial telemetry monitor merge ignored a known automatic shutdown bug. The mitigation removed automatic shutdown completely.

This change solves an automatic shutdown issue when the telemetry monitor has not yet begun to monitor a task. The prior auto-shutdown condition allowed the telemetry monitor to immediately complete. 

A cooldown/timeout period has been added to avoid immediate shutdown. The telemetry monitor can now be configured to live a specific duration and avoids shutdown prior to the writing of a runtime manifest. 