### PR TITLE
Template for pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+# Description
+A clear and concise description of what the feature or bug fix is intended to do.
+
+# Implementation Strategy
+A clear and concise description of the implementation strategy.
+
+# Pull Request Acceptance Criteria
+The following pull request review steps must be completed before merging:
+
+ - [ ] Code review for style, design, and accuracy
+ - [ ] Unit test review for completeness and accuracy
+ - [ ] Verification of Github CI/CD actions passing
+ - [ ] Verification of external WLM tests passing
+ - [ ] Review of documentation for proper content, build, and rendering
+ - [ ] Review of examples for sufficient breadth and accuracy
+ - [ ] Independent developer feature stress test
+ - [ ] Prior to closing the associated issue, verify documentation and examples have been properly uploaded to ``craylabs.org`` and all CI/CD tests pass post merge


### PR DESCRIPTION
This PR creates a PR template for SmartSim.  The PR template is meant to give more structure and consistency to the developer submitting the PR and the developers reviewing the PR.

It is worth noting that only a single PR template was created.  That is, a separate PR template was not created for bugs, features, documentation updates, etc.  This is because when there is more than one template, there is no way to access the various templates via the web GUI -- it can only be accessed through manipulation of the site URL query parameters (https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).  To make things easier for new contributors, it was decided to stick with one PR template which can be loaded automatically without query parameters.  

The proposed template will not be visible in this repository until it is merged.  However, I have pushed the changes to my fork's develop branch (https://github.com/mellis13/SmartSim), and as a result, PRs against my fork of SmartSim will show the rendered template.

