### PR TITLE
Register test groups, mitigate warning

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -28,7 +28,7 @@ Description
 
 Detailed Notes
 
-- Split tests into `group_a`, `group_b`, `slow_tests` for parallel execution in CI/CD pipeline (PR417_)
+- Split tests into `group_a`, `group_b`, `slow_tests` for parallel execution in CI/CD pipeline (PR417_, PR424_)
 - Change `format` argument to `style` in `Experiment.summary()`, this is
   an API break (PR391_)
 - Added support for first_device parameter for scripts, functions,

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -45,6 +45,7 @@ Detailed Notes
 - Add support for creation of multiple databases with unique identifiers. (PR342_)
 
 
+  .. _PR424: https://github.com/CrayLabs/SmartSim/pull/424
   .. _PR417: https://github.com/CrayLabs/SmartSim/pull/417
   .. _PR391: https://github.com/CrayLabs/SmartSim/pull/391
   .. _PR342: https://github.com/CrayLabs/SmartSim/pull/342

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,11 @@ exclude = '''
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "debug"
+markers = [
+  "group_a: fast test subset a",
+  "group_b: fast test subset b",
+  "slow_tests: tests that take a long duration to complete",
+]
 
 [tool.isort]
 # supress circular import warning


### PR DESCRIPTION
The pytest groups used to split execution of the test cases for parallelization currently result in a warning message displayed during test runs.

```
=== warnings summary ===
tests/test_cli.py:49
  /lus/cls01029/mcbridch/ss/tests/test_cli.py:49: PytestUnknownMarkWarning: Unknown pytest.mark.group_a - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytestmark = pytest.mark.group_a

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=== 52 passed, 1 warning in 0.53s ===
```

This fix adds group registrations to `pyproject.toml` to avoid those warnings:

```
=== 52 passed in 0.48s ===
```