### PR TITLE
Fix CLI bug hiding arguments matching root parser

### DIFF
--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -357,7 +357,7 @@ def _format_incompatible_python_env_message(
 
 
 def execute(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     verbose = args.v
     keydb = args.keydb

--- a/smartsim/_core/_cli/clean.py
+++ b/smartsim/_core/_cli/clean.py
@@ -41,13 +41,13 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
 
 def execute(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     return clean(get_install_path() / "_core", _all=args.clobber)
 
 
 def execute_all(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     args.clobber = True
     return execute(args)

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -78,7 +78,8 @@ class SmartCli:
             return 2
 
         if menu_item.is_plugin:
-            self.args, unparsed_args = self.parser.parse_known_args(app_args)
+            self.args = argparse.Namespace()
+            unparsed_args = app_args[1:]
         else:
             unparsed_args = []
             self.args = self.parser.parse_args(app_args)

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -76,12 +76,12 @@ class SmartCli:
             self.parser.print_help()
             return 2
 
-        args = argparse.Namespace()        
+        args = argparse.Namespace()
         unparsed_args = []
 
-        if menu_item.is_plugin:            
+        if menu_item.is_plugin:
             unparsed_args = app_args[1:]
-        else:    
+        else:
             args = self.parser.parse_args(app_args)
 
         return menu_item.handler(args, unparsed_args)

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -77,14 +77,15 @@ class SmartCli:
             self.parser.print_help()
             return 2
 
-        if menu_item.is_plugin:
-            self.args = argparse.Namespace()
-            unparsed_args = app_args[1:]
-        else:
-            unparsed_args = []
-            self.args = self.parser.parse_args(app_args)
+        args = argparse.Namespace()        
+        unparsed_args = []
 
-        return menu_item.handler(self.args, unparsed_args)
+        if menu_item.is_plugin:            
+            unparsed_args = app_args[1:]
+        else:    
+            args = self.parser.parse_args(app_args)
+
+        return menu_item.handler(args, unparsed_args)
 
     def _register_menu_item(self, item: MenuItemConfig) -> None:
         parser = self.subparsers.add_parser(

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -52,7 +52,6 @@ class SmartCli:
             prog="smart",
             description="SmartSim command line interface",
         )
-        self.args: t.Optional[argparse.Namespace] = None
 
         self.subparsers = self.parser.add_subparsers(
             dest="command",

--- a/smartsim/_core/_cli/dbcli.py
+++ b/smartsim/_core/_cli/dbcli.py
@@ -31,7 +31,7 @@ from smartsim._core._cli.utils import get_db_path
 
 
 def execute(
-    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     if db_path := get_db_path():
         print(db_path)

--- a/smartsim/_core/_cli/info.py
+++ b/smartsim/_core/_cli/info.py
@@ -13,7 +13,7 @@ _MISSING_DEP = _helpers.colorize("Not Installed", "red")
 
 
 def execute(
-    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     print("\nSmart Python Packages:")
     print(

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -9,10 +9,13 @@ from smartsim._core._cli.utils import MenuItemConfig
 
 def dynamic_execute(cmd: str) -> t.Callable[[argparse.Namespace, t.List[str]], int]:
     def process_execute(_args: argparse.Namespace, unparsed_args: t.List[str]) -> int:
+        not_found = f"{cmd} plugin not found. Please ensure it is installed"
         try:
-            importlib.find_spec(cmd)
+            spec = importlib.util.find_spec(cmd)
+            if spec is None:
+                raise AttributeError()
         except (ModuleNotFoundError, AttributeError):
-            print(f"{cmd} plugin not found. Please ensure it is installed")
+            print(not_found)
             return 1
 
         combined_cmd = [sys.executable, "-m", cmd] + unparsed_args

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -1,5 +1,6 @@
 import argparse
-import shutil
+import importlib
+import sys
 import subprocess as sp
 import typing as t
 
@@ -8,15 +9,20 @@ from smartsim._core._cli.utils import MenuItemConfig
 
 def dynamic_execute(cmd: str) -> t.Callable[[argparse.Namespace, t.List[str]], int]:
     def process_execute(_args: argparse.Namespace, unparsed_args: t.List[str]) -> int:
-        if not shutil.which(cmd):
-            raise ValueError(f"{cmd} plugin not found. Please ensure it is installed")
-        combined_cmd = [cmd] + unparsed_args
+        try:
+            importlib.find_spec(cmd)
+        except (ModuleNotFoundError, AttributeError):
+            print(f"{cmd} plugin not found. Please ensure it is installed")
+            return 1
+
+        combined_cmd = [sys.executable, "-m", cmd] + unparsed_args
         with sp.Popen(combined_cmd, stdout=sp.PIPE, stderr=sp.PIPE) as process:
             stdout, _ = process.communicate()
             while process.returncode is None:
                 stdout, _ = process.communicate()
-                print(stdout.decode("utf-8"))
 
+            plugin_stdout = stdout.decode("utf-8")
+            print(plugin_stdout)
             return process.returncode
 
     return process_execute
@@ -26,7 +32,7 @@ def dashboard() -> MenuItemConfig:
     return MenuItemConfig(
         "dashboard",
         "Start the SmartSim dashboard",
-        dynamic_execute("smart-dash"),
+        dynamic_execute("smartdashboard.Experiment_Overview"),
         is_plugin=True,
     )
 

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -8,7 +8,9 @@ from smartsim._core._cli.utils import MenuItemConfig
 
 
 def dynamic_execute(cmd: str) -> t.Callable[[argparse.Namespace, t.List[str]], int]:
-    def process_execute(_args: argparse.Namespace, unparsed_args: t.List[str]) -> int:
+    def process_execute(
+        _args: argparse.Namespace, unparsed_args: t.List[str], /
+    ) -> int:
         not_found = f"{cmd} plugin not found. Please ensure it is installed"
         try:
             spec = importlib.util.find_spec(cmd)
@@ -39,4 +41,5 @@ def dashboard() -> MenuItemConfig:
         is_plugin=True,
     )
 
-plugins = (dashboard, )
+
+plugins = (dashboard,)

--- a/smartsim/_core/_cli/site.py
+++ b/smartsim/_core/_cli/site.py
@@ -30,6 +30,6 @@ import typing as t
 from smartsim._core._cli.utils import get_install_path
 
 
-def execute(_args: argparse.Namespace, _unparsed_args: t.List[str]) -> int:
+def execute(_args: argparse.Namespace, _unparsed_args: t.List[str], /) -> int:
     print(get_install_path())
     return 0

--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -83,7 +83,7 @@ class _VerificationTempDir(_TemporaryDirectory):
 
 
 def execute(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     """Validate the SmartSim installation works as expected given a
     simple experiment

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,12 @@ from smartsim._core._cli.validate import (
 pytestmark = pytest.mark.group_a
 
 
+test_dash_plugin = True
+try:
+    import smartdashboard
+except:
+    test_dash_plugin = False
+
 def mock_execute_custom(msg: str = None, good: bool = True) -> int:
     retval = 0 if good else 1
     print(msg)
@@ -333,6 +339,26 @@ def test_cli_default_cli(capsys):
     assert "optional arguments:" in captured.out or "options:" in captured.out
     # assert "--clobber" not in captured.out
     assert ret_val == 2
+
+
+@pytest.mark.skipif(not test_dash_plugin, reason="plugin not found")
+def test_cli_plugin_dashboard(capsys):
+    """Ensure expected dashboard CLI plugin commands are supported"""
+    smart_cli = cli.default_cli()
+    
+    captured = capsys.readouterr()  # throw away existing output
+
+    # execute with `dashboard` argument, expect dashboard-specific help text
+    build_args = ["smart", "dashboard", "-h"]
+    rc = smart_cli.execute(build_args)
+
+    captured = capsys.readouterr() # capture new output
+    
+    assert "[-d DIRECTORY]" in captured.out
+    assert "[-p PORT]" in captured.out
+
+    assert "optional arguments:" in captured.out
+    assert rc == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -475,9 +475,6 @@ def test_cli_optional_args(capsys,
 
         assert exp_output in captured.out  # did the expected execution method occur?
         assert ret_val == 0  # is the retval is non-failure code?
-        
-        # is the value from the optional argument set in the parsed args?
-        assert smart_cli.args.__dict__[check_prop] == exp_prop_val
     else:
         with pytest.raises(SystemExit) as e:
             ret_val = smart_cli.execute(build_args)


### PR DESCRIPTION
Discovered a bug where using the CLI "plugin" to execute smart-dash did not return the correct help text. e.g. `smart dashboard -h` returned the default help text. This fix corrects the failure to pass arguments known by the smart CLI parser to the plugin.


After fixing the initial defect:

- A bug hiding the final output of the plugin was discovered. Moved `print(plugin_stdout)` to ensure plugin stdout was displayed
- Fixed bug where tests run in vscode test runner fail to load plugin. Mitigated with importlib
- Added test to verify passthrough output for initial fix
- Added test to verify outputs when plugin is not installed
- Revert removal of positional-only arguments

