### PR TITLE
Add support for producing dashboard outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ smartsim/_core/bin/*-cli
 
 # created upon install
 smartsim/_core/lib
+
+**/manifest/
+**/*.err
+**/*.out
+**/.smartsim/*

--- a/conftest.py
+++ b/conftest.py
@@ -630,7 +630,7 @@ class FileUtils:
         return dir_path
 
     @staticmethod
-    def make_test_file(file_name: str, file_dir: t.Optional[str] = None) -> str:
+    def make_test_file(file_name: str, file_dir: t.Optional[str] = None, file_content: t.Optional[str] = None) -> str:
         """Create a dummy file in the test output directory.
 
         :param file_name: name of file to create, e.g. "file.txt"
@@ -644,7 +644,10 @@ class FileUtils:
         file_path = os.path.join(test_dir, file_name)
 
         with open(file_path, "w+", encoding="utf-8") as dummy_file:
-            dummy_file.write("dummy\n")
+            if not file_content:
+                dummy_file.write("dummy\n")
+            else:
+                dummy_file.write(file_content)
 
         return file_path
 

--- a/conftest.py
+++ b/conftest.py
@@ -48,9 +48,6 @@ from smartsim._core.config import CONFIG
 from smartsim.error import SSConfigError
 from subprocess import run
 import sys
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
 import typing as t
 
 
@@ -669,18 +666,6 @@ class MLUtils:
     def get_test_num_gpus() -> int:
         return test_num_gpus
 
-    @staticmethod
-    def save_torch_cnn(path: str, file_name: str):
-        """Create a simple torch CNN and save to file specified by path and file_name"""
-        model = PyTorchNet()
-        example_forward_input = torch.rand(1, 1, 28, 28)
-        module = torch.jit.trace(model, example_forward_input)
-
-        output_path = path + "/" + file_name
-        torch.jit.save(module, output_path)
-
-        return output_path
-
 
 @pytest.fixture
 def coloutils() -> t.Type[ColoUtils]:
@@ -731,29 +716,3 @@ class ColoUtils:
         assert colo_model.colocated
         # Check to make sure that limit_db_cpus made it into the colo settings
         return colo_model
-
-
-class PyTorchNet(nn.Module):
-    def __init__(self):
-        super(PyTorchNet, self).__init__()
-        self.conv1 = nn.Conv2d(1, 32, 3, 1)
-        self.conv2 = nn.Conv2d(32, 64, 3, 1)
-        self.dropout1 = nn.Dropout(0.25)
-        self.dropout2 = nn.Dropout(0.5)
-        self.fc1 = nn.Linear(9216, 128)
-        self.fc2 = nn.Linear(128, 10)
-
-    def forward(self, x):
-        x = self.conv1(x)
-        x = F.relu(x)
-        x = self.conv2(x)
-        x = F.relu(x)
-        x = F.max_pool2d(x, 2)
-        x = self.dropout1(x)
-        x = torch.flatten(x, 1)
-        x = self.fc1(x)
-        x = F.relu(x)
-        x = self.dropout2(x)
-        x = self.fc2(x)
-        output = F.log_softmax(x, dim=1)
-        return output

--- a/conftest.py
+++ b/conftest.py
@@ -380,10 +380,10 @@ def local_db(
     """Yield fixture for startup and teardown of an local orchestrator"""
 
     exp_name = request.function.__name__
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir(
         caller_function=exp_name, caller_fspath=request.fspath
     )
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
     db = Orchestrator(port=wlmutils.get_test_port(), interface="lo")
     db.set_path(test_dir)
     exp.start(db)
@@ -402,10 +402,10 @@ def db(
     launcher = wlmutils.get_test_launcher()
 
     exp_name = request.function.__name__
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir(
         caller_function=exp_name, caller_fspath=request.fspath
     )
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
     db = wlmutils.get_orchestrator()
     db.set_path(test_dir)
     exp.start(db)
@@ -427,10 +427,10 @@ def db_cluster(
     launcher = wlmutils.get_test_launcher()
 
     exp_name = request.function.__name__
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir(
         caller_function=exp_name, caller_fspath=request.fspath
     )
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
     db = wlmutils.get_orchestrator(nodes=3)
     db.set_path(test_dir)
     exp.start(db)

--- a/conftest.py
+++ b/conftest.py
@@ -48,6 +48,9 @@ from smartsim._core.config import CONFIG
 from smartsim.error import SSConfigError
 from subprocess import run
 import sys
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
 import typing as t
 
 
@@ -666,6 +669,18 @@ class MLUtils:
     def get_test_num_gpus() -> int:
         return test_num_gpus
 
+    @staticmethod
+    def save_torch_cnn(path: str, file_name: str):
+        """Create a simple torch CNN and save to file specified by path and file_name"""
+        model = PyTorchNet()
+        example_forward_input = torch.rand(1, 1, 28, 28)
+        module = torch.jit.trace(model, example_forward_input)
+
+        output_path = path + "/" + file_name
+        torch.jit.save(module, output_path)
+
+        return output_path
+
 
 @pytest.fixture
 def coloutils() -> t.Type[ColoUtils]:
@@ -716,3 +731,29 @@ class ColoUtils:
         assert colo_model.colocated
         # Check to make sure that limit_db_cpus made it into the colo settings
         return colo_model
+
+
+class PyTorchNet(nn.Module):
+    def __init__(self):
+        super(PyTorchNet, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -50,6 +50,12 @@
 
 .. toctree::
    :maxdepth: 2
+   :caption: SmartDashboard
+
+   smartdashboard
+
+.. toctree::
+   :maxdepth: 2
    :caption: Reference
 
    changelog

--- a/doc/smartdashboard.rst
+++ b/doc/smartdashboard.rst
@@ -1,0 +1,7 @@
+
+**************
+SmartDashboard
+**************
+
+.. include:: ../smartdashboard/doc/overview.rst
+    :start-line: 4

--- a/docker/docs/dev/Dockerfile
+++ b/docker/docs/dev/Dockerfile
@@ -52,6 +52,12 @@ RUN git clone https://github.com/CrayLabs/SmartRedis.git --branch develop --dept
     && python -m pip install . \
     && rm -rf ~/.cache/pip
 
+# Install smartdashboard
+RUN git clone https://github.com/CrayLabs/SmartDashboard.git --branch develop --depth=1 smartdashboard \
+    && cd smartdashboard \
+    && python -m pip install . \
+    && rm -rf ~/.cache/pip
+
 RUN cd doc/tutorials/ && \
     ln -s ../../tutorials/* .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ module = [
   "keras",
   "torch",
   "smartsim.ml.torch.*",            # must solve/ignore inheritance issues
+  "watchdog",
 ]
 ignore_missing_imports = true
 ignore_errors = true

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ deps = [
     "tqdm>=4.50.2",
     "filelock>=3.4.2",
     "protobuf~=3.20",
+    "watchdog>=3.0.0",
 ]
 
 # Add SmartRedis at specific version

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -27,12 +27,28 @@
 import sys
 
 from smartsim._core._cli.cli import default_cli
+from smartsim._core._cli.utils import SMART_LOGGER_FORMAT
+from smartsim.error.errors import SmartSimCLIActionCancelled
+from smartsim.log import get_logger
+
+
+logger = get_logger("Smart", fmt=SMART_LOGGER_FORMAT)
 
 
 def main() -> int:
     smart_cli = default_cli()
 
-    return smart_cli.execute(sys.argv)
+    try:
+        return smart_cli.execute(sys.argv)
+    except SmartSimCLIActionCancelled as ssi:
+        logger.debug(ssi, exc_info=True)
+        logger.info(ssi)
+    except KeyboardInterrupt:
+        msg = "SmartSim was terminated by user"
+        logger.debug(msg, exc_info=True)
+        logger.info(msg)
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -38,16 +38,16 @@ logger = get_logger("Smart", fmt=SMART_LOGGER_FORMAT)
 
 def main() -> int:
     smart_cli = default_cli()
-    excpetion_trace_back_msg = "SmartSim exited with the following exception info:"
+    exception_trace_back_msg = "SmartSim exited with the following exception info:"
 
     try:
         return smart_cli.execute(sys.argv)
     except SmartSimCLIActionCancelled as ssi:
         logger.info(str(ssi))
-        logger.debug(excpetion_trace_back_msg, exc_info=ssi)
+        logger.debug(exception_trace_back_msg, exc_info=ssi)
     except KeyboardInterrupt as e:
         logger.info("SmartSim was terminated by user")
-        logger.debug(excpetion_trace_back_msg, exc_info=e)
+        logger.debug(exception_trace_back_msg, exc_info=e)
     return os.EX_OK
 
 

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -24,6 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
 import sys
 
 from smartsim._core._cli.cli import default_cli
@@ -47,8 +48,7 @@ def main() -> int:
         msg = "SmartSim was terminated by user"
         logger.debug(msg, exc_info=True)
         logger.info(msg)
-
-    return 0
+    return os.EX_OK
 
 
 if __name__ == "__main__":

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -31,6 +31,7 @@ from smartsim._core._cli.cli import default_cli
 
 def main() -> int:
     smart_cli = default_cli()
+
     return smart_cli.execute(sys.argv)
 
 

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -38,16 +38,16 @@ logger = get_logger("Smart", fmt=SMART_LOGGER_FORMAT)
 
 def main() -> int:
     smart_cli = default_cli()
+    excpetion_trace_back_msg = "SmartSim exited with the following exception info:"
 
     try:
         return smart_cli.execute(sys.argv)
     except SmartSimCLIActionCancelled as ssi:
-        logger.debug(ssi, exc_info=True)
-        logger.info(ssi)
-    except KeyboardInterrupt:
-        msg = "SmartSim was terminated by user"
-        logger.debug(msg, exc_info=True)
-        logger.info(msg)
+        logger.info(str(ssi))
+        logger.debug(excpetion_trace_back_msg, exc_info=ssi)
+    except KeyboardInterrupt as e:
+        logger.info("SmartSim was terminated by user")
+        logger.debug(excpetion_trace_back_msg, exc_info=e)
     return os.EX_OK
 
 

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -357,7 +357,7 @@ def _format_incompatible_python_env_message(
 
 
 def execute(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     verbose = args.v
     keydb = args.keydb

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -356,7 +356,9 @@ def _format_incompatible_python_env_message(
     )
 
 
-def execute(args: argparse.Namespace) -> int:
+def execute(
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+) -> int:
     verbose = args.v
     keydb = args.keydb
     device: _TDeviceStr = args.device

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -418,7 +418,7 @@ def execute(
             )
     except (SetupError, BuildError) as e:
         logger.error(str(e))
-        return 1
+        return os.EX_SOFTWARE
 
     backends = installed_redisai_backends()
     backends_str = ", ".join(s.capitalize() for s in backends) if backends else "No"
@@ -433,10 +433,10 @@ def execute(
             check_py_onnx_version(versions)
     except (SetupError, BuildError) as e:
         logger.error(str(e))
-        return 1
+        return os.EX_SOFTWARE
 
     logger.info("SmartSim build complete!")
-    return 0
+    return os.EX_OK
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:

--- a/smartsim/_core/_cli/clean.py
+++ b/smartsim/_core/_cli/clean.py
@@ -41,13 +41,13 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
 
 def execute(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     return clean(get_install_path() / "_core", _all=args.clobber)
 
 
 def execute_all(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     args.clobber = True
     return execute(args)

--- a/smartsim/_core/_cli/clean.py
+++ b/smartsim/_core/_cli/clean.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import typing as t
 
 from smartsim._core._cli.utils import clean, get_install_path
 
@@ -39,10 +40,14 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def execute(args: argparse.Namespace) -> int:
+def execute(
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+) -> int:
     return clean(get_install_path() / "_core", _all=args.clobber)
 
 
-def execute_all(args: argparse.Namespace) -> int:
+def execute_all(
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+) -> int:
     args.clobber = True
     return execute(args)

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -52,7 +52,6 @@ class SmartCli:
             prog="smart",
             description="SmartSim command line interface",
         )
-        self.args: t.Optional[argparse.Namespace] = None
 
         self.subparsers = self.parser.add_subparsers(
             dest="command",
@@ -77,13 +76,15 @@ class SmartCli:
             self.parser.print_help()
             return 2
 
-        if menu_item.is_plugin:
-            self.args, unparsed_args = self.parser.parse_known_args(app_args)
-        else:
-            unparsed_args = []
-            self.args = self.parser.parse_args(app_args)
+        args = argparse.Namespace()
+        unparsed_args = []
 
-        return menu_item.handler(self.args, unparsed_args)
+        if menu_item.is_plugin:
+            unparsed_args = app_args[1:]
+        else:
+            args = self.parser.parse_args(app_args)
+
+        return menu_item.handler(args, unparsed_args)
 
     def _register_menu_item(self, item: MenuItemConfig) -> None:
         parser = self.subparsers.add_parser(

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import os
 import typing as t
 
 from smartsim._core._cli.build import configure_parser as build_parser
@@ -66,7 +67,7 @@ class SmartCli:
     def execute(self, cli_args: t.List[str]) -> int:
         if len(cli_args) < 2:
             self.parser.print_help()
-            return 2
+            return os.EX_USAGE
 
         app_args = cli_args[1:]  # exclude the path to executable
         subcommand = cli_args[1]  # first positional arg is the subcommand
@@ -74,7 +75,7 @@ class SmartCli:
         menu_item = self.menu.get(subcommand, None)
         if not menu_item:
             self.parser.print_help()
-            return 2
+            return os.EX_USAGE
 
         args = argparse.Namespace()
         unparsed_args = []

--- a/smartsim/_core/_cli/cli.py
+++ b/smartsim/_core/_cli/cli.py
@@ -41,46 +41,67 @@ from smartsim._core._cli.validate import (
     execute as validate_execute,
     configure_parser as validate_parser,
 )
+from smartsim._core._cli.plugin import plugins
 from smartsim._core._cli.utils import MenuItemConfig
 
 
 class SmartCli:
     def __init__(self, menu: t.List[MenuItemConfig]) -> None:
-        self.menu: t.Dict[str, MenuItemConfig] = {item.command: item for item in menu}
-        parser = argparse.ArgumentParser(
+        self.menu: t.Dict[str, MenuItemConfig] = {}
+        self.parser = argparse.ArgumentParser(
             prog="smart",
             description="SmartSim command line interface",
         )
-        self.parser = parser
         self.args: t.Optional[argparse.Namespace] = None
 
-        subparsers = parser.add_subparsers(
+        self.subparsers = self.parser.add_subparsers(
             dest="command",
             required=True,
             metavar="<command>",
             help="Available commands",
         )
 
-        for cmd, item in self.menu.items():
-            parser = subparsers.add_parser(
-                cmd, description=item.description, help=item.description
-            )
-            if item.configurator:
-                item.configurator(parser)
+        self.register_menu_items(menu)
+        self.register_menu_items([plugin() for plugin in plugins])
 
     def execute(self, cli_args: t.List[str]) -> int:
         if len(cli_args) < 2:
             self.parser.print_help()
-            return 0
+            return 2
 
-        app_args = cli_args[1:]
-        self.args = self.parser.parse_args(app_args)
+        app_args = cli_args[1:]  # exclude the path to executable
+        subcommand = cli_args[1]  # first positional arg is the subcommand
 
-        if not (menu_item := self.menu.get(app_args[0], None)):
+        menu_item = self.menu.get(subcommand, None)
+        if not menu_item:
             self.parser.print_help()
-            return 0
+            return 2
 
-        return menu_item.handler(self.args)
+        if menu_item.is_plugin:
+            self.args, unparsed_args = self.parser.parse_known_args(app_args)
+        else:
+            unparsed_args = []
+            self.args = self.parser.parse_args(app_args)
+
+        return menu_item.handler(self.args, unparsed_args)
+
+    def _register_menu_item(self, item: MenuItemConfig) -> None:
+        parser = self.subparsers.add_parser(
+            item.command, description=item.description, help=item.description
+        )
+        if item.configurator:
+            item.configurator(parser)
+
+        if item.command in self.menu:
+            raise ValueError(
+                f"{item.command} cannot overwrite existing CLI command"
+            )
+
+        self.menu[item.command] = item
+
+    def register_menu_items(self, menu_items: t.List[MenuItemConfig]) -> None:
+        for item in menu_items:
+            self._register_menu_item(item)
 
 
 def default_cli() -> SmartCli:

--- a/smartsim/_core/_cli/dbcli.py
+++ b/smartsim/_core/_cli/dbcli.py
@@ -31,7 +31,7 @@ from smartsim._core._cli.utils import get_db_path
 
 
 def execute(
-    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     if db_path := get_db_path():
         print(db_path)

--- a/smartsim/_core/_cli/dbcli.py
+++ b/smartsim/_core/_cli/dbcli.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import os
 import typing as t
 
 from smartsim._core._cli.utils import get_db_path
@@ -35,6 +36,6 @@ def execute(
 ) -> int:
     if db_path := get_db_path():
         print(db_path)
-        return 0
+        return os.EX_OK
     print("Database (Redis or KeyDB) dependencies not found")
-    return 1
+    return os.EX_SOFTWARE

--- a/smartsim/_core/_cli/dbcli.py
+++ b/smartsim/_core/_cli/dbcli.py
@@ -25,11 +25,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import typing as t
 
 from smartsim._core._cli.utils import get_db_path
 
 
-def execute(_args: argparse.Namespace) -> int:
+def execute(
+    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+) -> int:
     if db_path := get_db_path():
         print(db_path)
         return 0

--- a/smartsim/_core/_cli/info.py
+++ b/smartsim/_core/_cli/info.py
@@ -12,7 +12,9 @@ from smartsim._core._install.buildenv import BuildEnv as _BuildEnv
 _MISSING_DEP = _helpers.colorize("Not Installed", "red")
 
 
-def execute(_args: argparse.Namespace, /) -> int:
+def execute(
+    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+) -> int:
     print("\nSmart Python Packages:")
     print(
         tabulate(

--- a/smartsim/_core/_cli/info.py
+++ b/smartsim/_core/_cli/info.py
@@ -1,5 +1,6 @@
 import argparse
 import importlib.metadata
+import os
 import pathlib
 import typing as t
 
@@ -68,7 +69,7 @@ def execute(
         ),
         end="\n\n",
     )
-    return 0
+    return os.EX_OK
 
 
 def _fmt_installed_db(db_path: t.Optional[pathlib.Path]) -> str:

--- a/smartsim/_core/_cli/info.py
+++ b/smartsim/_core/_cli/info.py
@@ -13,7 +13,7 @@ _MISSING_DEP = _helpers.colorize("Not Installed", "red")
 
 
 def execute(
-    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    _args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     print("\nSmart Python Packages:")
     print(

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -1,0 +1,33 @@
+import argparse
+import shutil
+import subprocess as sp
+import typing as t
+
+from smartsim._core._cli.utils import MenuItemConfig
+
+
+def dynamic_execute(cmd: str) -> t.Callable[[argparse.Namespace, t.List[str]], int]:
+    def process_execute(_args: argparse.Namespace, unparsed_args: t.List[str]) -> int:
+        if not shutil.which(cmd):
+            raise ValueError(f"{cmd} plugin not found. Please ensure it is installed")
+        combined_cmd = [cmd] + unparsed_args
+        with sp.Popen(combined_cmd, stdout=sp.PIPE, stderr=sp.PIPE) as process:
+            stdout, _ = process.communicate()
+            while process.returncode is None:
+                stdout, _ = process.communicate()
+                print(stdout.decode("utf-8"))
+
+            return process.returncode
+
+    return process_execute
+
+
+def dashboard() -> MenuItemConfig:
+    return MenuItemConfig(
+        "dashboard",
+        "Start the SmartSim dashboard",
+        dynamic_execute("smart-dash"),
+        is_plugin=True,
+    )
+
+plugins = (dashboard, )

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -1,5 +1,6 @@
 import argparse
 import importlib
+import os
 import sys
 import subprocess as sp
 import typing as t
@@ -21,7 +22,7 @@ def dynamic_execute(
                 raise AttributeError()
         except (ModuleNotFoundError, AttributeError):
             print(not_found)
-            return 1
+            return os.EX_CONFIG
 
         combined_cmd = [sys.executable, "-m", cmd] + unparsed_args
 
@@ -44,7 +45,12 @@ def dynamic_execute(
 def dashboard() -> MenuItemConfig:
     return MenuItemConfig(
         "dashboard",
-        "Start the SmartSim dashboard",
+        (
+            "Start the SmartSim dashboard to monitor experiment output from a "
+            "graphical user interface. This requires that the SmartSim Dashboard "
+            "Package be installed. For more infromation please visit "
+            "https://github.com/CrayLabs/SmartDashboard"
+        ),
         dynamic_execute("smartdashboard.Experiment_Overview", "Dashboard"),
         is_plugin=True,
     )

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -1,5 +1,5 @@
 import argparse
-import importlib
+import importlib.util
 import os
 import sys
 import subprocess as sp
@@ -21,7 +21,7 @@ def dynamic_execute(
         try:
             spec = importlib.util.find_spec(cmd)
             if spec is None:
-                raise AttributeError()
+                raise AttributeError
         except (ModuleNotFoundError, AttributeError):
             _LOGGER.error(f"{cmd} plugin not found. Please ensure it is installed")
             return os.EX_CONFIG

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -29,7 +29,7 @@ def dynamic_execute(
         combined_cmd = [sys.executable, "-m", cmd] + unparsed_args
 
         try:
-            completed_proc = sp.run(combined_cmd)
+            completed_proc = sp.run(combined_cmd, check=False)
         except KeyboardInterrupt as ex:
             msg = f"{plugin_name} terminated by user"
             raise SmartSimCLIActionCancelled(msg) from ex

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -47,7 +47,7 @@ def dashboard() -> MenuItemConfig:
             "Package be installed. For more infromation please visit "
             "https://github.com/CrayLabs/SmartDashboard"
         ),
-        dynamic_execute("smartdashboard.Experiment_Overview", "Dashboard"),
+        dynamic_execute("smartdashboard", "Dashboard"),
         is_plugin=True,
     )
 

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -1,5 +1,6 @@
 import argparse
-import shutil
+import importlib
+import sys
 import subprocess as sp
 import typing as t
 
@@ -7,16 +8,26 @@ from smartsim._core._cli.utils import MenuItemConfig
 
 
 def dynamic_execute(cmd: str) -> t.Callable[[argparse.Namespace, t.List[str]], int]:
-    def process_execute(_args: argparse.Namespace, unparsed_args: t.List[str]) -> int:
-        if not shutil.which(cmd):
-            raise ValueError(f"{cmd} plugin not found. Please ensure it is installed")
-        combined_cmd = [cmd] + unparsed_args
+    def process_execute(
+        _args: argparse.Namespace, unparsed_args: t.List[str], /
+    ) -> int:
+        not_found = f"{cmd} plugin not found. Please ensure it is installed"
+        try:
+            spec = importlib.util.find_spec(cmd)
+            if spec is None:
+                raise AttributeError()
+        except (ModuleNotFoundError, AttributeError):
+            print(not_found)
+            return 1
+
+        combined_cmd = [sys.executable, "-m", cmd] + unparsed_args
         with sp.Popen(combined_cmd, stdout=sp.PIPE, stderr=sp.PIPE) as process:
             stdout, _ = process.communicate()
             while process.returncode is None:
                 stdout, _ = process.communicate()
-                print(stdout.decode("utf-8"))
 
+            plugin_stdout = stdout.decode("utf-8")
+            print(plugin_stdout)
             return process.returncode
 
     return process_execute
@@ -26,8 +37,9 @@ def dashboard() -> MenuItemConfig:
     return MenuItemConfig(
         "dashboard",
         "Start the SmartSim dashboard",
-        dynamic_execute("smart-dash"),
+        dynamic_execute("smartdashboard.Experiment_Overview"),
         is_plugin=True,
     )
 
-plugins = (dashboard, )
+
+plugins = (dashboard,)

--- a/smartsim/_core/_cli/site.py
+++ b/smartsim/_core/_cli/site.py
@@ -30,6 +30,6 @@ import typing as t
 from smartsim._core._cli.utils import get_install_path
 
 
-def execute(_args: argparse.Namespace, _unparsed_args: t.List[str]) -> int:
+def execute(_args: argparse.Namespace, _unparsed_args: t.List[str], /) -> int:
     print(get_install_path())
     return 0

--- a/smartsim/_core/_cli/site.py
+++ b/smartsim/_core/_cli/site.py
@@ -25,10 +25,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import typing as t
 
 from smartsim._core._cli.utils import get_install_path
 
 
-def execute(_args: argparse.Namespace) -> int:
+def execute(_args: argparse.Namespace, _unparsed_args: t.List[str]) -> int:
     print(get_install_path())
     return 0

--- a/smartsim/_core/_cli/site.py
+++ b/smartsim/_core/_cli/site.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import os
 import typing as t
 
 from smartsim._core._cli.utils import get_install_path
@@ -32,4 +33,4 @@ from smartsim._core._cli.utils import get_install_path
 
 def execute(_args: argparse.Namespace, _unparsed_args: t.List[str], /) -> int:
     print(get_install_path())
-    return 0
+    return os.EX_OK

--- a/smartsim/_core/_cli/utils.py
+++ b/smartsim/_core/_cli/utils.py
@@ -121,7 +121,7 @@ def get_db_path() -> t.Optional[Path]:
     return None
 
 
-_CliHandler = t.Callable[[Namespace], int]
+_CliHandler = t.Callable[[Namespace, t.List[str]], int]
 _CliParseConfigurator = t.Callable[[ArgumentParser], None]
 
 
@@ -132,8 +132,10 @@ class MenuItemConfig:
         description: str,
         handler: _CliHandler,
         configurator: t.Optional[_CliParseConfigurator] = None,
+        is_plugin: bool = False
     ):
         self.command = cmd
         self.description = description
         self.handler = handler
         self.configurator = configurator
+        self.is_plugin = is_plugin

--- a/smartsim/_core/_cli/utils.py
+++ b/smartsim/_core/_cli/utils.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import importlib.util
+import os
 import shutil
 import subprocess as sp
 import sys
@@ -110,7 +111,7 @@ def clean(core_path: Path, _all: bool = False) -> int:
         if removed:
             logger.info("Successfully removed SmartSim database installation")
 
-    return 0
+    return os.EX_OK
 
 
 def get_db_path() -> t.Optional[Path]:

--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -105,8 +105,8 @@ def execute(
             f"Experiment failed due to the following exception:\n{e}\n\n"
             f"Output files are available at `{temp_dir}`", exc_info=True
         )
-        return 2
-    return 0
+        return os.EX_SOFTWARE
+    return os.EX_OK
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
@@ -141,7 +141,7 @@ def test_install(
 ) -> None:
     exp = Experiment("ValidationExperiment", exp_path=location, launcher="local")
     port = _find_free_port() if port is None else port
-    with _disable_telmon(), _make_managed_local_orc(exp, port) as client:
+    with _disable_telemetry_monitor(), _make_managed_local_orc(exp, port) as client:
         logger.info("Verifying Tensor Transfer")
         client.put_tensor("plain-tensor", np.ones((1, 1, 3, 3)))
         client.get_tensor("plain-tensor")
@@ -172,7 +172,7 @@ def _make_managed_local_orc(
 
 
 @contextmanager
-def _disable_telmon() -> t.Generator[None, None, None]:
+def _disable_telemetry_monitor() -> t.Generator[None, None, None]:
     """Ensure the telemetry monitor is disabled during a test and the environment
     is left in correct state after completion"""
     tm_key = "SMARTSIM_FLAG_TELEMETRY"

--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -83,7 +83,7 @@ class _VerificationTempDir(_TemporaryDirectory):
 
 
 def execute(
-    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None, /
 ) -> int:
     """Validate the SmartSim installation works as expected given a
     simple experiment

--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -82,7 +82,9 @@ class _VerificationTempDir(_TemporaryDirectory):
             self._finalizer.detach()  # type: ignore[attr-defined]
 
 
-def execute(args: argparse.Namespace, /) -> int:
+def execute(
+    args: argparse.Namespace, _unparsed_args: t.Optional[t.List[str]] = None
+) -> int:
     """Validate the SmartSim installation works as expected given a
     simple experiment
     """

--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -140,8 +140,9 @@ def test_install(
     with_onnx: bool,
 ) -> None:
     exp = Experiment("ValidationExperiment", exp_path=location, launcher="local")
+    exp.disable_telemetry()
     port = _find_free_port() if port is None else port
-    with _disable_telemetry_monitor(), _make_managed_local_orc(exp, port) as client:
+    with _make_managed_local_orc(exp, port) as client:
         logger.info("Verifying Tensor Transfer")
         client.put_tensor("plain-tensor", np.ones((1, 1, 3, 3)))
         client.get_tensor("plain-tensor")
@@ -169,22 +170,6 @@ def _make_managed_local_orc(
         yield Client(False, address=client_addr)
     finally:
         exp.stop(orc)
-
-
-@contextmanager
-def _disable_telemetry_monitor() -> t.Generator[None, None, None]:
-    """Ensure the telemetry monitor is disabled during a test and the environment
-    is left in correct state after completion
-    """
-    tm_key = "SMARTSIM_FLAG_TELEMETRY"
-    orig = os.environ.get(tm_key, None)
-    if orig is not None:
-        os.environ[tm_key] = "0"
-    try:
-        yield
-    finally:
-        if orig is not None:
-            os.environ[tm_key] = orig
 
 
 def _find_free_port() -> int:

--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -174,7 +174,8 @@ def _make_managed_local_orc(
 @contextmanager
 def _disable_telemetry_monitor() -> t.Generator[None, None, None]:
     """Ensure the telemetry monitor is disabled during a test and the environment
-    is left in correct state after completion"""
+    is left in correct state after completion
+    """
     tm_key = "SMARTSIM_FLAG_TELEMETRY"
     orig = os.environ.get(tm_key, None)
     if orig is not None:

--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -103,7 +103,7 @@ def execute(
         logger.error(
             "SmartSim failed to run a simple experiment!\n"
             f"Experiment failed due to the following exception:\n{e}\n\n"
-            f"Output files are available at `{temp_dir}`"
+            f"Output files are available at `{temp_dir}`", exc_info=True
         )
         return 2
     return 0
@@ -141,7 +141,7 @@ def test_install(
 ) -> None:
     exp = Experiment("ValidationExperiment", exp_path=location, launcher="local")
     port = _find_free_port() if port is None else port
-    with _make_managed_local_orc(exp, port) as client:
+    with _disable_telmon(), _make_managed_local_orc(exp, port) as client:
         logger.info("Verifying Tensor Transfer")
         client.put_tensor("plain-tensor", np.ones((1, 1, 3, 3)))
         client.get_tensor("plain-tensor")
@@ -169,6 +169,21 @@ def _make_managed_local_orc(
         yield Client(False, address=client_addr)
     finally:
         exp.stop(orc)
+
+
+@contextmanager
+def _disable_telmon() -> t.Generator[None, None, None]:
+    """Ensure the telemetry monitor is disabled during a test and the environment
+    is left in correct state after completion"""
+    tm_key = "SMARTSIM_FLAG_TELEMETRY"
+    orig = os.environ.get(tm_key, None)
+    if orig is not None:
+        os.environ[tm_key] = "0"
+    try:
+        yield
+    finally:
+        if orig is not None:
+            os.environ[tm_key] = orig
 
 
 def _find_free_port() -> int:

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -212,6 +212,10 @@ class Config:
     def telemetry_enabled(self) -> bool:
         return bool(os.environ.get("SMARTSIM_FLAG_TELEMETRY", 1))
 
+    @property
+    def telemetry_cooldown(self) -> int:
+        return int(os.environ.get("SMARTSIM_TELEMETRY_COOLDOWN", 90))
+
 @lru_cache(maxsize=128, typed=False)
 def get_config() -> Config:
     # wrap into a function with a cached result

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -204,6 +204,13 @@ class Config:
         # no account by default
         return os.environ.get("SMARTSIM_TEST_ACCOUNT", None)
 
+    @property
+    def telemetry_frequency(self) -> int:
+        return int(os.environ.get("SMARTSIM_TELEMETRY_FREQUENCY", 5))
+
+    @property
+    def telemetry_enabled(self) -> bool:
+        return bool(os.environ.get("SMARTSIM_FLAG_TELEMETRY", 1))
 
 @lru_cache(maxsize=128, typed=False)
 def get_config() -> Config:

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -210,7 +210,7 @@ class Config:
 
     @property
     def telemetry_enabled(self) -> bool:
-        return bool(os.environ.get("SMARTSIM_FLAG_TELEMETRY", 1))
+        return int(os.environ.get("SMARTSIM_FLAG_TELEMETRY", "0")) > 0
 
     @property
     def telemetry_cooldown(self) -> int:

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -343,6 +343,10 @@ class Controller:
         Orchestrators are always launched first so that the
         address of the database can be given to following entities
 
+        :param exp_name: The name of the launching experiment
+        :type exp_name: str
+        :param exp_path: path to location of ``Experiment`` directory if generated
+        :type exp_path: str
         :param manifest: Manifest of deployables to launch
         :type manifest: Manifest
         """

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -130,7 +130,8 @@ class Controller:
         )
 
         # launch a telemetry monitor to track job progress
-        self.start_telemetry_monitor(exp_path)
+        if CONFIG.telemetry_enabled:
+            self.start_telemetry_monitor(exp_path)
 
         # block until all non-database jobs are complete
         if block:
@@ -814,9 +815,6 @@ class Controller:
 
     def start_telemetry_monitor(self, exp_dir: str) -> None:
         logger.debug("Starting telemetry monitor process")
-        if not CONFIG.telemetry_enabled:
-            return
-
         if (
             self._telemetry_monitor is None
             or self._telemetry_monitor.returncode is not None

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -821,19 +821,22 @@ class Controller:
             self._telemetry_monitor is None
             or self._telemetry_monitor.returncode is not None
         ):
+            cmd = [
+                sys.executable,
+                "-m",
+                "smartsim._core.entrypoints.telemetrymonitor",
+                "-exp_dir",
+                exp_dir,
+                "-frequency",
+                str(frequency),
+                "-cooldown",
+                str(CONFIG.telemetry_cooldown),
+            ]
             # pylint: disable-next=consider-using-with
             self._telemetry_monitor = subprocess.Popen(
-                [
-                    sys.executable,
-                    "-m",
-                    "smartsim._core.entrypoints.telemetrymonitor",
-                    "-exp_dir",
-                    exp_dir,
-                    "-frequency",
-                    str(frequency),
-                ],
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
+                cmd,
+                stderr=sys.stderr,
+                stdout=sys.stdout,
                 cwd=str(pathlib.Path(__file__).parent.parent.parent),
                 shell=False,
             )

--- a/smartsim/_core/control/job.py
+++ b/smartsim/_core/control/job.py
@@ -39,8 +39,9 @@ class _JobKey():
 
 
 class JobEntity:
-    """Minimum API required for a job processed in the JobManager with support for
-    telemetry monitoring"""
+    """API required for a job processed in the JobManager with support for
+    telemetry monitoring
+    """
 
     def __init__(self) -> None:
         self.name: str = ""

--- a/smartsim/_core/control/job.py
+++ b/smartsim/_core/control/job.py
@@ -87,7 +87,7 @@ class Job:
         :param job_id: The id associated with the job
         :type job_id: str
         :param entity: The SmartSim entity(list) associated with the job
-        :type entity: SmartSimEntity | EntitySequence
+        :type entity: SmartSimEntity | EntitySequence | JobEntity
         :param launcher: Launcher job was started with
         :type launcher: str
         :param is_task: process monitored by TaskManager (True) or the WLM (True)

--- a/smartsim/_core/control/job.py
+++ b/smartsim/_core/control/job.py
@@ -27,8 +27,41 @@
 import time
 import typing as t
 
+from dataclasses import dataclass
 from ...entity import SmartSimEntity, EntitySequence
 from ...status import STATUS_NEW
+
+
+@dataclass(frozen=True)
+class _JobKey():
+    step_id: str
+    task_id: str
+
+
+class JobEntity:
+    """Minimum API required for a job processed in the JobManager with support for
+    telemetry monitoring"""
+
+    def __init__(self) -> None:
+        self.name: str = ""
+        self.path: str = ""
+        self.step_id: str = ""
+        self.task_id: str = ""
+        self.type: str = ""
+        self.timestamp: int = 0
+        self.status_dir: str = ""
+
+    @property
+    def is_db(self) -> bool:
+        return self.type in ["orchestrator", "dbnode"]
+
+    @property
+    def is_managed(self) -> bool:
+        return bool(self.step_id)
+
+    @property
+    def key(self) -> _JobKey:
+        return _JobKey(self.step_id, self.task_id)
 
 
 class Job:
@@ -42,7 +75,7 @@ class Job:
         self,
         job_name: str,
         job_id: t.Optional[str],
-        entity: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]],
+        entity: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity], JobEntity],
         launcher: str,
         is_task: bool,
     ) -> None:

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -309,7 +309,8 @@ class JobManager:
         for corresponding database identifiers
 
         :return: dictionary of host ip addresses
-        :rtype: Dict[str, list]"""
+        :rtype: Dict[str, list]
+        """
 
         address_dict = {}
         for db_job in self.db_jobs.values():

--- a/smartsim/_core/control/manifest.py
+++ b/smartsim/_core/control/manifest.py
@@ -25,11 +25,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import typing as t
+from dataclasses import dataclass, field
 
 from ...database import Orchestrator
-from ...entity import EntitySequence, SmartSimEntity, Model, Ensemble
+from ...entity import DBNode, Ensemble, EntitySequence, Model, SmartSimEntity
 from ...error import SmartSimError
 from ..utils.helpers import fmt_dict
+
+_T = t.TypeVar("_T")
+_U = t.TypeVar("_U")
+_AtomicLaunchableT = t.TypeVar("_AtomicLaunchableT", Model, DBNode)
 
 
 class Manifest:
@@ -91,7 +96,6 @@ class Manifest:
         :rtype: List[EntitySequence[SmartSimEntity]]
         """
         _all_entity_lists: t.List[EntitySequence[SmartSimEntity]] = list(self.ensembles)
-
 
         for db in self.dbs:
             _all_entity_lists.append(db)
@@ -216,3 +220,91 @@ class Manifest:
 
         # `has_db_objects` should be False here
         return has_db_objects
+
+
+class _LaunchedManifestMetadata(t.NamedTuple):
+    exp_name: str
+    exp_path: str
+    launcher_name: str
+
+
+@dataclass(frozen=True)
+class LaunchedManifest(t.Generic[_T]):
+    """Immutable manifest mapping launched entities or collections of launched
+    entities to other pieces of external data. This is commonly used to map a
+    launch-able entity to its constructed ``Step`` instance without assuming
+    that ``step.name == job.name`` or querying the ``JobManager`` which itself
+    can be ephemeral.
+    """
+
+    metadata: _LaunchedManifestMetadata
+    models: t.Tuple[t.Tuple[Model, _T], ...]
+    ensembles: t.Tuple[t.Tuple[Ensemble, t.Tuple[t.Tuple[Model, _T], ...]], ...]
+    databases: t.Tuple[t.Tuple[Orchestrator, t.Tuple[t.Tuple[DBNode, _T], ...]], ...]
+
+    def map(self, func: t.Callable[[_T], _U]) -> "LaunchedManifest[_U]":
+        def _map_entity_data(
+            fn: t.Callable[[_T], _U],
+            entity_list: t.Sequence[t.Tuple[_AtomicLaunchableT, _T]],
+        ) -> t.Tuple[t.Tuple[_AtomicLaunchableT, _U], ...]:
+            return tuple((entity, fn(data)) for entity, data in entity_list)
+
+        return LaunchedManifest(
+            metadata=self.metadata,
+            models=_map_entity_data(func, self.models),
+            ensembles=tuple(
+                (ens, _map_entity_data(func, model_data))
+                for ens, model_data in self.ensembles
+            ),
+            databases=tuple(
+                (db_, _map_entity_data(func, node_data))
+                for db_, node_data in self.databases
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class LaunchedManifestBuilder(t.Generic[_T]):
+    """A mutable class used to build a ``LaunchedManifest`` while going through
+    the launching process.
+    """
+
+    _models: t.List[t.Tuple[Model, _T]] = field(default_factory=list)
+    _ensembles: t.List[t.Tuple[Ensemble, t.Tuple[t.Tuple[Model, _T], ...]]] = field(
+        default_factory=list
+    )
+    _databases: t.List[
+        t.Tuple[Orchestrator, t.Tuple[t.Tuple[DBNode, _T], ...]]
+    ] = field(default_factory=list)
+
+    def add_model(self, model: Model, data: _T) -> None:
+        self._models.append((model, data))
+
+    def add_ensemble(self, ens: Ensemble, data: t.Sequence[_T]) -> None:
+        self._ensembles.append((ens, self._entities_to_data(ens.entities, data)))
+
+    def add_database(self, db_: Orchestrator, data: t.Sequence[_T]) -> None:
+        self._databases.append((db_, self._entities_to_data(db_.entities, data)))
+
+    @staticmethod
+    def _entities_to_data(
+        entities: t.Sequence[_AtomicLaunchableT], data: t.Sequence[_T]
+    ) -> t.Tuple[t.Tuple[_AtomicLaunchableT, _T], ...]:
+        if not entities:
+            raise ValueError("Cannot map data to an empty entity sequence")
+        if len(entities) != len(data):
+            raise ValueError(
+                f"Cannot map data sequence of length {len(data)} to entity "
+                f"sequence of length {len(entities)}"
+            )
+        return tuple(zip(entities, data))
+
+    def finalize(
+        self, exp_name: str, exp_path: str, launcher_name: str
+    ) -> LaunchedManifest[_T]:
+        return LaunchedManifest(
+            metadata=_LaunchedManifestMetadata(exp_name, exp_path, launcher_name),
+            models=tuple(self._models),
+            ensembles=tuple(self._ensembles),
+            databases=tuple(self._databases),
+        )

--- a/smartsim/_core/control/manifest.py
+++ b/smartsim/_core/control/manifest.py
@@ -282,8 +282,9 @@ class LaunchedManifest(t.Generic[_T]):
 
 @dataclass(frozen=True)
 class LaunchedManifestBuilder(t.Generic[_T]):
-    """A mutable class used to build a ``LaunchedManifest`` while going through
-    the launching process.
+    """A class comprised of mutable collections of SmartSim entities that is
+    used to build a ``LaunchedManifest`` while going through the launching
+    process.
     """
 
     exp_name: str

--- a/smartsim/_core/control/manifest.py
+++ b/smartsim/_core/control/manifest.py
@@ -234,11 +234,11 @@ class _LaunchedManifestMetadata(t.NamedTuple):
 
     @property
     def exp_telemetry_subdirectory(self) -> pathlib.Path:
-        return _fmt_exp_telemetry_path(self.exp_path)
+        return _format_exp_telemetry_path(self.exp_path)
 
     @property
     def run_telemetry_subdirectory(self) -> pathlib.Path:
-        return _fmt_run_telemetry_path(self.exp_path, self.exp_name, self.run_id)
+        return _format_run_telemetry_path(self.exp_path, self.exp_name, self.run_id)
 
     @property
     def manifest_file_path(self) -> pathlib.Path:
@@ -301,11 +301,11 @@ class LaunchedManifestBuilder(t.Generic[_T]):
 
     @property
     def exp_telemetry_subdirectory(self) -> pathlib.Path:
-        return _fmt_exp_telemetry_path(self.exp_path)
+        return _format_exp_telemetry_path(self.exp_path)
 
     @property
     def run_telemetry_subdirectory(self) -> pathlib.Path:
-        return _fmt_run_telemetry_path(self.exp_path, self.exp_name, self.run_id)
+        return _format_run_telemetry_path(self.exp_path, self.exp_name, self.run_id)
 
     def add_model(self, model: Model, data: _T) -> None:
         self._models.append((model, data))
@@ -340,13 +340,13 @@ class LaunchedManifestBuilder(t.Generic[_T]):
         )
 
 
-def _fmt_exp_telemetry_path(
+def _format_exp_telemetry_path(
     exp_path: t.Union[str, "os.PathLike[str]"]
 ) -> pathlib.Path:
     return pathlib.Path(exp_path, _serialize.TELMON_SUBDIR)
 
 
-def _fmt_run_telemetry_path(
+def _format_run_telemetry_path(
     exp_path: t.Union[str, "os.PathLike[str]"], exp_name: str, run_id: str
 ) -> pathlib.Path:
-    return _fmt_exp_telemetry_path(exp_path) / f"{exp_name}/{run_id}"
+    return _format_exp_telemetry_path(exp_path) / f"{exp_name}/{run_id}"

--- a/smartsim/_core/entrypoints/indirect.py
+++ b/smartsim/_core/entrypoints/indirect.py
@@ -1,0 +1,230 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023 Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import os
+import pathlib
+import psutil
+import signal
+import sys
+import typing as t
+
+from types import FrameType
+
+from smartsim.log import get_logger
+from smartsim._core.entrypoints.telemetrymonitor import track_event
+from smartsim._core.utils.helpers import get_ts, decode_cmd
+
+
+STEP_PID: t.Optional[int] = None
+logger = get_logger(__name__)
+
+# kill is not catchable
+SIGNALS = [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT, signal.SIGABRT]
+
+
+def main(
+    cmd: str,
+    etype: str,
+    output_path: str,
+    error_path: str,
+    cwd: str,
+    status_dir: str,
+) -> int:
+    """Execute the step command and emit tracking events"""
+    global STEP_PID  # pylint: disable=global-statement
+    proxy_pid = os.getpid()
+
+    status_path = pathlib.Path(status_dir)
+    if not status_path.exists():
+        status_path.mkdir(parents=True, exist_ok=True)
+
+    if not cmd.strip():
+        raise ValueError("Invalid cmd supplied")
+
+    cleaned_cmd = decode_cmd(cmd)
+    ret_code: int = 1
+    logger.debug("Indirect step starting")
+
+    ofp = open(output_path, "w+", encoding="utf-8")  # pylint: disable=consider-using-with
+    efp = open(error_path, "w+", encoding="utf-8")  # pylint: disable=consider-using-with
+
+    start_detail = f"Proxy process {proxy_pid}"
+    start_rc: t.Optional[int] = None
+
+    try:
+        process = psutil.Popen(
+            cleaned_cmd,
+            cwd=cwd,
+            stdout=ofp.fileno(),
+            stderr=efp.fileno(),
+            close_fds=True,
+        )
+        STEP_PID = process.pid
+        logger.info(f"Indirect proxy {proxy_pid} child process {STEP_PID} started")
+        start_detail += f" started child process {STEP_PID}"
+
+    except Exception as ex:
+        start_detail += f" failed to start child process. {ex}"
+        start_rc = 1
+        logger.error("Failed to create process", exc_info=True)
+        cleanup()
+        return 1
+    finally:
+        track_event(
+            get_ts(),
+            proxy_pid,
+            "",  # step_id for unmanaged task is always empty
+            etype,
+            "start",
+            status_path,
+            logger,
+            detail=start_detail,
+            return_code=start_rc,
+        )
+
+    logger.info(f"Waiting for child process {STEP_PID} to complete")
+    ret_code = process.wait()
+
+    logger.info(f"Indirect proxy {proxy_pid} child process {STEP_PID} complete."
+                f" return code: {ret_code}")
+    msg = f"Process {STEP_PID} finished with return code: {ret_code}"
+    track_event(
+        get_ts(),
+        proxy_pid,
+        "",  # step_id for unmanaged task is always empty
+        etype,
+        "stop",
+        status_path,
+        logger,
+        detail=msg,
+        return_code=ret_code,
+    )
+    cleanup()
+
+    return ret_code
+
+
+def cleanup() -> None:
+    """Perform cleanup required for clean termination"""
+    logger.info("Performing cleanup")
+    global STEP_PID  # pylint: disable=global-statement
+    if STEP_PID is None:
+        return
+
+    try:
+        # attempt to stop the subprocess performing step-execution
+        if psutil.pid_exists(STEP_PID):
+            process = psutil.Process(STEP_PID)
+            process.terminate()
+
+    except psutil.NoSuchProcess:
+        # swallow exception to avoid overwriting outputs from cmd
+        ...
+
+    except OSError as ex:
+        logger.warning(f"Failed to clean up step executor gracefully: {ex}")
+    finally:
+        STEP_PID = None
+
+
+def handle_signal(signo: int, _frame: t.Optional[FrameType]) -> None:
+    """Helper function to ensure clean process termination"""
+    logger.info(f"handling signal {signo}")
+    if not signo:
+        logger.warning("Received signal with no signo")
+
+    cleanup()
+
+
+def register_signal_handlers() -> None:
+    """Register a signal handling function for all termination events"""
+    for sig in SIGNALS:
+        signal.signal(sig, handle_signal)
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prefix_chars="+", description="SmartSim Step Executor"
+    )
+    parser.add_argument(
+        "+command", type=str, help="The command to execute", required=True
+    )
+    parser.add_argument(
+        "+entity_type",
+        type=str,
+        help="The type of entity related to the step",
+        required=True,
+    )
+    parser.add_argument(
+        "+working_dir",
+        type=str,
+        help="The working directory of the executable",
+        required=True,
+    )
+    parser.add_argument(
+        "+output_file", type=str, help="Output file", required=True
+    )
+    parser.add_argument(
+        "+error_file", type=str, help="Erorr output file", required=True
+    )
+    parser.add_argument(
+        "+telemetry_dir",
+        type=str,
+        help="Directory for telemetry output",
+        required=True,
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    arg_parser = get_parser()
+    os.environ["PYTHONUNBUFFERED"] = "1"
+
+    try:
+        parsed_args = arg_parser.parse_args()
+        logger.debug("Starting indirect step execution")
+
+        # make sure to register the cleanup before the start the process
+        # so our signaller will be able to stop the database process.
+        register_signal_handlers()
+
+        rc = main(
+            cmd=parsed_args.command,
+            etype=parsed_args.entity_type,
+            output_path=parsed_args.output_file,
+            error_path=parsed_args.error_file,
+            cwd=parsed_args.working_dir,
+            status_dir=parsed_args.telemetry_dir,
+        )
+        sys.exit(rc)
+
+    # gracefully exit the processes in the distributed application that
+    # we do not want to have start a colocated process. Only one process
+    # per node should be running.
+    except Exception as e:
+        logger.exception(f"An unexpected error caused step execution to fail: {e}")
+        sys.exit(1)

--- a/smartsim/_core/entrypoints/indirect.py
+++ b/smartsim/_core/entrypoints/indirect.py
@@ -53,7 +53,12 @@ def main(
     cwd: str,
     status_dir: str,
 ) -> int:
-    """Execute the step command and emit tracking events"""
+    """The main function of the entrypoint. This function takes an encoded step
+    command and runs it in a subprocess. In the background, this entrypoint
+    will then monitor the subprocess and write out status events such as when
+    the subprocess has started or stopped and write these events to a status
+    directory.
+    """
     global STEP_PID  # pylint: disable=global-statement
     proxy_pid = os.getpid()
 

--- a/smartsim/_core/entrypoints/indirect.py
+++ b/smartsim/_core/entrypoints/indirect.py
@@ -25,22 +25,23 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import logging
 import os
 import pathlib
-import psutil
 import signal
 import sys
 import typing as t
-
 from types import FrameType
 
-from smartsim.log import get_logger
-from smartsim._core.entrypoints.telemetrymonitor import track_event
-from smartsim._core.utils.helpers import get_ts, decode_cmd
+import coloredlogs
+import psutil
 
+import smartsim.log
+from smartsim._core.entrypoints.telemetrymonitor import track_event
+from smartsim._core.utils.helpers import decode_cmd, get_ts
 
 STEP_PID: t.Optional[int] = None
-logger = get_logger(__name__)
+logger = smartsim.log.get_logger(__name__)
 
 # kill is not catchable
 SIGNALS = [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT, signal.SIGABRT]
@@ -49,8 +50,6 @@ SIGNALS = [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT, signal.SIGABRT]
 def main(
     cmd: str,
     etype: str,
-    output_path: str,
-    error_path: str,
     cwd: str,
     status_dir: str,
 ) -> int:
@@ -69,9 +68,6 @@ def main(
     ret_code: int = 1
     logger.debug("Indirect step starting")
 
-    ofp = open(output_path, "w+", encoding="utf-8")  # pylint: disable=consider-using-with
-    efp = open(error_path, "w+", encoding="utf-8")  # pylint: disable=consider-using-with
-
     start_detail = f"Proxy process {proxy_pid}"
     start_rc: t.Optional[int] = None
 
@@ -79,9 +75,8 @@ def main(
         process = psutil.Popen(
             cleaned_cmd,
             cwd=cwd,
-            stdout=ofp.fileno(),
-            stderr=efp.fileno(),
-            close_fds=True,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
         )
         STEP_PID = process.pid
         logger.info(f"Indirect proxy {proxy_pid} child process {STEP_PID} started")
@@ -109,8 +104,10 @@ def main(
     logger.info(f"Waiting for child process {STEP_PID} to complete")
     ret_code = process.wait()
 
-    logger.info(f"Indirect proxy {proxy_pid} child process {STEP_PID} complete."
-                f" return code: {ret_code}")
+    logger.info(
+        f"Indirect proxy {proxy_pid} child process {STEP_PID} complete."
+        f" return code: {ret_code}"
+    )
     msg = f"Process {STEP_PID} finished with return code: {ret_code}"
     track_event(
         get_ts(),
@@ -140,7 +137,6 @@ def cleanup() -> None:
         if psutil.pid_exists(STEP_PID):
             process = psutil.Process(STEP_PID)
             process.terminate()
-
     except psutil.NoSuchProcess:
         # swallow exception to avoid overwriting outputs from cmd
         ...
@@ -171,6 +167,9 @@ def get_parser() -> argparse.ArgumentParser:
         prefix_chars="+", description="SmartSim Step Executor"
     )
     parser.add_argument(
+        "+name", type=str, help="Name of the step being executed", required=True
+    )
+    parser.add_argument(
         "+command", type=str, help="The command to execute", required=True
     )
     parser.add_argument(
@@ -186,12 +185,6 @@ def get_parser() -> argparse.ArgumentParser:
         required=True,
     )
     parser.add_argument(
-        "+output_file", type=str, help="Output file", required=True
-    )
-    parser.add_argument(
-        "+error_file", type=str, help="Erorr output file", required=True
-    )
-    parser.add_argument(
         "+telemetry_dir",
         type=str,
         help="Directory for telemetry output",
@@ -203,9 +196,25 @@ def get_parser() -> argparse.ArgumentParser:
 if __name__ == "__main__":
     arg_parser = get_parser()
     os.environ["PYTHONUNBUFFERED"] = "1"
+    parsed_args = arg_parser.parse_args()
+
+    # Set up a local private logger for when this module is run as an entry point
+    level = logger.getEffectiveLevel()
+    logger = logging.getLogger(f"{__name__}.{parsed_args.name}")
+    logger.propagate = False
+    logger.setLevel(level)
+
+    fh = logging.FileHandler(f"{parsed_args.name}.indirect.log")
+    coloredlogs.HostNameFilter.install(fh)
+    fh.setFormatter(
+        logging.Formatter(
+            smartsim.log.DEFAULT_LOG_FORMAT,
+            datefmt=smartsim.log.DEFAULT_DATE_FORMAT,
+        )
+    )
+    logger.addHandler(fh)
 
     try:
-        parsed_args = arg_parser.parse_args()
         logger.debug("Starting indirect step execution")
 
         # make sure to register the cleanup before the start the process
@@ -215,8 +224,6 @@ if __name__ == "__main__":
         rc = main(
             cmd=parsed_args.command,
             etype=parsed_args.entity_type,
-            output_path=parsed_args.output_file,
-            error_path=parsed_args.error_file,
             cwd=parsed_args.working_dir,
             status_dir=parsed_args.telemetry_dir,
         )

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -69,6 +69,7 @@ SIGNALS = [signal.SIGINT, signal.SIGQUIT, signal.SIGTERM, signal.SIGABRT]
 _EventClass = t.Literal["start", "stop", "timestep"]
 _MAX_MANIFEST_LOAD_ATTEMPTS: t.Final[int] = 6
 
+
 @dataclass
 class Run:
     """Model containing entities of an individual start call for an experiment"""
@@ -617,7 +618,7 @@ def main(
             observer.stop()  # type: ignore
             observer.join()
 
-    return 1
+    return os.EX_SOFTWARE
 
 
 def handle_signal(signo: int, _frame: t.Optional[FrameType]) -> None:

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -1,0 +1,650 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023 Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import json
+import logging
+import os
+import pathlib
+import signal
+import sys
+import threading
+import time
+import typing as t
+
+from dataclasses import dataclass, field
+from types import FrameType
+
+from watchdog.observers import Observer
+from watchdog.observers.api import BaseObserver
+from watchdog.events import PatternMatchingEventHandler, LoggingEventHandler
+from watchdog.events import FileCreatedEvent, FileModifiedEvent
+
+from smartsim._core.control.job import JobEntity, _JobKey
+from smartsim._core.control.jobmanager import JobManager
+from smartsim._core.launcher.stepInfo import StepInfo
+
+
+from smartsim._core.launcher.cobalt.cobaltLauncher import CobaltLauncher
+from smartsim._core.launcher.launcher import Launcher
+from smartsim._core.launcher.local.local import LocalLauncher
+from smartsim._core.launcher.lsf.lsfLauncher import LSFLauncher
+from smartsim._core.launcher.pbs.pbsLauncher import PBSLauncher
+from smartsim._core.launcher.slurm.slurmLauncher import SlurmLauncher
+from smartsim._core.utils.helpers import get_ts
+from smartsim._core.utils.serialize import TELMON_SUBDIR, MANIFEST_FILENAME
+
+from smartsim.error.errors import SmartSimError
+from smartsim.status import TERMINAL_STATUSES
+
+
+"""
+Telemetry Monitor entrypoint
+"""
+
+# kill is not catchable
+SIGNALS = [signal.SIGINT, signal.SIGQUIT, signal.SIGTERM, signal.SIGABRT]
+_EventClass = t.Literal["start", "stop", "timestep"]
+
+
+@dataclass
+class Run:
+    """Model containing entities of an individual start call for an experiment"""
+
+    timestamp: int
+    models: t.List[JobEntity]
+    orchestrators: t.List[JobEntity]
+    ensembles: t.List[JobEntity]
+
+    def flatten(
+        self, filter_fn: t.Optional[t.Callable[[JobEntity], bool]] = None
+    ) -> t.List[JobEntity]:
+        """Flatten runs into a list of SmartSimEntity run events"""
+        entities = self.models + self.orchestrators + self.ensembles
+        if filter_fn:
+            entities = [entity for entity in entities if filter_fn(entity)]
+        return entities
+
+
+@dataclass
+class RuntimeManifest:
+    """The runtime manifest holds meta information about the experiment entities created
+    at runtime to satisfy the experiment requirements."""
+
+    name: str
+    path: pathlib.Path
+    launcher: str
+    runs: t.List[Run] = field(default_factory=list)
+
+
+def _hydrate_persistable(
+    persistable_entity: t.Dict[str, t.Any],
+    entity_type: str,
+    exp_dir: str,
+) -> JobEntity:
+    """Populate JobEntity instance with supplied metdata and instance details"""
+    entity = JobEntity()
+
+    metadata = persistable_entity["telemetry_metadata"]
+    status_dir = pathlib.Path(metadata.get("status_dir"))
+
+    entity.type = entity_type
+    entity.name = persistable_entity["name"]
+    entity.step_id = str(metadata.get("step_id") or "")
+    entity.task_id = str(metadata.get("task_id") or "")
+    entity.timestamp = int(persistable_entity.get("timestamp", "0"))
+    entity.path = str(exp_dir)
+    entity.status_dir = str(status_dir)
+
+    return entity
+
+
+def hydrate_persistable(
+    entity_type: str,
+    persistable_entity: t.Dict[str, t.Any],
+    exp_dir: pathlib.Path,
+) -> t.List[JobEntity]:
+    """Map entity data persisted in a manifest file to an object"""
+    entities = []
+
+    # an entity w/parent key creates persistables for entities it contains
+    parent_keys = {"shards", "models"}
+    parent_keys = parent_keys.intersection(persistable_entity.keys())
+    if parent_keys:
+        container = "shards" if "shards" in parent_keys else "models"
+        child_type = "orchestrator" if container == "shards" else "model"
+        for child_entity in persistable_entity[container]:
+            entity = _hydrate_persistable(child_entity, child_type, str(exp_dir))
+            entities.append(entity)
+
+        return entities
+
+    entity = _hydrate_persistable(persistable_entity, entity_type, str(exp_dir))
+    entities.append(entity)
+    return entities
+
+
+def hydrate_persistables(
+    entity_type: str,
+    run: t.Dict[str, t.Any],
+    exp_dir: pathlib.Path,
+) -> t.Dict[str, t.List[JobEntity]]:
+    """Map a collection of entity data persisted in a manifest file to an object"""
+    persisted: t.Dict[str, t.List[JobEntity]] = {
+        "model": [],
+        "orchestrator": [],
+    }
+    for item in run[entity_type]:
+        entities = hydrate_persistable(entity_type, item, exp_dir)
+        for new_entity in entities:
+            persisted[new_entity.type].append(new_entity)
+
+    return persisted
+
+
+def hydrate_runs(
+    persisted_runs: t.List[t.Dict[str, t.Any]], exp_dir: pathlib.Path
+) -> t.List[Run]:
+    """Map run data persisted in a manifest file to an object"""
+    the_runs: t.List[Run] = []
+    for run_instance in persisted_runs:
+        run_entities: t.Dict[str, t.List[JobEntity]] = {
+            "model": [],
+            "orchestrator": [],
+            "ensemble": [],
+        }
+
+        for key in run_entities:
+            _entities = hydrate_persistables(key, run_instance, exp_dir)
+            for entity_type, new_entities in _entities.items():
+                if new_entities:
+                    run_entities[entity_type].extend(new_entities)
+
+        run = Run(
+            run_instance["timestamp"],
+            run_entities["model"],
+            run_entities["orchestrator"],
+            run_entities["ensemble"],
+        )
+        the_runs.append(run)
+
+    return the_runs
+
+
+def load_manifest(file_path: str) -> t.Optional[RuntimeManifest]:
+    """Load a persisted manifest and return the content"""
+    manifest_dict: t.Optional[t.Dict[str, t.Any]] = None
+    try_count = 1
+
+    while manifest_dict is None and try_count < 6:
+        source = pathlib.Path(file_path)
+        source = source.resolve()
+
+        try:
+            if text := source.read_text(encoding="utf-8").strip():
+                manifest_dict = json.loads(text)
+        except json.JSONDecodeError as ex:
+            print(f"Error loading manifest: {ex}")
+            # hack/fix: handle issues reading file before it is fully written
+            time.sleep(0.5 * try_count)
+        finally:
+            try_count += 1
+
+    if not manifest_dict:
+        return None
+
+    exp = manifest_dict.get("experiment", None)
+    if not exp:
+        raise ValueError("Manifest missing required experiment")
+
+    runs = manifest_dict.get("runs", None)
+    if runs is None:
+        raise ValueError("Manifest missing required runs")
+
+    exp_dir = pathlib.Path(exp["path"])
+    runs = hydrate_runs(runs, exp_dir)
+
+    manifest = RuntimeManifest(
+        name=exp["name"],
+        path=exp_dir,
+        launcher=exp["launcher"],
+        runs=runs,
+    )
+    return manifest
+
+
+def track_event(
+    timestamp: int,
+    task_id: t.Union[int, str],
+    step_id: str,
+    etype: str,
+    action: _EventClass,
+    status_dir: pathlib.Path,
+    logger: logging.Logger,
+    detail: str = "",
+    return_code: t.Optional[int] = None,
+) -> None:
+    """
+    Persist a tracking event for an entity
+    """
+    tgt_path = status_dir / f"{action}.json"
+    tgt_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        task_id = int(task_id)
+    except ValueError:
+        pass
+
+    entity_dict = {
+        "timestamp": timestamp,
+        "job_id": task_id,
+        "step_id": step_id,
+        "type": etype,
+        "action": action,
+    }
+
+    if detail is not None:
+        entity_dict["detail"] = detail
+
+    if return_code is not None:
+        entity_dict["return_code"] = return_code
+
+    try:
+        if not tgt_path.exists():
+            # Don't overwrite existing tracking files
+            bytes_written = tgt_path.write_text(json.dumps(entity_dict, indent=2))
+            if bytes_written < 1:
+                logger.warning("event tracking failed to write tracking file.")
+    except Exception:
+        logger.error("Unable to write tracking file.", exc_info=True)
+
+
+class ManifestEventHandler(PatternMatchingEventHandler):
+    """The ManifestEventHandler monitors an experiment for changes and updates
+    a telemetry datastore as needed.
+
+    It contains event handlers that are triggered by changes to a runtime experiment
+    manifest. The runtime manifest differs from a standard manifest. A runtime manifest
+    may contain multiple experiment executions in a `runs` collection.
+
+    It also contains a long-polling loop that checks experiment entities for updates
+    at each timestep."""
+
+    def __init__(
+        self,
+        pattern: str,
+        logger: logging.Logger,
+        ignore_patterns: t.Any = None,
+        ignore_directories: bool = True,
+        case_sensitive: bool = False,
+    ) -> None:
+        super().__init__(
+            [pattern], ignore_patterns, ignore_directories, case_sensitive
+        )  # type: ignore
+        self._logger = logger
+        self._tracked_runs: t.Dict[int, Run] = {}
+        self._tracked_jobs: t.Dict[_JobKey, JobEntity] = {}
+        self._completed_jobs: t.Dict[_JobKey, JobEntity] = {}
+        self._launcher: t.Optional[Launcher] = None
+        self.job_manager: JobManager = JobManager(threading.RLock())
+        self._launcher_map: t.Dict[str, t.Type[Launcher]] = {
+            "slurm": SlurmLauncher,
+            "pbs": PBSLauncher,
+            "cobalt": CobaltLauncher,
+            "lsf": LSFLauncher,
+            "local": LocalLauncher,
+        }
+
+    def init_launcher(self, launcher: str) -> Launcher:
+        """Initialize the controller with a specific type of launcher.
+        SmartSim currently supports slurm, pbs(pro), cobalt, lsf,
+        and local launching
+
+        :param launcher: which launcher to initialize
+        :type launcher: str
+        :raises SSUnsupportedError: if a string is passed that is not
+                                    a supported launcher
+        :raises TypeError: if no launcher argument is provided.
+        """
+        if not launcher:
+            raise TypeError("Must provide a 'launcher' argument")
+
+        if launcher_type := self._launcher_map.get(launcher.lower(), None):
+            return launcher_type()
+
+        raise ValueError("Launcher type not supported: " + launcher)
+
+
+    def set_launcher(self, launcher_type: str) -> None:
+        """Set the launcher for the experiment"""
+        self._launcher = self.init_launcher(launcher_type)
+        self.job_manager.set_launcher(self._launcher)
+        self.job_manager.start()
+
+    @property
+    def launcher(self) -> Launcher:
+        """Return a launcher appropriate for the experiment"""
+        if not self._launcher:
+            self.set_launcher("local")
+
+        if not self._launcher:
+            raise SmartSimError("Unable to set launcher")
+
+        return self._launcher
+
+    def process_manifest(self, manifest_path: str) -> None:
+        """Read the runtime manifest for the experiment and track new entities
+
+        :param manifest_path: The full path to the manifest file
+        :type manifest_path: str"""
+        try:
+            manifest = load_manifest(manifest_path)
+            if not manifest:
+                return
+        except json.JSONDecodeError:
+            self._logger.error(f"Malformed manifest encountered: {manifest_path}")
+            return
+        except ValueError:
+            self._logger.error("Manifest content error", exc_info=True)
+            return
+
+        self.set_launcher(manifest.launcher)
+
+        if not self._launcher:
+            raise SmartSimError(f"Unable to set launcher from {manifest_path}")
+
+        runs = [run for run in manifest.runs if run.timestamp not in self._tracked_runs]
+
+        exp_dir = pathlib.Path(manifest_path).parent.parent.parent
+
+        for run in runs:
+            for entity in run.flatten(
+                filter_fn=lambda e: e.key not in self._tracked_jobs and e.is_managed
+            ):
+                entity.path = str(exp_dir)
+
+                self._tracked_jobs[entity.key] = entity
+                track_event(
+                    run.timestamp,
+                    entity.task_id,
+                    entity.step_id,
+                    entity.type,
+                    "start",
+                    pathlib.Path(entity.status_dir),
+                    self._logger,
+                )
+
+                if entity.is_managed:
+                    self.job_manager.add_job(
+                        entity.name,
+                        entity.task_id,
+                        entity,
+                        False,
+                    )
+                    self._launcher.step_mapping.add(
+                        entity.name, entity.step_id, entity.task_id, True
+                    )
+            self._tracked_runs[run.timestamp] = run
+
+    def on_modified(self, event: FileModifiedEvent) -> None:
+        """Event handler for when a file or directory is modified.
+
+        :param event: Event representing file/directory modification.
+        :type event: FileModifiedEvent"""
+        super().on_modified(event)  # type: ignore
+        self._logger.info(f"processing modified manifest @ {event.src_path}")
+        self.process_manifest(event.src_path)
+
+    def on_created(self, event: FileCreatedEvent) -> None:
+        """Event handler for when a file or directory is created.
+
+        :param event: Event representing file/directory creation.
+        :type event: FileCreatedEvent"""
+        super().on_created(event)  # type: ignore
+        self.process_manifest(event.src_path)
+
+    def _to_completed(
+        self,
+        timestamp: int,
+        entity: JobEntity,
+        step_info: t.Optional[StepInfo],
+    ) -> None:
+        """Move a monitored entity from the active to completed collection to
+        stop monitoring for updates during timesteps.
+
+        :param timestamp: the current timestamp for event logging
+        :type timestamp: int
+        :param entity: the running SmartSim Job
+        :type entity: JobEntity
+        :param experiment_dir: the experiement directory to monitor for changes
+        :type experiment_dir: pathlib.Path
+        :param entity: the StepInfo received when requesting a Job status update
+        :type entity: t.Optional[StepInfo]
+        """
+        inactive_entity = self._tracked_jobs.pop(entity.key)
+        if entity.key not in self._completed_jobs:
+            self._completed_jobs[entity.key] = inactive_entity
+
+        job = self.job_manager[entity.name]
+        self.job_manager.move_to_completed(job)
+
+        if step_info:
+            detail = f"status: {step_info.status}, error: {step_info.error}"
+        else:
+            detail = "unknown status. step_info not retrieved"
+
+        if hasattr(job.entity, "status_dir"):
+            write_path = pathlib.Path(job.entity.status_dir)
+
+        track_event(
+            timestamp,
+            entity.task_id,
+            entity.step_id,
+            entity.type,
+            "stop",
+            write_path,
+            self._logger,
+            detail=detail,
+        )
+
+    def on_timestep(self, timestamp: int) -> None:
+        """Called at polling frequency .to request status updates on
+        monitored entities
+
+        :param timestamp: the current timestamp for event logging
+        :type timestamp: int
+        :param experiment_dir: the experiement directory to monitor for changes
+        :type experiment_dir: pathlib.Path"""
+        launcher = self.launcher
+        entity_map = self._tracked_jobs
+
+        # consider not using name to avoid collisions
+        names = {entity.name: entity for entity in entity_map.values()}
+
+        if names:
+            step_updates = launcher.get_step_update(list(names.keys()))
+
+            for step_name, step_info in step_updates:
+                if step_info and step_info.status in TERMINAL_STATUSES:
+                    completed_entity = names[step_name]
+                    self._to_completed(
+                        timestamp, completed_entity, step_info
+                    )
+
+
+def can_shutdown(_action_handler: ManifestEventHandler) -> bool:
+    # has_jobs = bool(action_handler.job_manager.jobs)
+    # has_dbs = bool(action_handler.job_manager.db_jobs)
+    # has_running_jobs = has_jobs or has_dbs
+
+    return False # known defect; must manually shutdown until fixed
+    # return not has_running_jobs
+
+
+def shutdown_when_completed(
+    observer: BaseObserver, action_handler: ManifestEventHandler
+) -> None:
+    """Inspect active and completed job queues and shutdown if all jobs are complete
+
+    :param observer: (optional) the watchdog Observer instance
+    :type observer: t.Optional[BaseObserver]
+    :param action_handler: The manifest event processor instance
+    :type action_handler: ManifestEventHandler"""
+    if can_shutdown(action_handler):
+        observer.stop()  # type: ignore[no-untyped-call]
+
+
+def event_loop(
+    observer: BaseObserver,
+    action_handler: ManifestEventHandler,
+    frequency: t.Union[int, float],
+    logger: logging.Logger,
+) -> None:
+    """Executes all attached timestep handlers every <frequency> seconds
+
+    :param observer: (optional) a preconfigured watchdog Observer to inject
+    :type observer: t.Optional[BaseObserver]
+    :param action_handler: The manifest event processor instance
+    :type action_handler: ManifestEventHandler
+    :param frequency: frequency (in seconds) of update loop
+    :type frequency: t.Union[int, float]
+    :param experiment_dir: the experiement directory to monitor for changes
+    :type experiment_dir: pathlib.Path
+    :param logger: a preconfigured Logger instance
+    :type logger: logging.Logger"""
+    while observer.is_alive():
+        timestamp = get_ts()
+        logger.debug(f"Telemetry timestep: {timestamp}")
+        action_handler.on_timestep(timestamp)
+        time.sleep(frequency)
+
+        shutdown_when_completed(observer, action_handler)
+
+
+def main(
+    frequency: t.Union[int, float],
+    experiment_dir: pathlib.Path,
+    logger: logging.Logger,
+    observer: t.Optional[BaseObserver] = None,
+) -> int:
+    """Setup the monitoring entities and start the timer-based loop that
+    will poll for telemetry data
+
+    :param frequency: frequency (in seconds) of update loop
+    :type frequency: t.Union[int, float]
+    :param experiment_dir: the experiement directory to monitor for changes
+    :type experiment_dir: pathlib.Path
+    :param observer: (optional) a preconfigured Observer to inject
+    :type observer: t.Optional[BaseObserver]
+    """
+    manifest_relpath = pathlib.Path(TELMON_SUBDIR) / MANIFEST_FILENAME
+    manifest_path = experiment_dir / manifest_relpath
+    monitor_pattern = str(manifest_relpath)
+
+    logger.info(
+        f"Executing telemetry monitor with frequency: {frequency}s"
+        f", on target directory: {experiment_dir}"
+        f" matching pattern: {monitor_pattern}"
+    )
+
+    log_handler = LoggingEventHandler(logger)  # type: ignore
+    action_handler = ManifestEventHandler(monitor_pattern, logger)
+
+    if observer is None:
+        observer = Observer()
+
+    try:
+        if manifest_path.exists():
+            # a manifest may not exist depending on startup timing
+            action_handler.process_manifest(str(manifest_path))
+
+        observer.schedule(log_handler, experiment_dir, recursive=True)  # type:ignore
+        observer.schedule(action_handler, experiment_dir, recursive=True)  # type:ignore
+        observer.start()  # type: ignore
+
+        event_loop(observer, action_handler, frequency, logger)
+        return 0
+    except Exception as ex:
+        logger.error(ex)
+    finally:
+        if observer.is_alive():
+            observer.stop()  # type: ignore
+            observer.join()
+
+    return 1
+
+
+def handle_signal(signo: int, _frame: t.Optional[FrameType]) -> None:
+    """Helper function to ensure clean process termination"""
+    if not signo:
+        logger = logging.getLogger()
+        logger.warning("Received signal with no signo")
+
+
+def register_signal_handlers() -> None:
+    """Register a signal handling function for all termination events"""
+    for sig in SIGNALS:
+        signal.signal(sig, handle_signal)
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Instantiate a parser to process command line arguments"""
+    arg_parser = argparse.ArgumentParser(description="SmartSim Telemetry Monitor")
+    arg_parser.add_argument(
+        "-frequency",
+        type=str,
+        help="Frequency of telemetry updates (in seconds))",
+        required=True,
+    )
+    arg_parser.add_argument(
+        "-exp_dir",
+        type=str,
+        help="Experiment root directory",
+        required=True,
+    )
+    return arg_parser
+
+
+if __name__ == "__main__":
+    os.environ["PYTHONUNBUFFERED"] = "1"
+
+    parser = get_parser()
+    args = parser.parse_args()
+
+    log = logging.getLogger()
+
+    # Must register cleanup before the main loop is running
+    register_signal_handlers()
+
+    try:
+        main(int(args.frequency), pathlib.Path(args.exp_dir), log)
+        sys.exit(0)
+    except Exception:
+        log.exception(
+            "Shutting down telemetry monitor due to unexpected error", exc_info=True
+        )
+
+    sys.exit(1)

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -62,9 +62,7 @@ from smartsim.error.errors import SmartSimError
 from smartsim.status import STATUS_COMPLETED, TERMINAL_STATUSES
 
 
-"""
-Telemetry Monitor entrypoint
-"""
+"""Telemetry Monitor entrypoint"""
 
 # kill is not catchable
 SIGNALS = [signal.SIGINT, signal.SIGQUIT, signal.SIGTERM, signal.SIGABRT]
@@ -93,7 +91,8 @@ class Run:
 @dataclass
 class RuntimeManifest:
     """The runtime manifest holds meta information about the experiment entities created
-    at runtime to satisfy the experiment requirements."""
+    at runtime to satisfy the experiment requirements.
+    """
 
     name: str
     path: pathlib.Path
@@ -248,9 +247,7 @@ def track_event(
     detail: str = "",
     return_code: t.Optional[int] = None,
 ) -> None:
-    """
-    Persist a tracking event for an entity
-    """
+    """Persist a tracking event for an entity"""
     tgt_path = status_dir / f"{action}.json"
     tgt_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -285,7 +282,8 @@ def track_event(
 
 def faux_return_code(step_info: StepInfo) -> t.Optional[int]:
     """Create a faux return code for a task run by the WLM. Must not be
-    called with non-terminal statuses or results may be confusing"""
+    called with non-terminal statuses or results may be confusing
+    """
     if step_info.status not in TERMINAL_STATUSES:
         return None
 
@@ -304,7 +302,8 @@ class ManifestEventHandler(PatternMatchingEventHandler):
     may contain multiple experiment executions in a `runs` collection.
 
     It also contains a long-polling loop that checks experiment entities for updates
-    at each timestep."""
+    at each timestep.
+    """
 
     def __init__(
         self,
@@ -360,7 +359,8 @@ class ManifestEventHandler(PatternMatchingEventHandler):
         """Read the runtime manifest for the experiment and track new entities
 
         :param manifest_path: The full path to the manifest file
-        :type manifest_path: str"""
+        :type manifest_path: str
+        """
         try:
             manifest = load_manifest(manifest_path)
             if not manifest:
@@ -415,7 +415,8 @@ class ManifestEventHandler(PatternMatchingEventHandler):
         """Event handler for when a file or directory is modified.
 
         :param event: Event representing file/directory modification.
-        :type event: FileModifiedEvent"""
+        :type event: FileModifiedEvent
+        """
         super().on_modified(event)  # type: ignore
         self._logger.info(f"processing manifest modified @ {event.src_path}")
         self.process_manifest(event.src_path)
@@ -424,7 +425,8 @@ class ManifestEventHandler(PatternMatchingEventHandler):
         """Event handler for when a file or directory is created.
 
         :param event: Event representing file/directory creation.
-        :type event: FileCreatedEvent"""
+        :type event: FileCreatedEvent
+        """
         super().on_created(event)  # type: ignore
         self._logger.info(f"processing manifest created @ {event.src_path}")
         self.process_manifest(event.src_path)
@@ -480,7 +482,8 @@ class ManifestEventHandler(PatternMatchingEventHandler):
         :param timestamp: the current timestamp for event logging
         :type timestamp: int
         :param experiment_dir: the experiement directory to monitor for changes
-        :type experiment_dir: pathlib.Path"""
+        :type experiment_dir: pathlib.Path
+        """
         entity_map = self._tracked_jobs
 
         if not self._launcher:
@@ -532,7 +535,8 @@ def event_loop(
     :param experiment_dir: the experiement directory to monitor for changes
     :type experiment_dir: pathlib.Path
     :param logger: a preconfigured Logger instance
-    :type logger: logging.Logger"""
+    :type logger: logging.Logger
+    """
     elapsed: int = 0
     last_ts: int = get_ts()
 

--- a/smartsim/_core/launcher/cobalt/cobaltLauncher.py
+++ b/smartsim/_core/launcher/cobalt/cobaltLauncher.py
@@ -117,15 +117,13 @@ class CobaltLauncher(WLMLauncher):
             # aprun doesn't direct output for us.
             out, err = step.get_output_files()
 
-            passed_env = step.env
-
             # pylint: disable-next=consider-using-with
             output = open(out, "w+", encoding="utf-8")
             # pylint: disable-next=consider-using-with
             error = open(err, "w+", encoding="utf-8")
 
             task_id = self.task_manager.start_task(
-                cmd_list, step.cwd, passed_env, out=output.fileno(), err=error.fileno()
+                cmd_list, step.cwd, step.env, out=output.fileno(), err=error.fileno()
             )
 
         # if batch submission did not successfully retrieve job ID

--- a/smartsim/_core/launcher/cobalt/cobaltLauncher.py
+++ b/smartsim/_core/launcher/cobalt/cobaltLauncher.py
@@ -117,8 +117,7 @@ class CobaltLauncher(WLMLauncher):
             # aprun doesn't direct output for us.
             out, err = step.get_output_files()
 
-            # LocalStep.run_command omits env, include it here
-            passed_env = step.env if isinstance(step, LocalStep) else None
+            passed_env = step.env
 
             # pylint: disable-next=consider-using-with
             output = open(out, "w+", encoding="utf-8")

--- a/smartsim/_core/launcher/launcher.py
+++ b/smartsim/_core/launcher/launcher.py
@@ -47,11 +47,6 @@ class Launcher(abc.ABC):  # pragma: no cover
     step_mapping: StepMapping
     task_manager: TaskManager
 
-    @property
-    @abc.abstractmethod
-    def supported_rs(self) -> t.Dict[t.Type[SettingsBase], t.Type[Step]]:
-        raise NotImplementedError
-
     @abc.abstractmethod
     def create_step(self, name: str, cwd: str, step_settings: SettingsBase) -> Step:
         raise NotImplementedError
@@ -85,6 +80,11 @@ class WLMLauncher(Launcher):  # cov-wlm
         super().__init__()
         self.task_manager = TaskManager()
         self.step_mapping = StepMapping()
+
+    @property
+    @abc.abstractmethod
+    def supported_rs(self) -> t.Dict[t.Type[SettingsBase], t.Type[Step]]:
+        raise NotImplementedError
 
     # every launcher utilizing this interface must have a map
     # of supported RunSettings types (see slurmLauncher.py for ex)
@@ -176,6 +176,6 @@ class WLMLauncher(Launcher):  # cov-wlm
     # pylint: disable-next=no-self-use
     def _get_managed_step_update(
         self,
-        step_ids: t.List[str], # pylint: disable=unused-argument
+        step_ids: t.List[str],  # pylint: disable=unused-argument
     ) -> t.List[StepInfo]:  # pragma: no cover
         return []

--- a/smartsim/_core/launcher/local/local.py
+++ b/smartsim/_core/launcher/local/local.py
@@ -66,7 +66,7 @@ class LocalLauncher(Launcher):
         :param step_names: list of step_names
         :type step_names: list[str]
         :return: list of tuples for update
-        :rtype: list[(str, UnmanagedStepInfo)]
+        :rtype: list[tuple[str, StepInfo | None]]
         """
         # step ids are process ids of the tasks
         # as there is no WLM intermediary

--- a/smartsim/_core/launcher/local/local.py
+++ b/smartsim/_core/launcher/local/local.py
@@ -112,10 +112,8 @@ class LocalLauncher(Launcher):
         # pylint: disable-next=consider-using-with
         error = open(err, "w+", encoding="utf-8")
 
-        passed_env = step.env
-
         task_id = self.task_manager.start_task(
-            cmd, step.cwd, env=passed_env, out=output.fileno(), err=error.fileno()
+            cmd, step.cwd, env=step.env, out=output.fileno(), err=error.fileno()
         )
 
         self.step_mapping.add(step.name, task_id=task_id, managed=False)

--- a/smartsim/_core/launcher/local/local.py
+++ b/smartsim/_core/launcher/local/local.py
@@ -31,8 +31,7 @@ import typing as t
 from ..launcher import Launcher
 from ....log import get_logger
 from ....settings import RunSettings, SettingsBase
-from ..step.localStep import LocalStep
-from ..step.step import Step
+from ..step import LocalStep, Step
 from ..stepInfo import UnmanagedStepInfo, StepInfo
 from ..stepMapping import StepMapping
 from ..taskManager import TaskManager

--- a/smartsim/_core/launcher/local/local.py
+++ b/smartsim/_core/launcher/local/local.py
@@ -31,8 +31,8 @@ import typing as t
 from ..launcher import Launcher
 from ....log import get_logger
 from ....settings import RunSettings, SettingsBase
-from ..step import LocalStep
-from ..step import Step
+from ..step.localStep import LocalStep
+from ..step.step import Step
 from ..stepInfo import UnmanagedStepInfo, StepInfo
 from ..stepMapping import StepMapping
 from ..taskManager import TaskManager
@@ -107,18 +107,12 @@ class LocalLauncher(Launcher):
         out, err = step.get_output_files()
         cmd = step.get_launch_cmd()
 
-        if CONFIG.telemetry_enabled:
-            out = step.get_step_file(ending=".indirect.out")
-            err = step.get_step_file(ending=".indirect.err")
-            cmd = self.get_proxy_cmd(step)
-
         # pylint: disable-next=consider-using-with
         output = open(out, "w+", encoding="utf-8")
         # pylint: disable-next=consider-using-with
         error = open(err, "w+", encoding="utf-8")
 
-        # LocalStep.run_command omits env, include it here
-        passed_env = step.env if isinstance(step, LocalStep) else None
+        passed_env = step.env
 
         task_id = self.task_manager.start_task(
             cmd, step.cwd, env=passed_env, out=output.fileno(), err=error.fileno()
@@ -145,43 +139,3 @@ class LocalLauncher(Launcher):
 
     def __str__(self) -> str:
         return "Local"
-
-    @staticmethod
-    def get_proxy_cmd(step: Step) -> t.List[str]:
-        """Executes a step indirectly through a proxy process. This ensures unmanaged tasks
-        continue telemetry logging after a driver process exits or fails.
-
-        :param step: the step to produce a proxied command for
-        :type step: Step
-        :return: CLI arguments to execute the step via the proxy step executor
-        :rtype: t.List[str]
-        """
-
-        proxy_module = "smartsim._core.entrypoints.indirect"
-        etype = step.meta["entity_type"]
-        status_dir = step.meta["status_dir"]
-        cmd_list = step.get_launch_cmd()
-        encoded_cmd = encode_cmd(cmd_list)
-
-        out, err = step.get_output_files()
-
-        # note: this is NOT safe. should either 1) sign cmd and verify OR 2) serialize step and let
-        # the indirect entrypoint rebuild the cmd... for now, test away...
-        proxied_cmd = [
-            sys.executable,
-            "-m",
-            proxy_module,
-            "+command",
-            encoded_cmd,
-            "+entity_type",
-            etype,
-            "+telemetry_dir",
-            status_dir,
-            "+working_dir",
-            step.cwd,
-            "+output_file",
-            out,
-            "+error_file",
-            err,
-        ]
-        return proxied_cmd

--- a/smartsim/_core/launcher/lsf/lsfLauncher.py
+++ b/smartsim/_core/launcher/lsf/lsfLauncher.py
@@ -115,12 +115,11 @@ class LSFLauncher(WLMLauncher):
             time.sleep(1)
             step_id = self._get_lsf_step_id(step)
             logger.debug(f"Gleaned jsrun step id: {step_id} for {step.name}")
-        else:  # isinstance(step, MpirunStep) or isinstance(step, LocalStep)
+        else:
             # mpirun and local launch don't direct output for us
             out, err = step.get_output_files()
 
-            # LocalStep.run_command omits env, include it here
-            passed_env = step.env if isinstance(step, LocalStep) else None
+            passed_env = step.env
 
             # pylint: disable-next=consider-using-with
             output = open(out, "w+", encoding="utf-8")

--- a/smartsim/_core/launcher/lsf/lsfLauncher.py
+++ b/smartsim/_core/launcher/lsf/lsfLauncher.py
@@ -42,13 +42,13 @@ from ....status import STATUS_CANCELLED, STATUS_COMPLETED
 from ...config import CONFIG
 from ..launcher import WLMLauncher
 from ..step import (
-    Step,
     BsubBatchStep,
     JsrunStep,
     LocalStep,
     MpiexecStep,
     MpirunStep,
     OrterunStep,
+    Step,
 )
 from ..stepInfo import LSFBatchStepInfo, LSFJsrunStepInfo, StepInfo
 from .lsfCommands import bjobs, bkill, jskill, jslist

--- a/smartsim/_core/launcher/lsf/lsfLauncher.py
+++ b/smartsim/_core/launcher/lsf/lsfLauncher.py
@@ -119,14 +119,12 @@ class LSFLauncher(WLMLauncher):
             # mpirun and local launch don't direct output for us
             out, err = step.get_output_files()
 
-            passed_env = step.env
-
             # pylint: disable-next=consider-using-with
             output = open(out, "w+", encoding="utf-8")
             # pylint: disable-next=consider-using-with
             error = open(err, "w+", encoding="utf-8")
             task_id = self.task_manager.start_task(
-                cmd_list, step.cwd, passed_env, out=output.fileno(), err=error.fileno()
+                cmd_list, step.cwd, step.env, out=output.fileno(), err=error.fileno()
             )
 
         self.step_mapping.add(step.name, step_id, task_id, step.managed)

--- a/smartsim/_core/launcher/pbs/pbsLauncher.py
+++ b/smartsim/_core/launcher/pbs/pbsLauncher.py
@@ -111,8 +111,7 @@ class PBSLauncher(WLMLauncher):
             # aprun/local doesn't direct output for us.
             out, err = step.get_output_files()
 
-            # LocalStep.run_command omits env, include it here
-            passed_env = step.env if isinstance(step, LocalStep) else None
+            passed_env = step.env
 
             # pylint: disable-next=consider-using-with
             output = open(out, "w+", encoding="utf-8")

--- a/smartsim/_core/launcher/pbs/pbsLauncher.py
+++ b/smartsim/_core/launcher/pbs/pbsLauncher.py
@@ -111,14 +111,12 @@ class PBSLauncher(WLMLauncher):
             # aprun/local doesn't direct output for us.
             out, err = step.get_output_files()
 
-            passed_env = step.env
-
             # pylint: disable-next=consider-using-with
             output = open(out, "w+", encoding="utf-8")
             # pylint: disable-next=consider-using-with
             error = open(err, "w+", encoding="utf-8")
             task_id = self.task_manager.start_task(
-                cmd_list, step.cwd, passed_env, out=output.fileno(), err=error.fileno()
+                cmd_list, step.cwd, step.env, out=output.fileno(), err=error.fileno()
             )
 
         # if batch submission did not successfully retrieve job ID

--- a/smartsim/_core/launcher/slurm/slurmLauncher.py
+++ b/smartsim/_core/launcher/slurm/slurmLauncher.py
@@ -155,8 +155,7 @@ class SlurmLauncher(WLMLauncher):
             # MPI/local steps don't direct output like slurm steps
             out, err = step.get_output_files()
 
-            # LocalStep.run_command omits env, include it here
-            passed_env = step.env if isinstance(step, LocalStep) else None
+            passed_env = step.env
 
             # pylint: disable-next=consider-using-with
             output = open(out, "w+", encoding="utf-8")

--- a/smartsim/_core/launcher/slurm/slurmLauncher.py
+++ b/smartsim/_core/launcher/slurm/slurmLauncher.py
@@ -155,14 +155,12 @@ class SlurmLauncher(WLMLauncher):
             # MPI/local steps don't direct output like slurm steps
             out, err = step.get_output_files()
 
-            passed_env = step.env
-
             # pylint: disable-next=consider-using-with
             output = open(out, "w+", encoding="utf-8")
             # pylint: disable-next=consider-using-with
             error = open(err, "w+", encoding="utf-8")
             task_id = self.task_manager.start_task(
-                cmd_list, step.cwd, passed_env, out=output.fileno(), err=error.fileno()
+                cmd_list, step.cwd, step.env, out=output.fileno(), err=error.fileno()
             )
 
         if not step_id and step.managed:

--- a/smartsim/_core/launcher/step/alpsStep.py
+++ b/smartsim/_core/launcher/step/alpsStep.py
@@ -31,7 +31,7 @@ from shlex import split as sh_split
 
 from ....error import AllocationError
 from ....log import get_logger
-from .step import Step
+from .step import Step, proxyable_launch_cmd
 from ....settings import AprunSettings, RunSettings, Singularity
 
 logger = get_logger(__name__)
@@ -59,6 +59,7 @@ class AprunStep(Step):
         of attached RunSettings"""
         return self.run_settings.mpmd
 
+    @proxyable_launch_cmd
     def get_launch_cmd(self) -> t.List[str]:
         """Get the command to launch this step
 

--- a/smartsim/_core/launcher/step/alpsStep.py
+++ b/smartsim/_core/launcher/step/alpsStep.py
@@ -56,7 +56,8 @@ class AprunStep(Step):
 
     def _get_mpmd(self) -> t.List[RunSettings]:
         """Temporary convenience function to return a typed list
-        of attached RunSettings"""
+        of attached RunSettings
+        """
         return self.run_settings.mpmd
 
     @proxyable_launch_cmd

--- a/smartsim/_core/launcher/step/localStep.py
+++ b/smartsim/_core/launcher/step/localStep.py
@@ -28,7 +28,7 @@ import os
 import shutil
 import typing as t
 
-from .step import Step
+from .step import Step, proxyable_launch_cmd
 from ....settings.base import RunSettings
 from ....settings import Singularity
 
@@ -37,8 +37,13 @@ class LocalStep(Step):
     def __init__(self, name: str, cwd: str, run_settings: RunSettings):
         super().__init__(name, cwd, run_settings)
         self.run_settings = run_settings
-        self.env = self._set_env()
+        self._env = self._set_env()
 
+    @property
+    def env(self) -> t.Dict[str, str]:
+        return self._env
+
+    @proxyable_launch_cmd
     def get_launch_cmd(self) -> t.List[str]:
         cmd = []
 

--- a/smartsim/_core/launcher/step/lsfStep.py
+++ b/smartsim/_core/launcher/step/lsfStep.py
@@ -213,7 +213,8 @@ class JsrunStep(Step):
 
     def _get_mpmd(self) -> t.List[RunSettings]:
         """Temporary convenience function to return a typed list
-        of attached RunSettings"""
+        of attached RunSettings
+        """
         if isinstance(self.step_settings, JsrunSettings):
             return self.step_settings.mpmd
         return []

--- a/smartsim/_core/launcher/step/mpiStep.py
+++ b/smartsim/_core/launcher/step/mpiStep.py
@@ -26,8 +26,8 @@
 
 import os
 import shutil
-from shlex import split as sh_split
 import typing as t
+from shlex import split as sh_split
 
 from ....error import AllocationError, SmartSimError
 from ....log import get_logger

--- a/smartsim/_core/launcher/step/mpiStep.py
+++ b/smartsim/_core/launcher/step/mpiStep.py
@@ -119,7 +119,8 @@ class _BaseMPIStep(Step):
 
     def _get_mpmd(self) -> t.List[RunSettings]:
         """Temporary convenience function to return a typed list
-        of attached RunSettings"""
+        of attached RunSettings
+        """
         if hasattr(self.run_settings, "mpmd") and self.run_settings.mpmd:
             rs_mpmd: t.List[RunSettings] = self.run_settings.mpmd
             return rs_mpmd

--- a/smartsim/_core/launcher/step/mpiStep.py
+++ b/smartsim/_core/launcher/step/mpiStep.py
@@ -31,7 +31,7 @@ from shlex import split as sh_split
 
 from ....error import AllocationError, SmartSimError
 from ....log import get_logger
-from .step import Step
+from .step import Step, proxyable_launch_cmd
 from ....settings import MpirunSettings, MpiexecSettings, OrterunSettings
 from ....settings.base import RunSettings
 
@@ -59,6 +59,7 @@ class _BaseMPIStep(Step):
 
     _supported_launchers = ["PBS", "COBALT", "SLURM", "LSB"]
 
+    @proxyable_launch_cmd
     def get_launch_cmd(self) -> t.List[str]:
         """Get the command to launch this step
 

--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -26,13 +26,13 @@
 
 import os
 import shutil
-from shlex import split as sh_split
 import typing as t
+from shlex import split as sh_split
 
 from ....error import AllocationError
 from ....log import get_logger
 from .step import Step
-from ....settings import SrunSettings, SbatchSettings, RunSettings, Singularity
+from ....settings import RunSettings, SbatchSettings, Singularity, SrunSettings
 
 logger = get_logger(__name__)
 

--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -189,13 +189,15 @@ class SrunStep(Step):
 
     def _get_mpmd(self) -> t.List[RunSettings]:
         """Temporary convenience function to return a typed list
-        of attached RunSettings"""
+        of attached RunSettings
+        """
         return self.run_settings.mpmd
 
     @staticmethod
     def _get_exe_args_list(run_setting: RunSettings) -> t.List[str]:
         """Convenience function to encapsulate checking the
-        runsettings.exe_args type to always return a list"""
+        runsettings.exe_args type to always return a list
+        """
         exe_args = run_setting.exe_args
         args: t.List[str] = exe_args if isinstance(exe_args, list) else [exe_args]
         return args

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -77,7 +77,8 @@ class Step:
     ) -> str:
         """Get the name for a file/script created by the step class
 
-        Used for Batch scripts, mpmd scripts, etc"""
+        Used for Batch scripts, mpmd scripts, etc.
+        """
         if script_name:
             script_name = script_name if "." in script_name else script_name + ending
             return osp.join(self.cwd, script_name)

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -29,14 +29,14 @@ from __future__ import annotations
 import os.path as osp
 import time
 import typing as t
-
 from os import makedirs
+
 from smartsim.error.errors import SmartSimError
 
 from ....log import get_logger
 from ...utils.helpers import get_base_36_repr
 from ..colocated import write_colocated_launch_script
-from ....settings.base import SettingsBase, RunSettings
+from ....settings.base import RunSettings, SettingsBase
 
 logger = get_logger(__name__)
 
@@ -48,6 +48,7 @@ class Step:
         self.cwd = cwd
         self.managed = False
         self.step_settings = step_settings
+        self.meta: t.Dict[str, str] = {}
 
     def get_launch_cmd(self) -> t.List[str]:
         raise NotImplementedError

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -27,9 +27,11 @@
 """
 A file of helper functions for SmartSim
 """
+import base64
 import os
 import uuid
 import typing as t
+from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 from shutil import which
@@ -76,13 +78,10 @@ def create_lockfile_name() -> str:
 
 @lru_cache(maxsize=20, typed=False)
 def check_dev_log_level() -> bool:
-    try:
-        lvl = os.environ["SMARTSIM_LOG_LEVEL"]
-        if lvl == "developer":
-            return True
-        return False
-    except KeyError:
-        return False
+    lvl = os.environ.get("SMARTSIM_LOG_LEVEL", "")
+    if lvl == "developer":
+        return True
+    return False
 
 
 def fmt_dict(value: t.Dict[str, t.Any]) -> str:
@@ -277,3 +276,30 @@ def installed_redisai_backends(
     }
 
     return {backend for backend in backends if _installed(base_path, backend)}
+
+
+def get_ts() -> int:
+    """Return the current timestamp (accurate to seconds) cast to an integer"""
+    return int(datetime.timestamp(datetime.now()))
+
+
+def encode_cmd(cmd: t.List[str]) -> str:
+    """Transform a standard command list into an encoded string safe for providing as an
+    argument to a proxy entrypoint"""
+    if not cmd:
+        raise ValueError("Invalid cmd supplied")
+
+    ascii_cmd = "|".join(cmd).encode("ascii")
+    encoded_cmd = base64.b64encode(ascii_cmd).decode("ascii")
+    return encoded_cmd
+
+
+def decode_cmd(encoded_cmd: str) -> t.List[str]:
+    """Decode an encoded command string to the original command list format"""
+    if not encoded_cmd.strip():
+        raise ValueError("Invalid cmd supplied")
+
+    decoded_cmd = base64.b64decode(encoded_cmd.encode("ascii"))
+    cleaned_cmd = decoded_cmd.decode("ascii").split("|")
+
+    return cleaned_cmd

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -285,7 +285,8 @@ def get_ts() -> int:
 
 def encode_cmd(cmd: t.List[str]) -> str:
     """Transform a standard command list into an encoded string safe for providing as an
-    argument to a proxy entrypoint"""
+    argument to a proxy entrypoint
+    """
     if not cmd:
         raise ValueError("Invalid cmd supplied")
 

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -64,9 +64,13 @@ def unpack_colo_db_identifier(db_id: str) -> str:
     return "_" + db_id if db_id else ""
 
 
+def create_short_id_str() -> str:
+    return str(uuid.uuid4())[:7]
+
+
 def create_lockfile_name() -> str:
     """Generate a unique lock filename using UUID"""
-    lock_suffix = str(uuid.uuid4())[:7]
+    lock_suffix = create_short_id_str()
     return f"smartsim-{lock_suffix}.lock"
 
 

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -79,9 +79,7 @@ def create_lockfile_name() -> str:
 @lru_cache(maxsize=20, typed=False)
 def check_dev_log_level() -> bool:
     lvl = os.environ.get("SMARTSIM_LOG_LEVEL", "")
-    if lvl == "developer":
-        return True
-    return False
+    return lvl == "developer":
 
 
 def fmt_dict(value: t.Dict[str, t.Any]) -> str:

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -79,7 +79,7 @@ def create_lockfile_name() -> str:
 @lru_cache(maxsize=20, typed=False)
 def check_dev_log_level() -> bool:
     lvl = os.environ.get("SMARTSIM_LOG_LEVEL", "")
-    return lvl == "developer":
+    return lvl == "developer"
 
 
 def fmt_dict(value: t.Dict[str, t.Any]) -> str:

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -1,0 +1,237 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import annotations
+
+import json
+import time
+import typing as t
+from pathlib import Path
+
+import smartsim._core._cli.utils as _utils
+import smartsim._core.utils.helpers as _helpers
+
+if t.TYPE_CHECKING:
+    from smartsim import Experiment
+    from smartsim._core.control.manifest import LaunchedManifest as _Manifest
+    from smartsim.database.orchestrator import Orchestrator
+    from smartsim.entity import DBNode, Ensemble, Model
+    from smartsim.entity.dbobject import DBModel, DBScript
+    from smartsim.settings.base import BatchSettings, RunSettings
+
+
+TStepLaunchMetaData = t.Tuple[
+    t.Optional[str], t.Optional[str], t.Optional[bool], str, str
+]
+
+
+def save_launch_manifest(manifest: _Manifest[TStepLaunchMetaData]) -> None:
+    manifest_dir = Path(manifest.metadata.exp_path) / ".smartsim/telemetry"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_file = manifest_dir / "manifest.json"
+
+    run_id = _helpers.create_short_id_str()
+    telemetry_data_root = manifest_dir / f"{manifest.metadata.exp_name}/{run_id}"
+
+    new_run = {
+        "run_id": run_id,
+        "timestamp": int(time.time_ns()),
+        "model": [
+            _dictify_model(
+                model,
+                *telemetry_metadata,
+                telemetry_data_root / "model",
+            )
+            for model, telemetry_metadata in manifest.models
+        ],
+        "orchestrator": [
+            _dictify_db(db, nodes_info, telemetry_data_root / "database")
+            for db, nodes_info in manifest.databases
+        ],
+        "ensemble": [
+            _dictify_ensemble(ens, member_info, telemetry_data_root / "ensemble")
+            for ens, member_info in manifest.ensembles
+        ],
+    }
+    try:
+        with open(manifest_file, "r", encoding="utf-8") as file:
+            manifest_dict = json.load(file)
+    except (FileNotFoundError, json.JSONDecodeError):
+        manifest_dict = {
+            "schema info": {
+                "schema_name": "entity manifest",
+                "version": "0.0.1",
+            },
+            "experiment": {
+                "name": manifest.metadata.exp_name,
+                "path": manifest.metadata.exp_path,
+                "launcher": manifest.metadata.launcher_name,
+            },
+            "runs": [new_run],
+        }
+    else:
+        manifest_dict["runs"].append(new_run)
+    finally:
+        with open(manifest_file, "w", encoding="utf-8") as file:
+            json.dump(manifest_dict, file, indent=2)
+
+
+def _dictify_model(
+    model: Model,
+    step_id: t.Optional[str],
+    task_id: t.Optional[str],
+    managed: t.Optional[bool],
+    out_file: str,
+    err_file: str,
+    telemetry_data_path: Path,
+) -> t.Dict[str, t.Any]:
+    colo_settings = (model.run_settings.colocated_db_settings or {}).copy()
+    db_scripts = t.cast("t.List[DBScript]", colo_settings.pop("db_scripts", []))
+    db_models = t.cast("t.List[DBModel]", colo_settings.pop("db_models", []))
+    return {
+        "name": model.name,
+        "path": model.path,
+        "exe_args": model.run_settings.exe_args,
+        "run_settings": _dictify_run_settings(model.run_settings),
+        "batch_settings": _dictify_batch_settings(model.batch_settings)
+        if model.batch_settings
+        else {},
+        "params": model.params,
+        "files": {
+            "Symlink": model.files.link,
+            "Configure": model.files.tagged,
+            "Copy": model.files.copy,
+        }
+        if model.files
+        else {
+            "Symlink": [],
+            "Configure": [],
+            "Copy": [],
+        },
+        "colocated_db": {
+            "settings": colo_settings,
+            "scripts": [
+                {
+                    script.name: {
+                        "backend": "TORCH",
+                        "device": script.device,
+                    }
+                }
+                for script in db_scripts
+            ],
+            "models": [
+                {
+                    model.name: {
+                        "backend": model.backend,
+                        "device": model.device,
+                    }
+                }
+                for model in db_models
+            ],
+        }
+        if colo_settings
+        else {},
+        "telemetry_metadata": {
+            "status_dir": str(telemetry_data_path / model.name),
+            "step_id": step_id,
+            "task_id": task_id,
+            "managed": managed,
+        },
+        "out_file": out_file,
+        "err_file": err_file,
+    }
+
+
+def _dictify_ensemble(
+    ens: Ensemble,
+    members: t.Sequence[t.Tuple[Model, TStepLaunchMetaData]],
+    telemetry_data_path: Path,
+) -> t.Dict[str, t.Any]:
+    return {
+        "name": ens.name,
+        "params": ens.params,
+        "batch_settings": _dictify_batch_settings(ens.batch_settings)
+        # FIXME: Typehint here is wrong, ``ens.batch_settings`` can
+        # also be an empty dict for no discernible reason...
+        if ens.batch_settings else {},
+        "models": [
+            _dictify_model(model, *launching_metadata, telemetry_data_path / ens.name)
+            for model, launching_metadata in members
+        ],
+    }
+
+
+def _dictify_run_settings(run_settings: RunSettings) -> t.Dict[str, t.Any]:
+    return {
+        "exe": run_settings.exe,
+        # TODO: We should try to move this back
+        # "exe_args": run_settings.exe_args,
+        "run_command": run_settings.run_command,
+        "run_args": run_settings.run_args,
+        # TODO: We currently do not have a way to represent MPMD commands!
+        #       Maybe add a ``"mpmd"`` key here that is a
+        #       ``list[TDictifiedRunSettings]``?
+    }
+
+
+def _dictify_batch_settings(batch_settings: BatchSettings) -> t.Dict[str, t.Any]:
+    return {
+        "batch_command": batch_settings.batch_cmd,
+        "batch_args": batch_settings.batch_args,
+    }
+
+
+def _dictify_db(
+    db: Orchestrator,
+    nodes: t.Sequence[t.Tuple[DBNode, TStepLaunchMetaData]],
+    telemetry_data_path: Path,
+) -> t.Dict[str, t.Any]:
+    db_path = _utils.get_db_path()
+    if db_path:
+        db_type, _ = db_path.name.split("-", 1)
+    else:
+        db_type = "Unknown"
+    return {
+        "name": db.name,
+        "type": db_type,
+        "interface": db._interfaces,  # pylint: disable=protected-access
+        "shards": [
+            {
+                **shard.to_dict(),
+                "conf_file": shard.cluster_conf_file,
+                "out_file": out_file,
+                "err_file": err_file,
+                "telemetry_metadata": {
+                    "status_dir": str(telemetry_data_path / f"{db.name}/{dbnode.name}"),
+                    "step_id": step_id,
+                    "task_id": task_id,
+                    "managed": managed,
+                },
+            }
+            for dbnode, (step_id, task_id, managed, out_file, err_file) in nodes
+            for shard in dbnode.get_launched_shard_info()
+        ],
+    }

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -32,6 +32,7 @@ import typing as t
 from pathlib import Path
 
 import smartsim._core._cli.utils as _utils
+from smartsim._core.config import CONFIG
 
 if t.TYPE_CHECKING:
     from smartsim import Experiment
@@ -50,6 +51,9 @@ MANIFEST_FILENAME: t.Final[str] = "manifest.json"
 
 
 def save_launch_manifest(manifest: _Manifest[TStepLaunchMetaData]) -> None:
+    if not CONFIG.telemetry_enabled:
+        return
+
     manifest.metadata.run_telemetry_subdirectory.mkdir(parents=True, exist_ok=True)
 
     new_run = {

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -31,6 +31,7 @@ import time
 import typing as t
 from pathlib import Path
 
+import smartsim.log
 import smartsim._core._cli.utils as _utils
 from smartsim._core.config import CONFIG
 
@@ -48,6 +49,8 @@ TStepLaunchMetaData = t.Tuple[
 ]
 TELMON_SUBDIR: t.Final[str] = ".smartsim/telemetry"
 MANIFEST_FILENAME: t.Final[str] = "manifest.json"
+
+_LOGGER = smartsim.log.get_logger(__name__)
 
 
 def save_launch_manifest(manifest: _Manifest[TStepLaunchMetaData]) -> None:
@@ -179,6 +182,12 @@ def _dictify_ensemble(
 
 
 def _dictify_run_settings(run_settings: RunSettings) -> t.Dict[str, t.Any]:
+    # TODO: remove this downcast
+    if hasattr(run_settings, "mpmd") and run_settings.mpmd:
+        _LOGGER.warning(
+            "SmartSim currently cannot properly serialize all information in "
+            "MPMD run settings"
+        )
     return {
         "exe": run_settings.exe,
         # TODO: We should try to move this back

--- a/smartsim/entity/dbnode.py
+++ b/smartsim/entity/dbnode.py
@@ -76,10 +76,11 @@ class DBNode(SmartSimEntity):
 
     @property
     def num_shards(self) -> int:
-        try:
-            return len(self.run_settings.mpmd) + 1  # type: ignore[attr-defined]
-        except AttributeError:
+        if not hasattr(self.run_settings, "mpmd"):
+            # return default number of shards if mpmd is not set
             return 1
+
+        return len(self.run_settings.mpmd) + 1
 
     @property
     def host(self) -> str:
@@ -99,10 +100,11 @@ class DBNode(SmartSimEntity):
 
     @property
     def is_mpmd(self) -> bool:
-        try:
-            return bool(self.run_settings.mpmd)  # type: ignore[attr-defined]
-        except AttributeError:
+        if not hasattr(self.run_settings, "mpmd"):
+            # missing mpmd property guarantees this is not an mpmd run
             return False
+
+        return bool(self.run_settings.mpmd)
 
     def set_hosts(self, hosts: t.List[str]) -> None:
         self._hosts = [str(host) for host in hosts]

--- a/smartsim/error/errors.py
+++ b/smartsim/error/errors.py
@@ -130,3 +130,14 @@ class ShellError(LauncherError):
         if details:
             msg += f"\nError from shell: {details}"
         return msg
+
+
+class TelemetryError(SSInternalError):
+    """Raised when SmartSim runs into trouble establishing or communicating
+    telemetry information
+    """
+
+class UnproxyableStepError(TelemetryError):
+    """Raised when a user attempts to proxy a managed ``Step`` through the
+    unmanaged step proxy entry point
+    """

--- a/smartsim/error/errors.py
+++ b/smartsim/error/errors.py
@@ -141,3 +141,6 @@ class UnproxyableStepError(TelemetryError):
     """Raised when a user attempts to proxy a managed ``Step`` through the
     unmanaged step proxy entry point
     """
+
+class SmartSimCLIActionCancelled(SmartSimError):
+    """Raised when a `smart` CLI command is terminated"""

--- a/smartsim/error/errors.py
+++ b/smartsim/error/errors.py
@@ -39,12 +39,14 @@ class SSUnsupportedError(Exception):
 
 class EntityExistsError(SmartSimError):
     """Raised when a user tries to create an entity or files/directories for
-    an entity and either the entity/files/directories already exist"""
+    an entity and either the entity/files/directories already exist
+    """
 
 
 class UserStrategyError(SmartSimError):
     """Raised when there is an error with model creation inside an ensemble
-    that is from a user provided permutation strategy"""
+    that is from a user provided permutation strategy
+    """
 
     def __init__(self, perm_strat: str) -> None:
         message = self.create_message(perm_strat)
@@ -80,16 +82,15 @@ class SSReservedKeywordError(SmartSimError):
 
 class SSDBIDConflictError(SmartSimError):
     """Raised in the event that a database identifier
-    is not unique when multiple databases are created"""
+    is not unique when multiple databases are created
+    """
 
 
 # Internal Exceptions
 
 
 class SSInternalError(Exception):
-    """
-    SSInternalError is raised when an internal error is encountered.
-    """
+    """SSInternalError is raised when an internal error is encountered"""
 
 
 class SSConfigError(SSInternalError):
@@ -106,7 +107,8 @@ class AllocationError(LauncherError):
 
 class ShellError(LauncherError):
     """Raised when error arises from function within launcher.shell
-    Closely related to error from subprocess(Popen) commands"""
+    Closely related to error from subprocess(Popen) commands
+    """
 
     def __init__(
         self,

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -882,7 +882,7 @@ class Experiment:
         # Otherwise, add
         self.db_identifiers.add(db_identifier)
 
-    def enable_telemetry(cls) -> None:
+    def enable_telemetry(self) -> None:
         """Experiments will start producing telemetry for all entities run
         through ``Experiment.start``
 
@@ -892,9 +892,9 @@ class Experiment:
             instances will begin producing telemetry data. In the future it
             planned to have this method work on a "per instance" basis!
         """
-        cls._set_telemetry(True)
+        self._set_telemetry(True)
 
-    def disable_telemetry(cls) -> None:
+    def disable_telemetry(self) -> None:
         """Experiments will stop producing telemetry for all entities run
         through ``Experiment.start``
 
@@ -904,7 +904,7 @@ class Experiment:
             instances will stop producing telemetry data. In the future it
             planned to have this method work on a "per instance" basis!
         """
-        cls._set_telemetry(False)
+        self._set_telemetry(False)
 
     @staticmethod
     def _set_telemetry(switch: bool, /) -> None:

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -194,6 +194,8 @@ class Experiment:
             if summary:
                 self._launch_summary(start_manifest)
             self._control.start(
+                exp_name=self.name,
+                exp_path=self.exp_path,
                 manifest=start_manifest,
                 block=block,
                 kill_on_interrupt=kill_on_interrupt,

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -24,6 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
 import os.path as osp
 import typing as t
 from os import getcwd
@@ -880,3 +881,35 @@ class Experiment:
             )
         # Otherwise, add
         self.db_identifiers.add(db_identifier)
+
+    def enable_telemetry(cls) -> None:
+        """Experiments will start producing telemetry for all entities run
+        through ``Experiment.start``
+
+        .. warning::
+
+            This method is currently implemented so that ALL ``Experiment``
+            instances will begin producing telemetry data. In the future it
+            planned to have this method work on a "per instance" basis!
+        """
+        cls._set_telemetry(True)
+
+    def disable_telemetry(cls) -> None:
+        """Experiments will stop producing telemetry for all entities run
+        through ``Experiment.start``
+
+        .. warning::
+
+            This method is currently implemented so that ALL ``Experiment``
+            instances will stop producing telemetry data. In the future it
+            planned to have this method work on a "per instance" basis!
+        """
+        cls._set_telemetry(False)
+
+    @staticmethod
+    def _set_telemetry(switch: bool, /) -> None:
+        tm_key = "SMARTSIM_FLAG_TELEMETRY"
+        if switch:
+            os.environ[tm_key] = "1"
+        else:
+            os.environ[tm_key] = "0"

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -890,7 +890,7 @@ class Experiment:
 
             This method is currently implemented so that ALL ``Experiment``
             instances will begin producing telemetry data. In the future it
-            planned to have this method work on a "per instance" basis!
+            is planned to have this method work on a "per instance" basis!
         """
         self._set_telemetry(True)
 
@@ -902,7 +902,7 @@ class Experiment:
 
             This method is currently implemented so that ALL ``Experiment``
             instances will stop producing telemetry data. In the future it
-            planned to have this method work on a "per instance" basis!
+            is planned to have this method work on a "per instance" basis!
         """
         self._set_telemetry(False)
 

--- a/smartsim/log.py
+++ b/smartsim/log.py
@@ -30,11 +30,15 @@ import sys
 
 import coloredlogs
 
-# constants for logging
-coloredlogs.DEFAULT_DATE_FORMAT = "%H:%M:%S"
-coloredlogs.DEFAULT_LOG_FORMAT = (
+# constants
+DEFAULT_DATE_FORMAT: t.Final[str] = "%H:%M:%S"
+DEFAULT_LOG_FORMAT: t.Final[str] = (
     "%(asctime)s %(hostname)s %(name)s[%(process)d] %(levelname)s %(message)s"
 )
+
+# configure colored loggs
+coloredlogs.DEFAULT_DATE_FORMAT = DEFAULT_DATE_FORMAT
+coloredlogs.DEFAULT_LOG_FORMAT = DEFAULT_LOG_FORMAT
 
 
 def _get_log_level() -> str:

--- a/smartsim/wlm/slurm.py
+++ b/smartsim/wlm/slurm.py
@@ -237,7 +237,8 @@ def _get_alloc_cmd(
     options: t.Optional[t.Dict[str, str]] = None,
 ) -> t.List[str]:
     """Return the command to request an allocation from Slurm with
-    the class variables as the slurm options."""
+    the class variables as the slurm options.
+    """
 
     salloc_args = [
         "--no-shell",

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -398,7 +398,7 @@ def test_colocated_db_model_tf(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
 
     # Create SmartSim Experience
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -469,7 +469,7 @@ def test_colocated_db_model_pytorch(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_pt_dbmodel_smartredis.py")
 
     # Create the SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -633,7 +633,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
 
     # Create the SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -735,7 +735,7 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
     test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create colocated RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -817,6 +817,7 @@ def test_colocated_db_model_errors(fileutils, wlmutils, mlutils):
 
     with pytest.raises(SSUnsupportedError):
         colo_ensemble.add_model(colo_model)
+
 
 @pytest.mark.skipif(not should_run_tf, reason="Test needs TensorFlow to run")
 def test_inconsistent_params_db_model():

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -245,7 +245,7 @@ def test_colocated_db_script(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create the SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -313,7 +313,7 @@ def test_colocated_db_script_ensemble(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -412,7 +412,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
@@ -509,7 +509,7 @@ def test_db_script_errors(fileutils, wlmutils, mlutils):
     torch_script = fileutils.get_test_conf_path("torchscript.py")
 
     # Create SmartSim experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create RunSettings
     colo_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)

--- a/tests/full_wlm/test_generic_batch_launch.py
+++ b/tests/full_wlm/test_generic_batch_launch.py
@@ -39,8 +39,10 @@ def test_batch_model(fileutils, wlmutils):
     """Test the launch of a manually construced batch model"""
 
     exp_name = "test-batch-model"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     batch_settings = exp.create_batch_settings(nodes=1, time="00:01:00")
@@ -64,8 +66,10 @@ def test_batch_ensemble(fileutils, wlmutils):
     """Test the launch of a manually constructed batch ensemble"""
 
     exp_name = "test-batch-ensemble"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = wlmutils.get_run_settings("python", f"{script} --time=5")
@@ -89,8 +93,10 @@ def test_batch_ensemble(fileutils, wlmutils):
 
 def test_batch_ensemble_replicas(fileutils, wlmutils):
     exp_name = "test-batch-ensemble-replicas"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = wlmutils.get_run_settings("python", f"{script} --time=5")

--- a/tests/full_wlm/test_generic_orc_launch_batch.py
+++ b/tests/full_wlm/test_generic_orc_launch_batch.py
@@ -41,8 +41,8 @@ def test_launch_orc_auto_batch(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-orc-batch"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -77,8 +77,8 @@ def test_launch_cluster_orc_batch_single(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-cluster-orc-batch-single"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -116,8 +116,8 @@ def test_launch_cluster_orc_batch_multi(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-cluster-orc-batch-multi"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -153,8 +153,8 @@ def test_launch_cluster_orc_reconnect(fileutils, wlmutils):
     """test reconnecting to clustered 3-node orchestrator"""
     launcher = wlmutils.get_test_launcher()
     exp_name = "test-launch-cluster-orc-batch-reconect"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()

--- a/tests/full_wlm/test_mpmd.py
+++ b/tests/full_wlm/test_mpmd.py
@@ -61,7 +61,8 @@ def test_mpmd(fileutils, wlmutils):
         "cobalt": ["mpirun"],
     }
 
-    exp = Experiment(exp_name, launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     def prune_commands(launcher):
         available_commands = []
@@ -77,7 +78,6 @@ def test_mpmd(fileutils, wlmutils):
             f"MPMD on {launcher} only supported for run commands {by_launcher[launcher]}"
         )
 
-    test_dir = fileutils.make_test_dir()
     for run_command in run_commands:
         script = fileutils.get_test_conf_path("sleep.py")
         settings = exp.create_run_settings(

--- a/tests/on_wlm/test_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_base_settings_on_wlm.py
@@ -42,8 +42,10 @@ if pytest.test_launcher not in pytest.wlm_options:
 
 def test_model_on_wlm(fileutils, wlmutils):
     exp_name = "test-base-settings-model-launch"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings1 = wlmutils.get_base_run_settings("python", f"{script} --time=5")
@@ -60,8 +62,10 @@ def test_model_on_wlm(fileutils, wlmutils):
 
 def test_model_stop_on_wlm(fileutils, wlmutils):
     exp_name = "test-base-settings-model-stop"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings1 = wlmutils.get_base_run_settings("python", f"{script} --time=5")

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -47,7 +47,8 @@ def test_launch_colocated_model_defaults(fileutils, coloutils, db_type):
 
     db_args = { }
 
-    exp = Experiment("colocated_model_defaults", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher=launcher, exp_path=test_dir)
     colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
@@ -69,7 +70,12 @@ def test_launch_colocated_model_defaults(fileutils, coloutils, db_type):
 @pytest.mark.parametrize("db_type", supported_dbs)
 def test_colocated_model_disable_pinning(fileutils, coloutils, db_type):
 
-    exp = Experiment("colocated_model_pinning_auto_1cpu", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_auto_1cpu",
+        launcher=launcher,
+        exp_path=test_dir
+    )
     db_args = {
         "db_cpus": 1,
         "custom_pinning": [],
@@ -91,7 +97,12 @@ def test_colocated_model_disable_pinning(fileutils, coloutils, db_type):
 @pytest.mark.parametrize("db_type", supported_dbs)
 def test_colocated_model_pinning_auto_2cpu(fileutils, coloutils, db_type):
 
-    exp = Experiment("colocated_model_pinning_auto_2cpu", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_auto_2cpu",
+        launcher=launcher,
+        exp_path=test_dir,
+    )
 
     db_args = {
         "db_cpus": 2,
@@ -115,7 +126,12 @@ def test_colocated_model_pinning_range(fileutils, coloutils, db_type):
     # Check to make sure that the CPU mask was correctly generated
     # Assume that there are at least 4 cpus on the node
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual",
+        launcher=launcher,
+        exp_path=test_dir,
+    )
 
     db_args = {
         "db_cpus": 4,
@@ -139,7 +155,12 @@ def test_colocated_model_pinning_list(fileutils, coloutils, db_type):
     # Check to make sure that the CPU mask was correctly generated
     # note we presume that this has more than 2 CPUs on the supercomputer node
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual",
+        launcher=launcher,
+        exp_path=test_dir,
+    )
 
     db_args = {
         "db_cpus": 2,
@@ -163,7 +184,12 @@ def test_colocated_model_pinning_mixed(fileutils, coloutils, db_type):
     # Check to make sure that the CPU mask was correctly generated
     # note we presume that this at least 4 CPUs on the supercomputer node
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual",
+        launcher=launcher,
+        exp_path=test_dir,
+    )
 
     db_args = {
         "db_cpus": 2,

--- a/tests/on_wlm/test_generic_orc_launch.py
+++ b/tests/on_wlm/test_generic_orc_launch.py
@@ -38,8 +38,8 @@ def test_launch_orc_auto(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-orc"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -71,8 +71,8 @@ def test_launch_cluster_orc_single(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-cluster-orc-single"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -105,8 +105,8 @@ def test_launch_cluster_orc_multi(fileutils, wlmutils):
     launcher = wlmutils.get_test_launcher()
 
     exp_name = "test-launch-auto-cluster-orc-multi"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()

--- a/tests/on_wlm/test_launch_errors.py
+++ b/tests/on_wlm/test_launch_errors.py
@@ -40,8 +40,10 @@ def test_failed_status(fileutils, wlmutils):
     """Test when a failure occurs deep into model execution"""
 
     exp_name = "test-report-failure"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name,
+            launcher=wlmutils.get_test_launcher(),
+            exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("bad.py")
     settings = exp.create_run_settings(
@@ -69,8 +71,8 @@ def test_bad_run_command_args(fileutils, wlmutils):
         pytest.skip(f"Only fails with slurm. Launcher is {launcher}")
 
     exp_name = "test-bad-run-command-args"
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("bad.py")
 

--- a/tests/on_wlm/test_restart.py
+++ b/tests/on_wlm/test_restart.py
@@ -38,8 +38,10 @@ if pytest.test_launcher not in pytest.wlm_options:
 def test_restart(fileutils, wlmutils):
 
     exp_name = "test-restart"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name,
+            launcher=wlmutils.get_test_launcher(),
+            exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=5")

--- a/tests/on_wlm/test_simple_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_simple_base_settings_on_wlm.py
@@ -56,8 +56,10 @@ def test_simple_model_on_wlm(fileutils, wlmutils):
         )
 
     exp_name = "test-simplebase-settings-model-launch"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = RunSettings("python", exe_args=f"{script} --time=5")
@@ -77,8 +79,10 @@ def test_simple_model_stop_on_wlm(fileutils, wlmutils):
         )
 
     exp_name = "test-simplebase-settings-model-stop"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = RunSettings("python", exe_args=f"{script} --time=5")

--- a/tests/on_wlm/test_simple_entity_launch.py
+++ b/tests/on_wlm/test_simple_entity_launch.py
@@ -48,8 +48,10 @@ if pytest.test_launcher not in pytest.wlm_options:
 
 def test_models(fileutils, wlmutils):
     exp_name = "test-models-launch"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=5")
@@ -65,8 +67,10 @@ def test_models(fileutils, wlmutils):
 
 def test_ensemble(fileutils, wlmutils):
     exp_name = "test-ensemble-launch"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=5")
@@ -84,8 +88,10 @@ def test_summary(fileutils, wlmutils):
     """Fairly rudimentary test of the summary dataframe"""
 
     exp_name = "test-launch-summary"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     sleep = fileutils.get_test_conf_path("sleep.py")
     bad = fileutils.get_test_conf_path("bad.py")

--- a/tests/on_wlm/test_stop.py
+++ b/tests/on_wlm/test_stop.py
@@ -44,8 +44,10 @@ if pytest.test_launcher not in pytest.wlm_options:
 
 def test_stop_entity(fileutils, wlmutils):
     exp_name = "test-launch-stop-model"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=10")
@@ -62,8 +64,10 @@ def test_stop_entity(fileutils, wlmutils):
 def test_stop_entity_list(fileutils, wlmutils):
 
     exp_name = "test-launch-stop-ensemble"
-    exp = Experiment(exp_name, launcher=wlmutils.get_test_launcher())
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        exp_name, launcher=wlmutils.get_test_launcher(), exp_path=test_dir
+    )
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=10")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -368,7 +368,7 @@ def test_cli_plugin_invalid(capsys: pytest.CaptureFixture, monkeypatch: pytest.M
         lambda: MenuItemConfig(
             "dashboard",
             "Start the SmartSim dashboard",
-            plugin.dynamic_execute(plugin_module),
+            plugin.dynamic_execute(plugin_module, "Dashboard!"),
             is_plugin=True,
         )
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -346,20 +346,17 @@ def test_cli_default_cli(capsys):
 
 
 @pytest.mark.skipif(not test_dash_plugin, reason="plugin not found")
-def test_cli_plugin_dashboard(capsys):
+def test_cli_plugin_dashboard(capfd):
     """Ensure expected dashboard CLI plugin commands are supported"""
-    # FIXME: This test is failing!!
-
     smart_cli = cli.default_cli()
-    
-    captured = capsys.readouterr()  # throw away existing output
+    capfd.readouterr()  # throw away existing output
 
     # execute with `dashboard` argument, expect dashboard-specific help text
     build_args = ["smart", "dashboard", "-h"]
     rc = smart_cli.execute(build_args)
 
-    captured = capsys.readouterr() # capture new output
-    
+    captured = capfd.readouterr()  # capture new output
+
     assert "[-d DIRECTORY]" in captured.out
     assert "[-p PORT]" in captured.out
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,7 @@
 import argparse
 from contextlib import contextmanager
 import logging
+import os
 import pathlib
 import typing as t
 
@@ -278,7 +279,7 @@ def test_cli_default_cli(capsys):
     # show that `smart dbcli` calls the build parser and build execute function
     assert "usage: smart [-h] <command>" in captured.out
     assert "Available commands" in captured.out
-    assert ret_val == 2
+    assert ret_val == os.EX_USAGE
 
     # execute with `build` argument, expect build-specific help text
     with pytest.raises(SystemExit) as e:
@@ -290,7 +291,7 @@ def test_cli_default_cli(capsys):
     assert "usage: smart build [-h]" in captured.out
     assert "Build SmartSim dependencies" in captured.out
     assert "optional arguments:" in captured.out or "options:" in captured.out
-    assert ret_val == 2
+    assert ret_val == os.EX_USAGE
 
     # execute with `clean` argument, expect clean-specific help text
     with pytest.raises(SystemExit) as e:
@@ -303,7 +304,7 @@ def test_cli_default_cli(capsys):
     assert "Remove previous ML runtime installation" in captured.out
     assert "optional arguments:" in captured.out or "options:" in captured.out
     assert "--clobber" in captured.out
-    assert ret_val == 2
+    assert ret_val == os.EX_USAGE
 
     # execute with `dbcli` argument, expect dbcli-specific help text
     with pytest.raises(SystemExit) as e:
@@ -315,7 +316,7 @@ def test_cli_default_cli(capsys):
     assert "usage: smart dbcli [-h]" in captured.out
     assert "Print the path to the redis-cli binary" in captured.out
     assert "optional arguments:" in captured.out or "options:" in captured.out
-    assert ret_val == 2
+    assert ret_val == os.EX_USAGE
 
     # execute with `site` argument, expect site-specific help text
     with pytest.raises(SystemExit) as e:
@@ -327,7 +328,7 @@ def test_cli_default_cli(capsys):
     assert "usage: smart site [-h]" in captured.out
     assert "Print the installation site of SmartSim" in captured.out
     assert "optional arguments:" in captured.out or "options:" in captured.out
-    assert ret_val == 2
+    assert ret_val == os.EX_USAGE
 
     # execute with `clobber` argument, expect clobber-specific help text
     with pytest.raises(SystemExit) as e:
@@ -340,7 +341,7 @@ def test_cli_default_cli(capsys):
     assert "Remove all previous dependency installations" in captured.out
     assert "optional arguments:" in captured.out or "options:" in captured.out
     # assert "--clobber" not in captured.out
-    assert ret_val == 2
+    assert ret_val == os.EX_USAGE
 
 
 @pytest.mark.skipif(not test_dash_plugin, reason="plugin not found")
@@ -391,7 +392,7 @@ def test_cli_plugin_invalid(capsys: pytest.CaptureFixture, monkeypatch: pytest.M
 
         assert plugin_module in captured.out
         assert "not found" in captured.out
-        assert rc == 1
+        assert rc == os.EX_CONFIG
 
 @pytest.mark.parametrize(
     "command,mock_location,exp_output",
@@ -763,11 +764,11 @@ def _mock_temp_dir(*a, **kw):
 @pytest.mark.parametrize(
     "mock_verify_fn, expected_stdout, expected_retval",
     [
-        pytest.param(_good_build, 'LGTM', 0, id="Configured Correctly"),
+        pytest.param(_good_build, 'LGTM', os.EX_OK, id="Configured Correctly"),
         pytest.param(
             _bad_build,
             "SmartSim failed to run a simple experiment", 
-            2, 
+            os.EX_SOFTWARE,
             id="Configured Incorrectly",
         )
     ],

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -45,7 +45,8 @@ def test_macosx_warning(fileutils, coloutils):
     db_args = {"custom_pinning": [1]}
     db_type = "uds"  # Test is insensitive to choice of db
 
-    exp = Experiment("colocated_model_defaults", launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher="local", exp_path=test_dir)
     with pytest.warns(
         RuntimeWarning,
         match="CPU pinning is not supported on MacOSX. Ignoring pinning specification.",
@@ -63,7 +64,8 @@ def test_unsupported_limit_app(fileutils, coloutils):
     db_args = {"limit_app_cpus": True}
     db_type = "uds"  # Test is insensitive to choice of db
 
-    exp = Experiment("colocated_model_defaults", launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher="local", exp_path=test_dir)
     with pytest.raises(SSUnsupportedError):
         coloutils.setup_test_colo(
             fileutils,
@@ -80,7 +82,8 @@ def test_unsupported_custom_pinning(fileutils, coloutils, custom_pinning):
     db_type = "uds"  # Test is insensitive to choice of db
     db_args = {"custom_pinning": custom_pinning}
 
-    exp = Experiment("colocated_model_defaults", launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher="local", exp_path=test_dir)
     with pytest.raises(TypeError):
         coloutils.setup_test_colo(
             fileutils,
@@ -116,7 +119,8 @@ def test_launch_colocated_model_defaults(
 
     db_args = {}
 
-    exp = Experiment("colocated_model_defaults", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("colocated_model_defaults", launcher=launcher, exp_path=test_dir)
     colo_model = coloutils.setup_test_colo(
         fileutils,
         db_type,
@@ -146,12 +150,12 @@ def test_launch_colocated_model_defaults(
 def test_launch_multiple_colocated_models(
     fileutils, coloutils, wlmutils, db_type, launcher="local"
 ):
-    """Test the concurrent launch of two models with a colocated database and local launcher
-    """
+    """Test the concurrent launch of two models with a colocated database and local launcher"""
 
     db_args = {}
 
-    exp = Experiment("multi_colo_models", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment("multi_colo_models", launcher=launcher, exp_path=test_dir)
     colo_models = [
         coloutils.setup_test_colo(
             fileutils,
@@ -187,7 +191,10 @@ def test_launch_multiple_colocated_models(
 def test_colocated_model_disable_pinning(
     fileutils, coloutils, db_type, launcher="local"
 ):
-    exp = Experiment("colocated_model_pinning_auto_1cpu", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_auto_1cpu", launcher=launcher, exp_path=test_dir
+    )
     db_args = {
         "db_cpus": 1,
         "custom_pinning": [],
@@ -210,7 +217,10 @@ def test_colocated_model_disable_pinning(
 def test_colocated_model_pinning_auto_2cpu(
     fileutils, coloutils, db_type, launcher="local"
 ):
-    exp = Experiment("colocated_model_pinning_auto_2cpu", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_auto_2cpu", launcher=launcher, exp_path=test_dir
+    )
 
     db_args = {
         "db_cpus": 2,
@@ -241,7 +251,10 @@ def test_colocated_model_pinning_auto_2cpu(
 def test_colocated_model_pinning_range(fileutils, coloutils, db_type, launcher="local"):
     # Check to make sure that the CPU mask was correctly generated
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual", launcher=launcher, exp_path=test_dir
+    )
 
     db_args = {"db_cpus": 2, "custom_pinning": range(2)}
 
@@ -263,7 +276,10 @@ def test_colocated_model_pinning_range(fileutils, coloutils, db_type, launcher="
 def test_colocated_model_pinning_list(fileutils, coloutils, db_type, launcher="local"):
     # Check to make sure that the CPU mask was correctly generated
 
-    exp = Experiment("colocated_model_pinning_manual", launcher=launcher)
+    test_dir = fileutils.make_test_dir()
+    exp = Experiment(
+        "colocated_model_pinning_manual", launcher=launcher, exp_path=test_dir
+    )
 
     db_args = {"db_cpus": 1, "custom_pinning": [1]}
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,3 +190,21 @@ def test_redis_cli():
     with pytest.raises(SSConfigError):
         config.database_cli
     os.environ.pop("REDIS_CLI_PATH")
+
+
+@pytest.mark.parametrize(
+        "value, exp_result", [
+            pytest.param("0", False, id="letter zero"),
+            pytest.param("1", True, id="letter one"),
+            pytest.param(None, False, id="not in env"),
+        ]
+)
+def test_telemetry_flag(monkeypatch: pytest.MonkeyPatch, 
+                        value: t.Union[int, str],
+                        exp_result: bool):
+    if value is not None:
+        monkeypatch.setenv("SMARTSIM_FLAG_TELEMETRY", value)
+    else:
+        monkeypatch.delenv("SMARTSIM_FLAG_TELEMETRY", raising=False)
+    config = Config()
+    assert config.telemetry_enabled == exp_result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -196,11 +196,12 @@ def test_redis_cli():
         "value, exp_result", [
             pytest.param("0", False, id="letter zero"),
             pytest.param("1", True, id="letter one"),
+            pytest.param("-1", False, id="letter negative one"),
             pytest.param(None, False, id="not in env"),
         ]
 )
 def test_telemetry_flag(monkeypatch: pytest.MonkeyPatch, 
-                        value: t.Union[int, str],
+                        value: t.Optional[str],
                         exp_result: bool):
     if value is not None:
         monkeypatch.setenv("SMARTSIM_FLAG_TELEMETRY", value)
@@ -208,3 +209,38 @@ def test_telemetry_flag(monkeypatch: pytest.MonkeyPatch,
         monkeypatch.delenv("SMARTSIM_FLAG_TELEMETRY", raising=False)
     config = Config()
     assert config.telemetry_enabled == exp_result
+
+@pytest.mark.parametrize(
+    "value, exp_result", [
+        pytest.param("1", 1, id="1"),
+        pytest.param("123", 123, id="123"),
+        pytest.param(None, 5, id="not in env"),
+    ]
+)
+def test_telemetry_frequency(
+    monkeypatch: pytest.MonkeyPatch, value: t.Optional[str], exp_result: int
+):
+    if value is not None:
+        monkeypatch.setenv("SMARTSIM_TELEMETRY_FREQUENCY", value)
+    else:
+        monkeypatch.delenv("SMARTSIM_TELEMETRY_FREQUENCY", raising=False)
+    config = Config()
+    assert config.telemetry_frequency == exp_result
+
+
+@pytest.mark.parametrize(
+    "value, exp_result", [
+        pytest.param("30", 30, id="30"),
+        pytest.param("123", 123, id="123"),
+        pytest.param(None, 90, id="not in env"),
+    ]
+)
+def test_telemetry_cooldown(
+    monkeypatch: pytest.MonkeyPatch, value: t.Optional[str], exp_result: bool
+):
+    if value is not None:
+        monkeypatch.setenv("SMARTSIM_TELEMETRY_COOLDOWN", value)
+    else:
+        monkeypatch.delenv("SMARTSIM_TELEMETRY_COOLDOWN", raising=False)
+    config = Config()
+    assert config.telemetry_cooldown == exp_result

--- a/tests/test_configs/echo.py
+++ b/tests/test_configs/echo.py
@@ -24,45 +24,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import pytest
+import argparse
+import time
 
-import pathlib
 
-from smartsim._core.control.controller import Controller
-from smartsim.settings.slurmSettings import SbatchSettings, SrunSettings
-from smartsim._core.launcher.step import Step
-from smartsim.entity.ensemble import Ensemble
-from smartsim.database.orchestrator import Orchestrator
+def echo(message: str, sleep_time: int):
+    if sleep_time > 0:
+        time.sleep(sleep_time)
+    print(f"Echoing: {message}")
 
-controller = Controller()
+if __name__ == "__main__":
 
-rs = SrunSettings('echo', ['spam', 'eggs'])
-bs = SbatchSettings()
-
-ens = Ensemble("ens", params={}, run_settings=rs, batch_settings=bs, replicas=3)
-orc = Orchestrator(db_nodes=3, batch=True, launcher="slurm", run_command="srun")
-
-class MockStep(Step):
-    @staticmethod
-    def _create_unique_name(name):
-        return name
-
-    def add_to_batch(self, step):
-        ...
-
-    def get_launch_cmd(self):
-        return []
-
-@pytest.mark.parametrize("collection", [
-    pytest.param(ens, id="Ensemble"),
-    pytest.param(orc, id="Database"),
-])
-def test_controller_batch_step_creation_preserves_entity_order(collection, monkeypatch):
-    monkeypatch.setattr(controller._launcher, "create_step",
-                        lambda name, path, settings: MockStep(name, path, settings))
-    entity_names = [x.name for x in collection.entities]
-    assert len(entity_names) == len(set(entity_names))
-    _, steps = controller._create_batch_job_step(collection, pathlib.Path("mock/exp/path"))
-    assert entity_names == [step.name for step in steps]
-
-    
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--message", type=str, default="Lorem ipsum")
+    parser.add_argument("--sleep_time", type=int, default=0)
+    args = parser.parse_args()
+    echo(args.message, args.sleep_time)

--- a/tests/test_configs/printing_model.py
+++ b/tests/test_configs/printing_model.py
@@ -1,0 +1,18 @@
+import time
+import sys
+
+
+def main() -> int:
+    print(";START;")
+    time.sleep(20)
+    print(";MID;")
+    print("This is an error msg", file=sys.stderr)
+    time.sleep(20)
+    print(";END;")
+
+    print("yay!!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_configs/telemetry/colocatedmodel.json
+++ b/tests/test_configs/telemetry/colocatedmodel.json
@@ -5,7 +5,7 @@
   },
   "experiment": {
     "name": "my-exp",
-    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp",
+    "path": "/tmp/my-exp",
     "launcher": "Slurm"
   },
   "runs": [
@@ -15,13 +15,13 @@
       "model": [
         {
           "name": "colocated_model",
-          "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp/colocated_model",
+          "path": "/tmp/my-exp/colocated_model",
           "exe_args": [
-            "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+            "/path/to/my/script.py"
           ],
           "run_settings": {
             "exe": [
-              "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+              "/path/to/my/python"
             ],
             "run_command": "/opt/slurm/20.11.5/bin/srun",
             "run_args": {}
@@ -53,13 +53,13 @@
             "models": []
           },
           "telemetry_metadata": {
-            "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp/.smartsim/telemetry/telemetry_ensemble/002816b/model/colocated_model",
+            "status_dir": "/tmp/my-exp/.smartsim/telemetry/telemetry_ensemble/002816b/model/colocated_model",
             "step_id": "4139111.21",
             "task_id": "21529",
             "managed": true
           },
-          "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp/colocated_model/colocated_model.out",
-          "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp/colocated_model/colocated_model.err"
+          "out_file": "/tmp/my-exp/colocated_model/colocated_model.out",
+          "err_file": "/tmp/my-exp/colocated_model/colocated_model.err"
         }
       ],
       "orchestrator": [],

--- a/tests/test_configs/telemetry/colocatedmodel.json
+++ b/tests/test_configs/telemetry/colocatedmodel.json
@@ -1,0 +1,69 @@
+{
+  "schema info": {
+    "schema_name": "entity manifest",
+    "version": "0.0.1"
+  },
+  "experiment": {
+    "name": "my-exp",
+    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp",
+    "launcher": "Slurm"
+  },
+  "runs": [
+    {
+      "run_id": "002816b",
+      "timestamp": 1699037041106269774,
+      "model": [
+        {
+          "name": "colocated_model",
+          "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp/colocated_model",
+          "exe_args": [
+            "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+          ],
+          "run_settings": {
+            "exe": [
+              "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+            ],
+            "run_command": "/opt/slurm/20.11.5/bin/srun",
+            "run_args": {}
+          },
+          "batch_settings": {},
+          "params": {},
+          "files": {
+            "Symlink": [],
+            "Configure": [],
+            "Copy": []
+          },
+          "colocated_db": {
+            "settings": {
+              "unix_socket": "/tmp/redis.socket",
+              "socket_permissions": 755,
+              "port": 0,
+              "cpus": 1,
+              "custom_pinning": "0",
+              "debug": false,
+              "db_identifier": "",
+              "rai_args": {
+                "threads_per_queue": null,
+                "inter_op_parallelism": null,
+                "intra_op_parallelism": null
+              },
+              "extra_db_args": {}
+            },
+            "scripts": [],
+            "models": []
+          },
+          "telemetry_metadata": {
+            "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp/.smartsim/telemetry/telemetry_ensemble/002816b/model/colocated_model",
+            "step_id": "4139111.21",
+            "task_id": "21529",
+            "managed": true
+          },
+          "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp/colocated_model/colocated_model.out",
+          "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp/colocated_model/colocated_model.err"
+        }
+      ],
+      "orchestrator": [],
+      "ensemble": []
+    }
+  ]
+}

--- a/tests/test_configs/telemetry/db_and_model.json
+++ b/tests/test_configs/telemetry/db_and_model.json
@@ -5,7 +5,7 @@
     },
     "experiment": {
         "name": "my-exp",
-        "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp",
+        "path": "/tmp/my-exp",
         "launcher": "Slurm"
     },
     "runs": [
@@ -27,10 +27,10 @@
                             "port": 6780,
                             "cluster": false,
                             "conf_file": null,
-                            "out_file": "/lus/cls01029/mcbridch/ss/orchestrator_0.out",
-                            "err_file": "/lus/cls01029/mcbridch/ss/orchestrator_0.err",
+                            "out_file": "/path/to/some/file.out",
+                            "err_file": "/path/to/some/file.err",
                             "telemetry_metadata": {
-                                "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/.smartsim/telemetry/telemetry_db_and_model/2ca19ad/database/orchestrator/orchestrator_0",
+                                "status_dir": "/tmp/my-exp/.smartsim/telemetry/telemetry_db_and_model/2ca19ad/database/orchestrator/orchestrator_0",
                                 "step_id": "4139111.27",
                                 "task_id": "1452",
                                 "managed": true
@@ -47,13 +47,13 @@
             "model": [
                 {
                     "name": "perroquet",
-                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet",
+                    "path": "/tmp/my-exp/perroquet",
                     "exe_args": [
-                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                        "/path/to/my/script.py"
                     ],
                     "run_settings": {
                         "exe": [
-                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                            "/path/to/my/python"
                         ],
                         "run_command": "/opt/slurm/20.11.5/bin/srun",
                         "run_args": {
@@ -70,13 +70,13 @@
                     },
                     "colocated_db": {},
                     "telemetry_metadata": {
-                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/.smartsim/telemetry/telemetry_db_and_model/4b5507a/model/perroquet",
+                        "status_dir": "/tmp/my-exp/.smartsim/telemetry/telemetry_db_and_model/4b5507a/model/perroquet",
                         "step_id": "4139111.28",
                         "task_id": "2929",
                         "managed": true
                     },
-                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet/perroquet.out",
-                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet/perroquet.err"
+                    "out_file": "/tmp/my-exp/perroquet/perroquet.out",
+                    "err_file": "/tmp/my-exp/perroquet/perroquet.err"
                 }
             ],
             "orchestrator": [],

--- a/tests/test_configs/telemetry/db_and_model.json
+++ b/tests/test_configs/telemetry/db_and_model.json
@@ -1,0 +1,86 @@
+{
+    "schema info": {
+        "schema_name": "entity manifest",
+        "version": "0.0.1"
+    },
+    "experiment": {
+        "name": "my-exp",
+        "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp",
+        "launcher": "Slurm"
+    },
+    "runs": [
+        {
+            "run_id": "2ca19ad",
+            "timestamp": 1699038647234488933,
+            "model": [],
+            "orchestrator": [
+                {
+                    "name": "orchestrator",
+                    "type": "redis",
+                    "interface": [
+                        "ipogif0"
+                    ],
+                    "shards": [
+                        {
+                            "name": "orchestrator_0",
+                            "hostname": "10.128.0.4",
+                            "port": 6780,
+                            "cluster": false,
+                            "conf_file": null,
+                            "out_file": "/lus/cls01029/mcbridch/ss/orchestrator_0.out",
+                            "err_file": "/lus/cls01029/mcbridch/ss/orchestrator_0.err",
+                            "telemetry_metadata": {
+                                "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/.smartsim/telemetry/telemetry_db_and_model/2ca19ad/database/orchestrator/orchestrator_0",
+                                "step_id": "4139111.27",
+                                "task_id": "1452",
+                                "managed": true
+                            }
+                        }
+                    ]
+                }
+            ],
+            "ensemble": []
+        },
+        {
+            "run_id": "4b5507a",
+            "timestamp": 1699038661491043211,
+            "model": [
+                {
+                    "name": "perroquet",
+                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet",
+                    "exe_args": [
+                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                    ],
+                    "run_settings": {
+                        "exe": [
+                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                        ],
+                        "run_command": "/opt/slurm/20.11.5/bin/srun",
+                        "run_args": {
+                            "nodes": 1,
+                            "ntasks-per-node": 1
+                        }
+                    },
+                    "batch_settings": {},
+                    "params": {},
+                    "files": {
+                        "Symlink": [],
+                        "Configure": [],
+                        "Copy": []
+                    },
+                    "colocated_db": {},
+                    "telemetry_metadata": {
+                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/.smartsim/telemetry/telemetry_db_and_model/4b5507a/model/perroquet",
+                        "step_id": "4139111.28",
+                        "task_id": "2929",
+                        "managed": true
+                    },
+                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet/perroquet.out",
+                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet/perroquet.err"
+                }
+            ],
+            "orchestrator": [],
+            "ensemble": []
+        }
+    ]
+}

--- a/tests/test_configs/telemetry/db_and_model_1run.json
+++ b/tests/test_configs/telemetry/db_and_model_1run.json
@@ -1,0 +1,79 @@
+{
+  "schema info": {
+    "schema_name": "entity manifest",
+    "version": "0.0.1"
+  },
+  "experiment": {
+    "name": "my-exp",
+    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp",
+    "launcher": "Slurm"
+  },
+  "runs": [
+    {
+      "run_id": "4b5507a",
+      "timestamp": 1699038661491043211,
+      "model": [
+        {
+          "name": "perroquet",
+          "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet",
+          "exe_args": [
+            "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+          ],
+          "run_settings": {
+            "exe": [
+              "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+            ],
+            "run_command": "/opt/slurm/20.11.5/bin/srun",
+            "run_args": {
+              "nodes": 1,
+              "ntasks-per-node": 1
+            }
+          },
+          "batch_settings": {},
+          "params": {},
+          "files": {
+            "Symlink": [],
+            "Configure": [],
+            "Copy": []
+          },
+          "colocated_db": {},
+          "telemetry_metadata": {
+            "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/.smartsim/telemetry/telemetry_db_and_model/4b5507a/model/perroquet",
+            "step_id": "4139111.28",
+            "task_id": "2929",
+            "managed": true
+          },
+          "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet/perroquet.out",
+          "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet/perroquet.err"
+        }
+      ],
+      "orchestrator": [
+        {
+          "name": "orchestrator",
+          "type": "redis",
+          "interface": [
+            "ipogif0"
+          ],
+          "shards": [
+            {
+              "name": "orchestrator_0",
+              "hostname": "10.128.0.4",
+              "port": 6780,
+              "cluster": false,
+              "conf_file": null,
+              "out_file": "/lus/cls01029/mcbridch/ss/orchestrator_0.out",
+              "err_file": "/lus/cls01029/mcbridch/ss/orchestrator_0.err",
+              "telemetry_metadata": {
+                "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/.smartsim/telemetry/telemetry_db_and_model/2ca19ad/database/orchestrator/orchestrator_0",
+                "step_id": "4139111.27",
+                "task_id": "1452",
+                "managed": true
+              }
+            }
+          ]
+        }
+      ],
+      "ensemble": []
+    }
+  ]
+}

--- a/tests/test_configs/telemetry/db_and_model_1run.json
+++ b/tests/test_configs/telemetry/db_and_model_1run.json
@@ -5,7 +5,7 @@
   },
   "experiment": {
     "name": "my-exp",
-    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp",
+    "path": "/tmp/my-exp",
     "launcher": "Slurm"
   },
   "runs": [
@@ -15,13 +15,13 @@
       "model": [
         {
           "name": "perroquet",
-          "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet",
+          "path": "/tmp/my-exp/perroquet",
           "exe_args": [
-            "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+            "/path/to/my/script.py"
           ],
           "run_settings": {
             "exe": [
-              "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+              "/path/to/my/python"
             ],
             "run_command": "/opt/slurm/20.11.5/bin/srun",
             "run_args": {
@@ -38,13 +38,13 @@
           },
           "colocated_db": {},
           "telemetry_metadata": {
-            "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/.smartsim/telemetry/telemetry_db_and_model/4b5507a/model/perroquet",
+            "status_dir": "/tmp/my-exp/.smartsim/telemetry/telemetry_db_and_model/4b5507a/model/perroquet",
             "step_id": "4139111.28",
             "task_id": "2929",
             "managed": true
           },
-          "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet/perroquet.out",
-          "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/perroquet/perroquet.err"
+          "out_file": "/tmp/my-exp/perroquet/perroquet.out",
+          "err_file": "/tmp/my-exp/perroquet/perroquet.err"
         }
       ],
       "orchestrator": [
@@ -61,10 +61,10 @@
               "port": 6780,
               "cluster": false,
               "conf_file": null,
-              "out_file": "/lus/cls01029/mcbridch/ss/orchestrator_0.out",
-              "err_file": "/lus/cls01029/mcbridch/ss/orchestrator_0.err",
+              "out_file": "/path/to/some/file.out",
+              "err_file": "/path/to/some/file.err",
               "telemetry_metadata": {
-                "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp/.smartsim/telemetry/telemetry_db_and_model/2ca19ad/database/orchestrator/orchestrator_0",
+                "status_dir": "/tmp/my-exp/.smartsim/telemetry/telemetry_db_and_model/2ca19ad/database/orchestrator/orchestrator_0",
                 "step_id": "4139111.27",
                 "task_id": "1452",
                 "managed": true

--- a/tests/test_configs/telemetry/ensembles.json
+++ b/tests/test_configs/telemetry/ensembles.json
@@ -1,0 +1,329 @@
+{
+    "schema info": {
+      "schema_name": "entity manifest",
+      "version": "0.0.1"
+    },
+    "experiment": {
+      "name": "my-exp",
+      "path": "/home/chris/code/ss/my-exp",
+      "launcher": "Local"
+    },
+    "runs": [
+      {
+        "run_id": "d041b90",
+        "timestamp": 1698679830384608928,
+        "model": [],
+        "orchestrator": [],
+        "ensemble": [
+          {
+            "name": "my-ens",
+            "params": {
+              "START": [
+                "spam",
+                "foo"
+              ],
+              "MID": [
+                "eggs",
+                "bar"
+              ],
+              "END": [
+                "ham",
+                "baz"
+              ]
+            },
+            "batch_settings": {},
+            "models": [
+              {
+                "name": "my-ens_0",
+                "path": "/home/chris/code/ss",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                  ],
+                  "run_command": null,
+                  "run_args": {}
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "eggs",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/home/chris/code/ss/manifest/demo/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_0",
+                  "step_id": null,
+                  "task_id": "88118",
+                  "managed": false
+                },
+                "out_file": "/home/chris/code/ss/my-ens_0.out",
+                "err_file": "/home/chris/code/ss/my-ens_0.err"
+              },
+              {
+                "name": "my-ens_1",
+                "path": "/home/chris/code/ss",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                  ],
+                  "run_command": null,
+                  "run_args": {}
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "eggs",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/home/chris/code/ss/manifest/demo/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_1",
+                  "step_id": null,
+                  "task_id": "88131",
+                  "managed": false
+                },
+                "out_file": "/home/chris/code/ss/my-ens_1.out",
+                "err_file": "/home/chris/code/ss/my-ens_1.err"
+              },
+              {
+                "name": "my-ens_2",
+                "path": "/home/chris/code/ss",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                  ],
+                  "run_command": null,
+                  "run_args": {}
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "bar",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/home/chris/code/ss/manifest/demo/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_2",
+                  "step_id": null,
+                  "task_id": "88146",
+                  "managed": false
+                },
+                "out_file": "/home/chris/code/ss/my-ens_2.out",
+                "err_file": "/home/chris/code/ss/my-ens_2.err"
+              },
+              {
+                "name": "my-ens_3",
+                "path": "/home/chris/code/ss",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                  ],
+                  "run_command": null,
+                  "run_args": {}
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "bar",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/home/chris/code/ss/manifest/demo/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_3",
+                  "step_id": null,
+                  "task_id": "88170",
+                  "managed": false
+                },
+                "out_file": "/home/chris/code/ss/my-ens_3.out",
+                "err_file": "/home/chris/code/ss/my-ens_3.err"
+              },
+              {
+                "name": "my-ens_4",
+                "path": "/home/chris/code/ss",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                  ],
+                  "run_command": null,
+                  "run_args": {}
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "eggs",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/home/chris/code/ss/manifest/demo/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_4",
+                  "step_id": null,
+                  "task_id": "88178",
+                  "managed": false
+                },
+                "out_file": "/home/chris/code/ss/my-ens_4.out",
+                "err_file": "/home/chris/code/ss/my-ens_4.err"
+              },
+              {
+                "name": "my-ens_5",
+                "path": "/home/chris/code/ss",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                  ],
+                  "run_command": null,
+                  "run_args": {}
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "eggs",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/home/chris/code/ss/manifest/demo/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_5",
+                  "step_id": null,
+                  "task_id": "88193",
+                  "managed": false
+                },
+                "out_file": "/home/chris/code/ss/my-ens_5.out",
+                "err_file": "/home/chris/code/ss/my-ens_5.err"
+              },
+              {
+                "name": "my-ens_6",
+                "path": "/home/chris/code/ss",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                  ],
+                  "run_command": null,
+                  "run_args": {}
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "bar",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/home/chris/code/ss/manifest/demo/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_6",
+                  "step_id": null,
+                  "task_id": "88221",
+                  "managed": false
+                },
+                "out_file": "/home/chris/code/ss/my-ens_6.out",
+                "err_file": "/home/chris/code/ss/my-ens_6.err"
+              },
+              {
+                "name": "my-ens_7",
+                "path": "/home/chris/code/ss",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                  ],
+                  "run_command": null,
+                  "run_args": {}
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "bar",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/home/chris/code/ss/manifest/demo/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_7",
+                  "step_id": null,
+                  "task_id": "88241",
+                  "managed": false
+                },
+                "out_file": "/home/chris/code/ss/my-ens_7.out",
+                "err_file": "/home/chris/code/ss/my-ens_7.err"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/tests/test_configs/telemetry/ensembles.json
+++ b/tests/test_configs/telemetry/ensembles.json
@@ -5,7 +5,7 @@
     },
     "experiment": {
       "name": "my-exp",
-      "path": "/home/chris/code/ss/my-exp",
+      "path": "/home/someuser/code/ss/my-exp",
       "launcher": "Local"
     },
     "runs": [
@@ -35,13 +35,13 @@
             "models": [
               {
                 "name": "my-ens_0",
-                "path": "/home/chris/code/ss",
+                "path": "/home/someuser/code/ss",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                    "/home/someuser/.pyenv/versions/3.9.16/envs/ss/bin/python"
                   ],
                   "run_command": null,
                   "run_args": {}
@@ -55,29 +55,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/home/chris/code/ss/manifest/demo/yo.py"
+                    "/home/someuser/code/ss/manifest/demo/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_0",
+                  "status_dir": "/home/someuser/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_0",
                   "step_id": null,
                   "task_id": "88118",
                   "managed": false
                 },
-                "out_file": "/home/chris/code/ss/my-ens_0.out",
-                "err_file": "/home/chris/code/ss/my-ens_0.err"
+                "out_file": "/home/someuser/code/ss/my-ens_0.out",
+                "err_file": "/home/someuser/code/ss/my-ens_0.err"
               },
               {
                 "name": "my-ens_1",
-                "path": "/home/chris/code/ss",
+                "path": "/home/someuser/code/ss",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                    "/home/someuser/.pyenv/versions/3.9.16/envs/ss/bin/python"
                   ],
                   "run_command": null,
                   "run_args": {}
@@ -91,29 +91,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/home/chris/code/ss/manifest/demo/yo.py"
+                    "/home/someuser/code/ss/manifest/demo/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_1",
+                  "status_dir": "/home/someuser/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_1",
                   "step_id": null,
                   "task_id": "88131",
                   "managed": false
                 },
-                "out_file": "/home/chris/code/ss/my-ens_1.out",
-                "err_file": "/home/chris/code/ss/my-ens_1.err"
+                "out_file": "/home/someuser/code/ss/my-ens_1.out",
+                "err_file": "/home/someuser/code/ss/my-ens_1.err"
               },
               {
                 "name": "my-ens_2",
-                "path": "/home/chris/code/ss",
+                "path": "/home/someuser/code/ss",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                    "/home/someuser/.pyenv/versions/3.9.16/envs/ss/bin/python"
                   ],
                   "run_command": null,
                   "run_args": {}
@@ -127,29 +127,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/home/chris/code/ss/manifest/demo/yo.py"
+                    "/home/someuser/code/ss/manifest/demo/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_2",
+                  "status_dir": "/home/someuser/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_2",
                   "step_id": null,
                   "task_id": "88146",
                   "managed": false
                 },
-                "out_file": "/home/chris/code/ss/my-ens_2.out",
-                "err_file": "/home/chris/code/ss/my-ens_2.err"
+                "out_file": "/home/someuser/code/ss/my-ens_2.out",
+                "err_file": "/home/someuser/code/ss/my-ens_2.err"
               },
               {
                 "name": "my-ens_3",
-                "path": "/home/chris/code/ss",
+                "path": "/home/someuser/code/ss",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                    "/home/someuser/.pyenv/versions/3.9.16/envs/ss/bin/python"
                   ],
                   "run_command": null,
                   "run_args": {}
@@ -163,29 +163,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/home/chris/code/ss/manifest/demo/yo.py"
+                    "/home/someuser/code/ss/manifest/demo/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_3",
+                  "status_dir": "/home/someuser/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_3",
                   "step_id": null,
                   "task_id": "88170",
                   "managed": false
                 },
-                "out_file": "/home/chris/code/ss/my-ens_3.out",
-                "err_file": "/home/chris/code/ss/my-ens_3.err"
+                "out_file": "/home/someuser/code/ss/my-ens_3.out",
+                "err_file": "/home/someuser/code/ss/my-ens_3.err"
               },
               {
                 "name": "my-ens_4",
-                "path": "/home/chris/code/ss",
+                "path": "/home/someuser/code/ss",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                    "/home/someuser/.pyenv/versions/3.9.16/envs/ss/bin/python"
                   ],
                   "run_command": null,
                   "run_args": {}
@@ -199,29 +199,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/home/chris/code/ss/manifest/demo/yo.py"
+                    "/home/someuser/code/ss/manifest/demo/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_4",
+                  "status_dir": "/home/someuser/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_4",
                   "step_id": null,
                   "task_id": "88178",
                   "managed": false
                 },
-                "out_file": "/home/chris/code/ss/my-ens_4.out",
-                "err_file": "/home/chris/code/ss/my-ens_4.err"
+                "out_file": "/home/someuser/code/ss/my-ens_4.out",
+                "err_file": "/home/someuser/code/ss/my-ens_4.err"
               },
               {
                 "name": "my-ens_5",
-                "path": "/home/chris/code/ss",
+                "path": "/home/someuser/code/ss",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                    "/home/someuser/.pyenv/versions/3.9.16/envs/ss/bin/python"
                   ],
                   "run_command": null,
                   "run_args": {}
@@ -235,29 +235,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/home/chris/code/ss/manifest/demo/yo.py"
+                    "/home/someuser/code/ss/manifest/demo/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_5",
+                  "status_dir": "/home/someuser/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_5",
                   "step_id": null,
                   "task_id": "88193",
                   "managed": false
                 },
-                "out_file": "/home/chris/code/ss/my-ens_5.out",
-                "err_file": "/home/chris/code/ss/my-ens_5.err"
+                "out_file": "/home/someuser/code/ss/my-ens_5.out",
+                "err_file": "/home/someuser/code/ss/my-ens_5.err"
               },
               {
                 "name": "my-ens_6",
-                "path": "/home/chris/code/ss",
+                "path": "/home/someuser/code/ss",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                    "/home/someuser/.pyenv/versions/3.9.16/envs/ss/bin/python"
                   ],
                   "run_command": null,
                   "run_args": {}
@@ -271,29 +271,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/home/chris/code/ss/manifest/demo/yo.py"
+                    "/home/someuser/code/ss/manifest/demo/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_6",
+                  "status_dir": "/home/someuser/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_6",
                   "step_id": null,
                   "task_id": "88221",
                   "managed": false
                 },
-                "out_file": "/home/chris/code/ss/my-ens_6.out",
-                "err_file": "/home/chris/code/ss/my-ens_6.err"
+                "out_file": "/home/someuser/code/ss/my-ens_6.out",
+                "err_file": "/home/someuser/code/ss/my-ens_6.err"
               },
               {
                 "name": "my-ens_7",
-                "path": "/home/chris/code/ss",
+                "path": "/home/someuser/code/ss",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/home/chris/.pyenv/versions/3.9.16/envs/ss/bin/python"
+                    "/home/someuser/.pyenv/versions/3.9.16/envs/ss/bin/python"
                   ],
                   "run_command": null,
                   "run_args": {}
@@ -307,19 +307,19 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/home/chris/code/ss/manifest/demo/yo.py"
+                    "/home/someuser/code/ss/manifest/demo/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/home/chris/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_7",
+                  "status_dir": "/home/someuser/code/ss/my-exp/.smartsim/telemetry/my-exp/d041b90/ensemble/my-ens/my-ens_7",
                   "step_id": null,
                   "task_id": "88241",
                   "managed": false
                 },
-                "out_file": "/home/chris/code/ss/my-ens_7.out",
-                "err_file": "/home/chris/code/ss/my-ens_7.err"
+                "out_file": "/home/someuser/code/ss/my-ens_7.out",
+                "err_file": "/home/someuser/code/ss/my-ens_7.err"
               }
             ]
           }

--- a/tests/test_configs/telemetry/serialmodels.json
+++ b/tests/test_configs/telemetry/serialmodels.json
@@ -1,0 +1,186 @@
+{
+    "schema info": {
+        "schema_name": "entity manifest",
+        "version": "0.0.1"
+    },
+    "experiment": {
+        "name": "my-exp",
+        "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp",
+        "launcher": "Slurm"
+    },
+    "runs": [
+        {
+            "run_id": "8c0fbb1",
+            "timestamp": 1699037881502730708,
+            "model": [
+                {
+                    "name": "perroquet_0",
+                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_0",
+                    "exe_args": [
+                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                    ],
+                    "run_settings": {
+                        "exe": [
+                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                        ],
+                        "run_command": "/opt/slurm/20.11.5/bin/srun",
+                        "run_args": {
+                            "nodes": 1,
+                            "ntasks-per-node": 1
+                        }
+                    },
+                    "batch_settings": {},
+                    "params": {},
+                    "files": {
+                        "Symlink": [],
+                        "Configure": [],
+                        "Copy": []
+                    },
+                    "colocated_db": {},
+                    "telemetry_metadata": {
+                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_0",
+                        "step_id": "4139111.22",
+                        "task_id": "17966",
+                        "managed": true
+                    },
+                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_0/perroquet_0.out",
+                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_0/perroquet_0.err"
+                },
+                {
+                    "name": "perroquet_1",
+                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_1",
+                    "exe_args": [
+                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                    ],
+                    "run_settings": {
+                        "exe": [
+                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                        ],
+                        "run_command": "/opt/slurm/20.11.5/bin/srun",
+                        "run_args": {
+                            "nodes": 1,
+                            "ntasks-per-node": 1
+                        }
+                    },
+                    "batch_settings": {},
+                    "params": {},
+                    "files": {
+                        "Symlink": [],
+                        "Configure": [],
+                        "Copy": []
+                    },
+                    "colocated_db": {},
+                    "telemetry_metadata": {
+                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_1",
+                        "step_id": "4139111.23",
+                        "task_id": "18100",
+                        "managed": true
+                    },
+                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_1/perroquet_1.out",
+                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_1/perroquet_1.err"
+                },
+                {
+                    "name": "perroquet_2",
+                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_2",
+                    "exe_args": [
+                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                    ],
+                    "run_settings": {
+                        "exe": [
+                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                        ],
+                        "run_command": "/opt/slurm/20.11.5/bin/srun",
+                        "run_args": {
+                            "nodes": 1,
+                            "ntasks-per-node": 1
+                        }
+                    },
+                    "batch_settings": {},
+                    "params": {},
+                    "files": {
+                        "Symlink": [],
+                        "Configure": [],
+                        "Copy": []
+                    },
+                    "colocated_db": {},
+                    "telemetry_metadata": {
+                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_2",
+                        "step_id": "4139111.24",
+                        "task_id": "18159",
+                        "managed": true
+                    },
+                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_2/perroquet_2.out",
+                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_2/perroquet_2.err"
+                },
+                {
+                    "name": "perroquet_3",
+                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_3",
+                    "exe_args": [
+                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                    ],
+                    "run_settings": {
+                        "exe": [
+                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                        ],
+                        "run_command": "/opt/slurm/20.11.5/bin/srun",
+                        "run_args": {
+                            "nodes": 1,
+                            "ntasks-per-node": 1
+                        }
+                    },
+                    "batch_settings": {},
+                    "params": {},
+                    "files": {
+                        "Symlink": [],
+                        "Configure": [],
+                        "Copy": []
+                    },
+                    "colocated_db": {},
+                    "telemetry_metadata": {
+                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_3",
+                        "step_id": "4139111.25",
+                        "task_id": "18499",
+                        "managed": true
+                    },
+                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_3/perroquet_3.out",
+                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_3/perroquet_3.err"
+                },
+                {
+                    "name": "perroquet_4",
+                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_4",
+                    "exe_args": [
+                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                    ],
+                    "run_settings": {
+                        "exe": [
+                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                        ],
+                        "run_command": "/opt/slurm/20.11.5/bin/srun",
+                        "run_args": {
+                            "nodes": 1,
+                            "ntasks-per-node": 1
+                        }
+                    },
+                    "batch_settings": {},
+                    "params": {},
+                    "files": {
+                        "Symlink": [],
+                        "Configure": [],
+                        "Copy": []
+                    },
+                    "colocated_db": {},
+                    "telemetry_metadata": {
+                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_4",
+                        "step_id": "4139111.26",
+                        "task_id": "18832",
+                        "managed": true
+                    },
+                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_4/perroquet_4.out",
+                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_4/perroquet_4.err"
+                }
+            ],
+            "orchestrator": [],
+            "ensemble": []
+        }
+    ]
+}

--- a/tests/test_configs/telemetry/serialmodels.json
+++ b/tests/test_configs/telemetry/serialmodels.json
@@ -5,7 +5,7 @@
     },
     "experiment": {
         "name": "my-exp",
-        "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp",
+        "path": "/tmp/my-exp",
         "launcher": "Slurm"
     },
     "runs": [
@@ -15,13 +15,13 @@
             "model": [
                 {
                     "name": "perroquet_0",
-                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_0",
+                    "path": "/tmp/my-exp/perroquet_0",
                     "exe_args": [
-                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                        "/tmp/echo.py"
                     ],
                     "run_settings": {
                         "exe": [
-                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                            "/path/to/some/python"
                         ],
                         "run_command": "/opt/slurm/20.11.5/bin/srun",
                         "run_args": {
@@ -38,23 +38,23 @@
                     },
                     "colocated_db": {},
                     "telemetry_metadata": {
-                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_0",
+                        "status_dir": "/tmp/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_0",
                         "step_id": "4139111.22",
                         "task_id": "17966",
                         "managed": true
                     },
-                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_0/perroquet_0.out",
-                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_0/perroquet_0.err"
+                    "out_file": "/tmp/my-exp/perroquet_0/perroquet_0.out",
+                    "err_file": "/tmp/my-exp/perroquet_0/perroquet_0.err"
                 },
                 {
                     "name": "perroquet_1",
-                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_1",
+                    "path": "/tmp/my-exp/perroquet_1",
                     "exe_args": [
-                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                        "/tmp/echo.py"
                     ],
                     "run_settings": {
                         "exe": [
-                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                            "/path/to/some/python"
                         ],
                         "run_command": "/opt/slurm/20.11.5/bin/srun",
                         "run_args": {
@@ -71,23 +71,23 @@
                     },
                     "colocated_db": {},
                     "telemetry_metadata": {
-                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_1",
+                        "status_dir": "/tmp/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_1",
                         "step_id": "4139111.23",
                         "task_id": "18100",
                         "managed": true
                     },
-                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_1/perroquet_1.out",
-                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_1/perroquet_1.err"
+                    "out_file": "/tmp/my-exp/perroquet_1/perroquet_1.out",
+                    "err_file": "/tmp/my-exp/perroquet_1/perroquet_1.err"
                 },
                 {
                     "name": "perroquet_2",
-                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_2",
+                    "path": "/tmp/my-exp/perroquet_2",
                     "exe_args": [
-                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                        "/tmp/echo.py"
                     ],
                     "run_settings": {
                         "exe": [
-                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                            "/path/to/some/python"
                         ],
                         "run_command": "/opt/slurm/20.11.5/bin/srun",
                         "run_args": {
@@ -104,23 +104,23 @@
                     },
                     "colocated_db": {},
                     "telemetry_metadata": {
-                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_2",
+                        "status_dir": "/tmp/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_2",
                         "step_id": "4139111.24",
                         "task_id": "18159",
                         "managed": true
                     },
-                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_2/perroquet_2.out",
-                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_2/perroquet_2.err"
+                    "out_file": "/tmp/my-exp/perroquet_2/perroquet_2.out",
+                    "err_file": "/tmp/my-exp/perroquet_2/perroquet_2.err"
                 },
                 {
                     "name": "perroquet_3",
-                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_3",
+                    "path": "/tmp/my-exp/perroquet_3",
                     "exe_args": [
-                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                        "/tmp/echo.py"
                     ],
                     "run_settings": {
                         "exe": [
-                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                            "/path/to/some/python"
                         ],
                         "run_command": "/opt/slurm/20.11.5/bin/srun",
                         "run_args": {
@@ -137,23 +137,23 @@
                     },
                     "colocated_db": {},
                     "telemetry_metadata": {
-                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_3",
+                        "status_dir": "/tmp/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_3",
                         "step_id": "4139111.25",
                         "task_id": "18499",
                         "managed": true
                     },
-                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_3/perroquet_3.out",
-                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_3/perroquet_3.err"
+                    "out_file": "/tmp/my-exp/perroquet_3/perroquet_3.out",
+                    "err_file": "/tmp/my-exp/perroquet_3/perroquet_3.err"
                 },
                 {
                     "name": "perroquet_4",
-                    "path": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_4",
+                    "path": "/tmp/my-exp/perroquet_4",
                     "exe_args": [
-                        "/lus/cls01029/mcbridch/ss/tests/test_configs/echo.py"
+                        "/tmp/echo.py"
                     ],
                     "run_settings": {
                         "exe": [
-                            "/home/users/mcbridch/anaconda3/envs/ss/bin/python"
+                            "/path/to/some/python"
                         ],
                         "run_command": "/opt/slurm/20.11.5/bin/srun",
                         "run_args": {
@@ -170,13 +170,13 @@
                     },
                     "colocated_db": {},
                     "telemetry_metadata": {
-                        "status_dir": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_4",
+                        "status_dir": "/tmp/my-exp/.smartsim/telemetry/telemetry_serial_models/8c0fbb1/model/perroquet_4",
                         "step_id": "4139111.26",
                         "task_id": "18832",
                         "managed": true
                     },
-                    "out_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_4/perroquet_4.out",
-                    "err_file": "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp/perroquet_4/perroquet_4.err"
+                    "out_file": "/tmp/my-exp/perroquet_4/perroquet_4.out",
+                    "err_file": "/tmp/my-exp/perroquet_4/perroquet_4.err"
                 }
             ],
             "orchestrator": [],

--- a/tests/test_configs/telemetry/telemetry.json
+++ b/tests/test_configs/telemetry/telemetry.json
@@ -1,0 +1,946 @@
+{
+    "experiment": {
+      "name": "my-exp",
+      "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp",
+      "launcher": "Slurm"
+    },
+    "runs": [
+      {
+        "run_id": "d999ad89-020f-4e6a-b834-dbd88658ce84",
+        "timestamp": 1697824072792854287,
+        "model": [
+          {
+            "name": "my-model",
+            "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model",
+            "exe_args": [
+              "hello",
+              "world"
+            ],
+            "run_settings": {
+              "exe": [
+                "/usr/bin/echo"
+              ],
+              "run_command": "/opt/slurm/20.11.5/bin/srun",
+              "run_args": {
+                "nodes": 1,
+                "ntasks": 1
+              }
+            },
+            "batch_settings": {},
+            "params": {},
+            "files": {
+              "Symlink": [],
+              "Configure": [],
+              "Copy": []
+            },
+            "colocated_db": {
+              "settings": {
+                "port": 5757,
+                "ifname": "lo",
+                "cpus": 1,
+                "custom_pinning": "0",
+                "debug": false,
+                "db_identifier": "COLO",
+                "rai_args": {
+                  "threads_per_queue": null,
+                  "inter_op_parallelism": null,
+                  "intra_op_parallelism": null
+                },
+                "extra_db_args": {}
+              },
+              "scripts": [],
+              "models": [
+                {
+                  "cnn": {
+                    "backend": "TORCH",
+                    "device": "CPU"
+                  }
+                }
+              ]
+            },
+            "telemetry_metadata": {
+              "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d999ad89-020f-4e6a-b834-dbd88658ce84/model/my-model",
+              "step_id": "4121050.30",
+              "task_id": "25230",
+              "managed": true
+            },
+            "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model/my-model.out",
+            "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model/my-model.err"
+          }
+        ],
+        "orchestrator": [],
+        "ensemble": []
+      },
+      {
+        "run_id": "fd3cd1a8-cb8f-4f61-b847-73a8eb0881fa",
+        "timestamp": 1697824102122439975,
+        "model": [],
+        "orchestrator": [
+          {
+            "name": "orchestrator",
+            "type": "redis",
+            "interface": [
+              "ipogif0"
+            ],
+            "shards": [
+              {
+                "name": "orchestrator_1",
+                "hostname": "10.128.0.70",
+                "port": 2424,
+                "cluster": true,
+                "conf_file": "nodes-orchestrator_1-2424.conf",
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/fd3cd1a8-cb8f-4f61-b847-73a8eb0881fa/database/orchestrator/orchestrator",
+                  "step_id": "4121050.31+2",
+                  "task_id": "25241",
+                  "managed": true
+                }
+              },
+              {
+                "name": "orchestrator_2",
+                "hostname": "10.128.0.71",
+                "port": 2424,
+                "cluster": true,
+                "conf_file": "nodes-orchestrator_2-2424.conf",
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/fd3cd1a8-cb8f-4f61-b847-73a8eb0881fa/database/orchestrator/orchestrator",
+                  "step_id": "4121050.31+2",
+                  "task_id": "25241",
+                  "managed": true
+                }
+              },
+              {
+                "name": "orchestrator_0",
+                "hostname": "10.128.0.69",
+                "port": 2424,
+                "cluster": true,
+                "conf_file": "nodes-orchestrator_0-2424.conf",
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/fd3cd1a8-cb8f-4f61-b847-73a8eb0881fa/database/orchestrator/orchestrator",
+                  "step_id": "4121050.31+2",
+                  "task_id": "25241",
+                  "managed": true
+                }
+              }
+            ]
+          }
+        ],
+        "ensemble": []
+      },
+      {
+        "run_id": "d65ae1df-cb5e-45d9-ab09-6fa641755997",
+        "timestamp": 1697824127962219505,
+        "model": [],
+        "orchestrator": [],
+        "ensemble": [
+          {
+            "name": "my-ens",
+            "params": {
+              "START": [
+                "spam",
+                "foo"
+              ],
+              "MID": [
+                "eggs",
+                "bar"
+              ],
+              "END": [
+                "ham",
+                "baz"
+              ]
+            },
+            "batch_settings": {},
+            "models": [
+              {
+                "name": "my-ens_0",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "eggs",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_0",
+                  "step_id": "4121050.32",
+                  "task_id": "25639",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0/my-ens_0.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0/my-ens_0.err"
+              },
+              {
+                "name": "my-ens_1",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "eggs",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_1",
+                  "step_id": "4121050.33",
+                  "task_id": "25768",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1/my-ens_1.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1/my-ens_1.err"
+              },
+              {
+                "name": "my-ens_2",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "bar",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_2",
+                  "step_id": "4121050.34",
+                  "task_id": "25817",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2/my-ens_2.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2/my-ens_2.err"
+              },
+              {
+                "name": "my-ens_3",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "bar",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_3",
+                  "step_id": "4121050.35",
+                  "task_id": "25837",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3/my-ens_3.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3/my-ens_3.err"
+              },
+              {
+                "name": "my-ens_4",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "eggs",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_4",
+                  "step_id": "4121050.36",
+                  "task_id": "25872",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4/my-ens_4.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4/my-ens_4.err"
+              },
+              {
+                "name": "my-ens_5",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "eggs",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_5",
+                  "step_id": "4121050.37",
+                  "task_id": "25930",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5/my-ens_5.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5/my-ens_5.err"
+              },
+              {
+                "name": "my-ens_6",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "bar",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_6",
+                  "step_id": "4121050.38",
+                  "task_id": "25945",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6/my-ens_6.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6/my-ens_6.err"
+              },
+              {
+                "name": "my-ens_7",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "bar",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_7",
+                  "step_id": "4121050.39",
+                  "task_id": "25967",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7/my-ens_7.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7/my-ens_7.err"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "run_id": "e41f8e17-c4b2-441d-adf9-707443ee2c72",
+        "timestamp": 1697835227560376025,
+        "model": [
+          {
+            "name": "my-model",
+            "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model",
+            "exe_args": [
+              "hello",
+              "world"
+            ],
+            "run_settings": {
+              "exe": [
+                "/usr/bin/echo"
+              ],
+              "run_command": "/opt/slurm/20.11.5/bin/srun",
+              "run_args": {
+                "nodes": 1,
+                "ntasks": 1
+              }
+            },
+            "batch_settings": {},
+            "params": {},
+            "files": {
+              "Symlink": [],
+              "Configure": [],
+              "Copy": []
+            },
+            "colocated_db": {
+              "settings": {
+                "port": 5757,
+                "ifname": "lo",
+                "cpus": 1,
+                "custom_pinning": "0",
+                "debug": false,
+                "db_identifier": "COLO",
+                "rai_args": {
+                  "threads_per_queue": null,
+                  "inter_op_parallelism": null,
+                  "intra_op_parallelism": null
+                },
+                "extra_db_args": {}
+              },
+              "scripts": [],
+              "models": [
+                {
+                  "cnn": {
+                    "backend": "TORCH",
+                    "device": "CPU"
+                  }
+                }
+              ]
+            },
+            "telemetry_metadata": {
+              "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/e41f8e17-c4b2-441d-adf9-707443ee2c72/model/my-model",
+              "step_id": "4121904.0",
+              "task_id": "28277",
+              "managed": true
+            },
+            "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model/my-model.out",
+            "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model/my-model.err"
+          }
+        ],
+        "orchestrator": [],
+        "ensemble": []
+      },
+      {
+        "run_id": "b33a5d27-6822-4795-8e0e-cfea18551fa4",
+        "timestamp": 1697835261956135240,
+        "model": [],
+        "orchestrator": [
+          {
+            "name": "orchestrator",
+            "type": "redis",
+            "interface": [
+              "ipogif0"
+            ],
+            "shards": [
+              {
+                "name": "orchestrator_0",
+                "hostname": "10.128.0.2",
+                "port": 2424,
+                "cluster": true,
+                "conf_file": "nodes-orchestrator_0-2424.conf",
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/b33a5d27-6822-4795-8e0e-cfea18551fa4/database/orchestrator/orchestrator",
+                  "step_id": "4121904.1+2",
+                  "task_id": "28289",
+                  "managed": true
+                }
+              },
+              {
+                "name": "orchestrator_2",
+                "hostname": "10.128.0.4",
+                "port": 2424,
+                "cluster": true,
+                "conf_file": "nodes-orchestrator_2-2424.conf",
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/b33a5d27-6822-4795-8e0e-cfea18551fa4/database/orchestrator/orchestrator",
+                  "step_id": "4121904.1+2",
+                  "task_id": "28289",
+                  "managed": true
+                }
+              },
+              {
+                "name": "orchestrator_1",
+                "hostname": "10.128.0.3",
+                "port": 2424,
+                "cluster": true,
+                "conf_file": "nodes-orchestrator_1-2424.conf",
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/b33a5d27-6822-4795-8e0e-cfea18551fa4/database/orchestrator/orchestrator",
+                  "step_id": "4121904.1+2",
+                  "task_id": "28289",
+                  "managed": true
+                }
+              }
+            ]
+          }
+        ],
+        "ensemble": []
+      },
+      {
+        "run_id": "45772df2-fd80-43fd-adf0-d5e319870182",
+        "timestamp": 1697835287798613875,
+        "model": [],
+        "orchestrator": [],
+        "ensemble": [
+          {
+            "name": "my-ens",
+            "params": {
+              "START": [
+                "spam",
+                "foo"
+              ],
+              "MID": [
+                "eggs",
+                "bar"
+              ],
+              "END": [
+                "ham",
+                "baz"
+              ]
+            },
+            "batch_settings": {},
+            "models": [
+              {
+                "name": "my-ens_0",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "eggs",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_0",
+                  "step_id": "4121904.2",
+                  "task_id": "28333",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0/my-ens_0.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0/my-ens_0.err"
+              },
+              {
+                "name": "my-ens_1",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "eggs",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_1",
+                  "step_id": "4121904.3",
+                  "task_id": "28342",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1/my-ens_1.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1/my-ens_1.err"
+              },
+              {
+                "name": "my-ens_2",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "bar",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_2",
+                  "step_id": "4121904.4",
+                  "task_id": "28353",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2/my-ens_2.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2/my-ens_2.err"
+              },
+              {
+                "name": "my-ens_3",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "spam",
+                  "MID": "bar",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_3",
+                  "step_id": "4121904.5",
+                  "task_id": "28362",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3/my-ens_3.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3/my-ens_3.err"
+              },
+              {
+                "name": "my-ens_4",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "eggs",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_4",
+                  "step_id": "4121904.6",
+                  "task_id": "28371",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4/my-ens_4.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4/my-ens_4.err"
+              },
+              {
+                "name": "my-ens_5",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "eggs",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_5",
+                  "step_id": "4121904.7",
+                  "task_id": "28380",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5/my-ens_5.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5/my-ens_5.err"
+              },
+              {
+                "name": "my-ens_6",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "bar",
+                  "END": "ham"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_6",
+                  "step_id": "4121904.8",
+                  "task_id": "28389",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6/my-ens_6.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6/my-ens_6.err"
+              },
+              {
+                "name": "my-ens_7",
+                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7",
+                "exe_args": [
+                  "yo.py"
+                ],
+                "run_settings": {
+                  "exe": [
+                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                  ],
+                  "run_command": "/opt/slurm/20.11.5/bin/srun",
+                  "run_args": {
+                    "nodes": 1,
+                    "ntasks": 1
+                  }
+                },
+                "batch_settings": {},
+                "params": {
+                  "START": "foo",
+                  "MID": "bar",
+                  "END": "baz"
+                },
+                "files": {
+                  "Symlink": [],
+                  "Configure": [
+                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                  ],
+                  "Copy": []
+                },
+                "colocated_db": {},
+                "telemetry_metadata": {
+                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_7",
+                  "step_id": "4121904.9",
+                  "task_id": "28398",
+                  "managed": true
+                },
+                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7/my-ens_7.out",
+                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7/my-ens_7.err"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/tests/test_configs/telemetry/telemetry.json
+++ b/tests/test_configs/telemetry/telemetry.json
@@ -1,7 +1,7 @@
 {
     "experiment": {
       "name": "my-exp",
-      "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp",
+      "path": "/path/to/my-exp",
       "launcher": "Slurm"
     },
     "runs": [
@@ -11,7 +11,7 @@
         "model": [
           {
             "name": "my-model",
-            "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model",
+            "path": "/path/to/my-exp/my-model",
             "exe_args": [
               "hello",
               "world"
@@ -59,13 +59,13 @@
               ]
             },
             "telemetry_metadata": {
-              "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d999ad89-020f-4e6a-b834-dbd88658ce84/model/my-model",
+              "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/d999ad89-020f-4e6a-b834-dbd88658ce84/model/my-model",
               "step_id": "4121050.30",
               "task_id": "25230",
               "managed": true
             },
-            "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model/my-model.out",
-            "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model/my-model.err"
+            "out_file": "/path/to/my-exp/my-model/my-model.out",
+            "err_file": "/path/to/my-exp/my-model/my-model.err"
           }
         ],
         "orchestrator": [],
@@ -89,10 +89,10 @@
                 "port": 2424,
                 "cluster": true,
                 "conf_file": "nodes-orchestrator_1-2424.conf",
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "out_file": "/path/to/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/path/to/my-exp/orchestrator/orchestrator.err",
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/fd3cd1a8-cb8f-4f61-b847-73a8eb0881fa/database/orchestrator/orchestrator",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/fd3cd1a8-cb8f-4f61-b847-73a8eb0881fa/database/orchestrator/orchestrator",
                   "step_id": "4121050.31+2",
                   "task_id": "25241",
                   "managed": true
@@ -104,10 +104,10 @@
                 "port": 2424,
                 "cluster": true,
                 "conf_file": "nodes-orchestrator_2-2424.conf",
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "out_file": "/path/to/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/path/to/my-exp/orchestrator/orchestrator.err",
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/fd3cd1a8-cb8f-4f61-b847-73a8eb0881fa/database/orchestrator/orchestrator",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/fd3cd1a8-cb8f-4f61-b847-73a8eb0881fa/database/orchestrator/orchestrator",
                   "step_id": "4121050.31+2",
                   "task_id": "25241",
                   "managed": true
@@ -119,10 +119,10 @@
                 "port": 2424,
                 "cluster": true,
                 "conf_file": "nodes-orchestrator_0-2424.conf",
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "out_file": "/path/to/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/path/to/my-exp/orchestrator/orchestrator.err",
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/fd3cd1a8-cb8f-4f61-b847-73a8eb0881fa/database/orchestrator/orchestrator",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/fd3cd1a8-cb8f-4f61-b847-73a8eb0881fa/database/orchestrator/orchestrator",
                   "step_id": "4121050.31+2",
                   "task_id": "25241",
                   "managed": true
@@ -159,13 +159,13 @@
             "models": [
               {
                 "name": "my-ens_0",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0",
+                "path": "/path/to/my-exp/my-ens/my-ens_0",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -182,29 +182,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_0",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_0",
                   "step_id": "4121050.32",
                   "task_id": "25639",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0/my-ens_0.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0/my-ens_0.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_0/my-ens_0.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_0/my-ens_0.err"
               },
               {
                 "name": "my-ens_1",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1",
+                "path": "/path/to/my-exp/my-ens/my-ens_1",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -221,29 +221,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_1",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_1",
                   "step_id": "4121050.33",
                   "task_id": "25768",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1/my-ens_1.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1/my-ens_1.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_1/my-ens_1.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_1/my-ens_1.err"
               },
               {
                 "name": "my-ens_2",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2",
+                "path": "/path/to/my-exp/my-ens/my-ens_2",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -260,29 +260,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_2",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_2",
                   "step_id": "4121050.34",
                   "task_id": "25817",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2/my-ens_2.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2/my-ens_2.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_2/my-ens_2.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_2/my-ens_2.err"
               },
               {
                 "name": "my-ens_3",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3",
+                "path": "/path/to/my-exp/my-ens/my-ens_3",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -299,29 +299,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_3",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_3",
                   "step_id": "4121050.35",
                   "task_id": "25837",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3/my-ens_3.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3/my-ens_3.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_3/my-ens_3.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_3/my-ens_3.err"
               },
               {
                 "name": "my-ens_4",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4",
+                "path": "/path/to/my-exp/my-ens/my-ens_4",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -338,29 +338,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_4",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_4",
                   "step_id": "4121050.36",
                   "task_id": "25872",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4/my-ens_4.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4/my-ens_4.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_4/my-ens_4.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_4/my-ens_4.err"
               },
               {
                 "name": "my-ens_5",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5",
+                "path": "/path/to/my-exp/my-ens/my-ens_5",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -377,29 +377,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_5",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_5",
                   "step_id": "4121050.37",
                   "task_id": "25930",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5/my-ens_5.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5/my-ens_5.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_5/my-ens_5.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_5/my-ens_5.err"
               },
               {
                 "name": "my-ens_6",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6",
+                "path": "/path/to/my-exp/my-ens/my-ens_6",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -416,29 +416,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_6",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_6",
                   "step_id": "4121050.38",
                   "task_id": "25945",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6/my-ens_6.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6/my-ens_6.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_6/my-ens_6.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_6/my-ens_6.err"
               },
               {
                 "name": "my-ens_7",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7",
+                "path": "/path/to/my-exp/my-ens/my-ens_7",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -455,19 +455,19 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_7",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/d65ae1df-cb5e-45d9-ab09-6fa641755997/ensemble/my-ens/my-ens_7",
                   "step_id": "4121050.39",
                   "task_id": "25967",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7/my-ens_7.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7/my-ens_7.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_7/my-ens_7.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_7/my-ens_7.err"
               }
             ]
           }
@@ -479,7 +479,7 @@
         "model": [
           {
             "name": "my-model",
-            "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model",
+            "path": "/path/to/my-exp/my-model",
             "exe_args": [
               "hello",
               "world"
@@ -527,13 +527,13 @@
               ]
             },
             "telemetry_metadata": {
-              "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/e41f8e17-c4b2-441d-adf9-707443ee2c72/model/my-model",
+              "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/e41f8e17-c4b2-441d-adf9-707443ee2c72/model/my-model",
               "step_id": "4121904.0",
               "task_id": "28277",
               "managed": true
             },
-            "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model/my-model.out",
-            "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-model/my-model.err"
+            "out_file": "/path/to/my-exp/my-model/my-model.out",
+            "err_file": "/path/to/my-exp/my-model/my-model.err"
           }
         ],
         "orchestrator": [],
@@ -557,10 +557,10 @@
                 "port": 2424,
                 "cluster": true,
                 "conf_file": "nodes-orchestrator_0-2424.conf",
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "out_file": "/path/to/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/path/to/my-exp/orchestrator/orchestrator.err",
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/b33a5d27-6822-4795-8e0e-cfea18551fa4/database/orchestrator/orchestrator",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/b33a5d27-6822-4795-8e0e-cfea18551fa4/database/orchestrator/orchestrator",
                   "step_id": "4121904.1+2",
                   "task_id": "28289",
                   "managed": true
@@ -572,10 +572,10 @@
                 "port": 2424,
                 "cluster": true,
                 "conf_file": "nodes-orchestrator_2-2424.conf",
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "out_file": "/path/to/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/path/to/my-exp/orchestrator/orchestrator.err",
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/b33a5d27-6822-4795-8e0e-cfea18551fa4/database/orchestrator/orchestrator",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/b33a5d27-6822-4795-8e0e-cfea18551fa4/database/orchestrator/orchestrator",
                   "step_id": "4121904.1+2",
                   "task_id": "28289",
                   "managed": true
@@ -587,10 +587,10 @@
                 "port": 2424,
                 "cluster": true,
                 "conf_file": "nodes-orchestrator_1-2424.conf",
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/orchestrator/orchestrator.err",
+                "out_file": "/path/to/my-exp/orchestrator/orchestrator.out",
+                "err_file": "/path/to/my-exp/orchestrator/orchestrator.err",
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/b33a5d27-6822-4795-8e0e-cfea18551fa4/database/orchestrator/orchestrator",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/b33a5d27-6822-4795-8e0e-cfea18551fa4/database/orchestrator/orchestrator",
                   "step_id": "4121904.1+2",
                   "task_id": "28289",
                   "managed": true
@@ -627,13 +627,13 @@
             "models": [
               {
                 "name": "my-ens_0",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0",
+                "path": "/path/to/my-exp/my-ens/my-ens_0",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -650,29 +650,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_0",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_0",
                   "step_id": "4121904.2",
                   "task_id": "28333",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0/my-ens_0.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_0/my-ens_0.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_0/my-ens_0.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_0/my-ens_0.err"
               },
               {
                 "name": "my-ens_1",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1",
+                "path": "/path/to/my-exp/my-ens/my-ens_1",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -689,29 +689,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_1",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_1",
                   "step_id": "4121904.3",
                   "task_id": "28342",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1/my-ens_1.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_1/my-ens_1.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_1/my-ens_1.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_1/my-ens_1.err"
               },
               {
                 "name": "my-ens_2",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2",
+                "path": "/path/to/my-exp/my-ens/my-ens_2",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -728,29 +728,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_2",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_2",
                   "step_id": "4121904.4",
                   "task_id": "28353",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2/my-ens_2.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_2/my-ens_2.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_2/my-ens_2.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_2/my-ens_2.err"
               },
               {
                 "name": "my-ens_3",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3",
+                "path": "/path/to/my-exp/my-ens/my-ens_3",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -767,29 +767,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_3",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_3",
                   "step_id": "4121904.5",
                   "task_id": "28362",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3/my-ens_3.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_3/my-ens_3.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_3/my-ens_3.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_3/my-ens_3.err"
               },
               {
                 "name": "my-ens_4",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4",
+                "path": "/path/to/my-exp/my-ens/my-ens_4",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -806,29 +806,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_4",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_4",
                   "step_id": "4121904.6",
                   "task_id": "28371",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4/my-ens_4.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_4/my-ens_4.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_4/my-ens_4.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_4/my-ens_4.err"
               },
               {
                 "name": "my-ens_5",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5",
+                "path": "/path/to/my-exp/my-ens/my-ens_5",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -845,29 +845,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_5",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_5",
                   "step_id": "4121904.7",
                   "task_id": "28380",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5/my-ens_5.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_5/my-ens_5.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_5/my-ens_5.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_5/my-ens_5.err"
               },
               {
                 "name": "my-ens_6",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6",
+                "path": "/path/to/my-exp/my-ens/my-ens_6",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -884,29 +884,29 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_6",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_6",
                   "step_id": "4121904.8",
                   "task_id": "28389",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6/my-ens_6.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_6/my-ens_6.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_6/my-ens_6.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_6/my-ens_6.err"
               },
               {
                 "name": "my-ens_7",
-                "path": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7",
+                "path": "/path/to/my-exp/my-ens/my-ens_7",
                 "exe_args": [
                   "yo.py"
                 ],
                 "run_settings": {
                   "exe": [
-                    "/lus/scratch/drozt/miniconda3/envs/ss/bin/python3"
+                    "/path/to/my/python3"
                   ],
                   "run_command": "/opt/slurm/20.11.5/bin/srun",
                   "run_args": {
@@ -923,19 +923,19 @@
                 "files": {
                   "Symlink": [],
                   "Configure": [
-                    "/lus/cls01029/drozt/playground/ss/dash-int/yo.py"
+                    "/path/to/yo.py"
                   ],
                   "Copy": []
                 },
                 "colocated_db": {},
                 "telemetry_metadata": {
-                  "status_dir": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_7",
+                  "status_dir": "/path/to/my-exp/.smartsim/telemetry/my-exp/45772df2-fd80-43fd-adf0-d5e319870182/ensemble/my-ens/my-ens_7",
                   "step_id": "4121904.9",
                   "task_id": "28398",
                   "managed": true
                 },
-                "out_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7/my-ens_7.out",
-                "err_file": "/lus/cls01029/drozt/playground/ss/dash-int/my-exp/my-ens/my-ens_7/my-ens_7.err"
+                "out_file": "/path/to/my-exp/my-ens/my-ens_7/my-ens_7.out",
+                "err_file": "/path/to/my-exp/my-ens/my-ens_7/my-ens_7.err"
               }
             ]
           }

--- a/tests/test_controller_errors.py
+++ b/tests/test_controller_errors.py
@@ -97,7 +97,7 @@ def test_wrong_orchestrator(wlmutils):
     cont = Controller(launcher="local")
     manifest = Manifest(orc)
     with pytest.raises(SmartSimError):
-        cont._launch(manifest)
+        cont._launch("exp_name", "exp_path", manifest)
 
 
 def test_bad_orc_checkpoint():

--- a/tests/test_dbnode.py
+++ b/tests/test_dbnode.py
@@ -48,8 +48,8 @@ def test_parse_db_host_error():
 
 def test_hosts(fileutils, wlmutils):
     exp_name = "test_hosts"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
 
     orc = Orchestrator(port=wlmutils.get_test_port(), interface="lo", launcher="local")
     orc.set_path(test_dir)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -110,8 +110,8 @@ def test_bad_ensemble_init_no_rs_bs():
 
 def test_stop_entity(fileutils):
     exp_name = "test_stop_entity"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
     m = exp.create_model("model", path=test_dir, run_settings=RunSettings("sleep", "5"))
     exp.start(m, block=False)
     assert exp.finished(m) == False
@@ -122,8 +122,8 @@ def test_stop_entity(fileutils):
 def test_poll(fileutils):
     # Ensure that a SmartSimError is not raised
     exp_name = "test_exp_poll"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
     model = exp.create_model(
         "model", path=test_dir, run_settings=RunSettings("sleep", "5")
     )
@@ -134,8 +134,8 @@ def test_poll(fileutils):
 
 def test_summary(fileutils):
     exp_name = "test_exp_summary"
-    exp = Experiment(exp_name)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, exp_path=test_dir)
     m = exp.create_model(
         "model", path=test_dir, run_settings=RunSettings("echo", "Hello")
     )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -26,10 +26,13 @@
 
 import pytest
 
+import os
+
 from smartsim import Experiment
 from smartsim.entity import Model
 from smartsim.error import SmartSimError
 from smartsim.settings import RunSettings
+from smartsim._core.config import CONFIG
 
 # The tests in this file belong to the slow_tests group
 pytestmark = pytest.mark.slow_tests
@@ -156,6 +159,7 @@ def test_summary(fileutils):
     assert 0 == int(row["RunID"])
     assert 0 == int(row["Returncode"])
 
+
 def test_launcher_detection(wlmutils, monkeypatch):
     if wlmutils.get_test_launcher() == "pals":
         pytest.skip(reason="Launcher detection cannot currently detect pbs vs pals")
@@ -165,3 +169,16 @@ def test_launcher_detection(wlmutils, monkeypatch):
     exp = Experiment("test-launcher-detection", launcher="auto")
 
     assert exp._launcher == wlmutils.get_test_launcher()
+
+
+def test_enable_disable_telemtery(monkeypatch):
+    # TODO: Currently these are implemented by setting an environment variable
+    #       so that ALL experiments instanced in a driver script will begin
+    #       producing telemetry data. In the future it is planned to have this
+    #       work on a "per-instance" basis
+    monkeypatch.setattr(os, "environ", {})
+    exp = Experiment("my-exp")
+    exp.enable_telemetry()
+    assert CONFIG.telemetry_enabled
+    exp.disable_telemetry()
+    assert not CONFIG.telemetry_enabled

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -261,10 +261,8 @@ def test_multiple_tags(fileutils):
     exp.start(parameterized_model, block=True)
 
     with open(osp.join(parameterized_model.path, "multi-tags.out")) as f:
-        line = f.readline()
-        assert (
-            line.strip() == "My two parameters are 6379 and unbreakable_password, OK?"
-        )
+        log_content = f.read()
+        assert "My two parameters are 6379 and unbreakable_password, OK?" in log_content
 
 
 def test_generation_log(fileutils):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -27,6 +27,7 @@
 import pytest
 
 from smartsim._core.utils.helpers import cat_arg_and_value
+from smartsim._core.utils import helpers
 
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a
@@ -47,3 +48,17 @@ def test_single_char_concat():
 def test_fallthrough_concat():
     result = cat_arg_and_value("xx", "FOO")  # <-- no dashes, > 1 char
     assert result == "--xx=FOO"
+
+def test_encode_decode_cmd_round_trip():
+    orig_cmd = ["this", "is", "a", "cmd"]
+    decoded_cmd = helpers.decode_cmd(helpers.encode_cmd(orig_cmd))
+    assert orig_cmd == decoded_cmd
+    assert orig_cmd is not decoded_cmd
+
+def test_encode_raises_on_empty():
+    with pytest.raises(ValueError):
+        helpers.encode_cmd([])
+
+def test_decode_raises_on_empty():
+    with pytest.raises(ValueError):
+        helpers.decode_cmd("")

--- a/tests/test_indirect.py
+++ b/tests/test_indirect.py
@@ -76,7 +76,7 @@ def test_parser(capsys, cmd, missing):
 
 
 def test_cleanup(capsys, monkeypatch):
-    """Ensure cleanup attempts termination of correcct process"""
+    """Ensure cleanup attempts termination of correct process"""
     mock_pid = 123
     create_msg = "creating: {0}"
     term_msg = "terminating: {0}"

--- a/tests/test_indirect.py
+++ b/tests/test_indirect.py
@@ -1,0 +1,204 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import pathlib
+import psutil
+import pytest
+import sys
+import uuid
+
+from smartsim._core.entrypoints.indirect import get_parser, cleanup, get_ts, main
+from smartsim._core.utils.serialize import TELMON_SUBDIR, MANIFEST_FILENAME
+from smartsim._core.utils.helpers import encode_cmd
+
+ALL_ARGS = {"+command", "+entity_type", "+telemetry_dir", "+output_file", "+error_file", "+working_dir"}
+
+
+@pytest.mark.parametrize(
+        ["cmd", "missing"],
+        [
+            pytest.param("indirect.py", {"+command", "+entity_type", "+telemetry_dir", "+output_file", "+error_file", "+working_dir"}, id="no args"),
+            pytest.param("indirect.py -c echo +entity_type ttt +telemetry_dir ddd +output_file ooo +working_dir www +error_file eee", {"+command"}, id="cmd typo"),
+            pytest.param("indirect.py -t orchestrator +command ccc +telemetry_dir ddd +output_file ooo +working_dir www +error_file eee", {"+entity_type"}, id="etype typo"),
+            pytest.param("indirect.py -d /foo/bar +entity_type ttt +command ccc +output_file ooo +working_dir www +error_file eee", {"+telemetry_dir"}, id="dir typo"),
+            pytest.param("indirect.py        +entity_type ttt +telemetry_dir ddd +output_file ooo +working_dir www +error_file eee", {"+command"}, id="no cmd"),
+            pytest.param("indirect.py +command ccc        +telemetry_dir ddd +output_file ooo +working_dir www +error_file eee", {"+entity_type"}, id="no etype"),
+            pytest.param("indirect.py +command ccc +entity_type ttt        +output_file ooo +working_dir www +error_file eee", {"+telemetry_dir"}, id="no dir"),
+        ]
+)
+def test_parser(capsys, cmd, missing):
+    """Test that the parser reports any missing required arguments"""
+    parser = get_parser()
+
+    args = cmd.split()
+
+    captured = capsys.readouterr()  # throw away existing output
+    with pytest.raises(SystemExit) as ex:
+        ns = parser.parse_args(args)
+
+    captured = capsys.readouterr()
+    assert "the following arguments are required" in captured.err
+    for arg in missing:
+        assert arg in captured.err
+
+    expected = ALL_ARGS - missing
+    msg_tuple = captured.err.split("the following arguments are required: ")
+    if len(msg_tuple) < 2:
+        assert False, "error message indicates no missing arguments"
+
+    actual_missing = msg_tuple[1].strip()
+    for exp in expected:
+        assert f"{exp}/" not in actual_missing
+
+
+def test_cleanup(capsys, monkeypatch):
+    """Ensure cleanup attempts termination of correcct process"""
+    mock_pid = 123
+    create_msg = "creating: {0}"
+    term_msg = "terminating: {0}"
+
+    class MockProc:
+        def __init__(self, pid: int):
+            print(create_msg.format(pid))
+        def terminate(self):
+            print(term_msg.format(mock_pid))
+    
+    captured = capsys.readouterr()  # throw away existing output
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr('psutil.pid_exists', lambda pid: True)
+        ctx.setattr('psutil.Process', MockProc)
+        ctx.setattr('smartsim._core.entrypoints.indirect.STEP_PID', mock_pid)
+        cleanup()        
+
+    captured = capsys.readouterr()
+    assert create_msg.format(mock_pid) in captured.out
+    assert term_msg.format(mock_pid) in captured.out
+
+
+def test_cleanup_late(capsys, monkeypatch):
+    """Ensure cleanup exceptions are swallowed if a process is already terminated"""
+    mock_pid = 123
+    create_msg = "creating: {0}"
+    term_msg = "terminating: {0}"
+
+    class MockMissingProc:
+        def __init__(self, pid: int) -> None:
+            print(create_msg.format(mock_pid))
+            raise psutil.NoSuchProcess(pid)
+        def terminate(self) -> None:
+            print(term_msg.format(mock_pid))
+    
+    captured = capsys.readouterr()  # throw away existing output
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr('psutil.pid_exists', lambda pid: True)
+        ctx.setattr('psutil.Process', MockMissingProc)
+        ctx.setattr('smartsim._core.entrypoints.indirect.STEP_PID', mock_pid)
+        cleanup()
+
+    captured = capsys.readouterr()
+    assert create_msg.format(mock_pid) in captured.out
+
+
+def test_ts():
+    """Ensure expected output type"""
+    ts = get_ts()
+    assert isinstance(ts, int)
+
+
+def test_indirect_main_dir_check(fileutils):
+    """Ensure that the proxy validates the test directory exists"""
+    test_dir = fileutils.make_test_dir()
+    exp_dir = pathlib.Path(test_dir)
+    std_out = str(exp_dir / "out.txt")
+    err_out = str(exp_dir / "err.txt")
+
+    cmd = ["echo", "unit-test"]
+    encoded_cmd = encode_cmd(cmd)
+
+    status_path = exp_dir / TELMON_SUBDIR
+    
+    # show that a missing status_path is created when missing
+    main(encoded_cmd, "application", std_out, err_out, exp_dir, status_path)
+
+    assert status_path.exists()
+
+
+def test_indirect_main_cmd_check(capsys, fileutils, monkeypatch):
+    """Ensure that the proxy validates the cmd is not empty or whitespace-only"""
+    test_dir = fileutils.make_test_dir()
+    exp_dir = pathlib.Path(test_dir)
+    std_out = str(exp_dir / "out.txt")
+    err_out = str(exp_dir / "err.txt")
+
+    captured = capsys.readouterr()  # throw away existing output
+    with monkeypatch.context() as ctx, pytest.raises(ValueError) as ex:
+        ctx.setattr('smartsim._core.entrypoints.indirect.logger.error', print)
+        _ = main("", "application", std_out, err_out, exp_dir, exp_dir / TELMON_SUBDIR)
+
+    captured = capsys.readouterr()
+    assert "Invalid cmd supplied" in ex.value.args[0]
+
+    std_out = str(exp_dir / "out.txt")
+    err_out = str(exp_dir / "err.txt")
+
+    # test with non-emptystring cmd
+    with monkeypatch.context() as ctx, pytest.raises(ValueError) as ex:
+        ctx.setattr('smartsim._core.entrypoints.indirect.logger.error', print)
+        _ = main("  \n  \t   ", "application", std_out, err_out, exp_dir, exp_dir / TELMON_SUBDIR)
+
+    captured = capsys.readouterr()
+    assert "Invalid cmd supplied" in ex.value.args[0]
+
+
+def test_complete_process(capsys, fileutils):
+    """Ensure the happy-path completes and returns a success return code"""
+    script = fileutils.get_test_conf_path("sleep.py")
+
+    test_dir = fileutils.make_test_dir()
+    exp_dir = pathlib.Path(test_dir)
+    std_out = str(exp_dir / "out.txt")
+    err_out = str(exp_dir / "err.txt")
+
+    _ = capsys.readouterr()  # throw away existing output
+
+    raw_cmd = f"{sys.executable} {script} --time=1"
+    cmd = encode_cmd(raw_cmd.split())
+
+    rc = main(cmd, "application", std_out, err_out, exp_dir, exp_dir / TELMON_SUBDIR)
+    assert rc == 0
+
+    assert exp_dir.exists()
+
+    # NOTE: don't have a manifest so we're falling back to default event path
+    data_dir = exp_dir / TELMON_SUBDIR
+    start_events = list(data_dir.rglob("start.json"))
+    stop_events = list(data_dir.rglob("stop.json"))
+
+    assert start_events
+    assert stop_events

--- a/tests/test_indirect.py
+++ b/tests/test_indirect.py
@@ -37,6 +37,8 @@ from smartsim._core.utils.helpers import encode_cmd
 
 ALL_ARGS = {"+command", "+entity_type", "+telemetry_dir", "+output_file", "+error_file", "+working_dir"}
 
+# The tests in this file belong to the group_a group
+pytestmark = pytest.mark.group_a
 
 @pytest.mark.parametrize(
         ["cmd", "missing"],

--- a/tests/test_launch_errors.py
+++ b/tests/test_launch_errors.py
@@ -45,8 +45,8 @@ def test_unsupported_run_settings():
 
 def test_model_failure(fileutils):
     exp_name = "test-model-failure"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("bad.py")
     settings = RunSettings("python", f"{script} --time=3")
@@ -61,8 +61,8 @@ def test_model_failure(fileutils):
 def test_orchestrator_relaunch(fileutils, wlmutils):
     """Test when users try to launch second orchestrator"""
     exp_name = "test-orc-on-relaunch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     orc = Orchestrator(port=wlmutils.get_test_port())
     orc.set_path(test_dir)

--- a/tests/test_local_launch.py
+++ b/tests/test_local_launch.py
@@ -34,8 +34,8 @@ Test the launch of simple entity types with local launcher
 
 def test_models(fileutils):
     exp_name = "test-models-local-launch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")
@@ -50,8 +50,8 @@ def test_models(fileutils):
 
 def test_ensemble(fileutils):
     exp_name = "test-ensemble-launch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")

--- a/tests/test_local_multi_run.py
+++ b/tests/test_local_multi_run.py
@@ -34,8 +34,8 @@ Test the launch of simple entity types with local launcher
 
 def test_models(fileutils):
     exp_name = "test-models-local-launch"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=5")

--- a/tests/test_local_restart.py
+++ b/tests/test_local_restart.py
@@ -35,8 +35,8 @@ Test restarting ensembles and models.
 def test_restart(fileutils):
 
     exp_name = "test-models-local-restart"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")
@@ -55,8 +55,8 @@ def test_restart(fileutils):
 
 def test_ensemble(fileutils):
     exp_name = "test-ensemble-restart"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     script = fileutils.get_test_conf_path("sleep.py")
     settings = exp.create_run_settings("python", f"{script} --time=3")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -26,6 +26,7 @@
 
 
 from copy import deepcopy
+import os.path
 
 import pytest
 
@@ -146,3 +147,22 @@ def test_launched_manifest_builer_raises_if_attaching_data_to_empty_collection(
     monkeypatch.setattr(ensemble, "entities", [])
     with pytest.raises(ValueError):
         lmb.add_ensemble(ensemble, [])
+
+
+def test_lmb_and_launched_manifest_have_same_paths_for_launched_metadata():
+    exp_path = "/path/to/some/exp"
+    lmb = LaunchedManifestBuilder("exp_name", exp_path, "launcher")
+    manifest = lmb.finalize()
+    assert lmb.exp_telemetry_subdirectory == manifest.metadata.exp_telemetry_subdirectory
+    assert lmb.run_telemetry_subdirectory == manifest.metadata.run_telemetry_subdirectory
+    assert os.path.commonprefix([
+        manifest.metadata.run_telemetry_subdirectory,
+        manifest.metadata.exp_telemetry_subdirectory,
+        manifest.metadata.manifest_file_path,
+        exp_path,
+    ]) == exp_path
+    assert os.path.commonprefix([
+        manifest.metadata.run_telemetry_subdirectory,
+        manifest.metadata.exp_telemetry_subdirectory,
+        manifest.metadata.manifest_file_path,
+    ]) == str(manifest.metadata.exp_telemetry_subdirectory)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -109,7 +109,7 @@ def test_launched_manifest_transform_data():
     ensembles = [(ensemble, [(m, i) for i, m in enumerate(ensemble.entities)])]
     dbs = [(orc, [(n, i) for i, n in enumerate(orc.entities)])]
     launched = LaunchedManifest(
-        metadata=LaunchedManifestMetadata("name", "path", "launcher"),
+        metadata=LaunchedManifestMetadata("name", "path", "launcher", "run_id"),
         models=models,
         ensembles=ensembles,
         databases=dbs,
@@ -121,20 +121,20 @@ def test_launched_manifest_transform_data():
 
 
 def test_launched_manifest_builder_correctly_maps_data():
-    lmb = LaunchedManifestBuilder()
+    lmb = LaunchedManifestBuilder("name", "path", "launcher name")
     lmb.add_model(model, 1)
     lmb.add_model(model_2, 1)
     lmb.add_ensemble(ensemble, [i for i in range(len(ensemble.entities))])
     lmb.add_database(orc, [i for i in range(len(orc.entities))])
 
-    manifest = lmb.finalize("name", "path", "launcher name")
+    manifest = lmb.finalize()
     assert len(manifest.models) == 2
     assert len(manifest.ensembles) == 1
     assert len(manifest.databases) == 1
 
 
 def test_launced_manifest_builder_raises_if_lens_do_not_match():
-    lmb = LaunchedManifestBuilder()
+    lmb = LaunchedManifestBuilder("name", "path", "launcher name")
     with pytest.raises(ValueError):
         lmb.add_ensemble(ensemble, list(range(123)))
     with pytest.raises(ValueError):
@@ -144,7 +144,7 @@ def test_launced_manifest_builder_raises_if_lens_do_not_match():
 def test_launched_manifest_builer_raises_if_attaching_data_to_empty_collection(
     monkeypatch
 ):
-    lmb = LaunchedManifestBuilder()
+    lmb = LaunchedManifestBuilder("name", "path", "launcher")
     monkeypatch.setattr(ensemble, "entities", [])
     with pytest.raises(ValueError):
         lmb.add_ensemble(ensemble, [])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -89,7 +89,7 @@ def monkeypatch_exp_controller(monkeypatch):
         def start_wo_job_manager(self, exp_name, exp_path, manifest,
                                  block=True, kill_on_interrupt=True):
             self._launch(exp_name, exp_path, manifest)
-            return LaunchedManifestBuilder().finalize("name", "path", "launcher")
+            return LaunchedManifestBuilder("name", "path", "launcher").finalize()
 
         def launch_step_nop(self, step, entity):
             entity_steps.append((step, entity))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -28,6 +28,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim._core.launcher.step import SbatchStep, SrunStep
+from smartsim._core.control.manifest import LaunchedManifestBuilder
 from smartsim.entity import Ensemble, Model
 from smartsim.error import EntityExistsError, SSUnsupportedError
 from smartsim.settings import RunSettings, SbatchSettings, SrunSettings
@@ -85,8 +86,10 @@ def monkeypatch_exp_controller(monkeypatch):
     def _monkeypatch_exp_controller(exp):
         entity_steps = []
 
-        def start_wo_job_manager(self, manifest, block=True, kill_on_interrupt=True):
-            self._launch(manifest)
+        def start_wo_job_manager(self, exp_name, exp_path, manifest,
+                                 block=True, kill_on_interrupt=True):
+            self._launch(exp_name, exp_path, manifest)
+            return LaunchedManifestBuilder().finalize("name", "path", "launcher")
 
         def launch_step_nop(self, step, entity):
             entity_steps.append((step, entity))

--- a/tests/test_multidb.py
+++ b/tests/test_multidb.py
@@ -62,7 +62,7 @@ def test_db_identifier_standard_then_colo(fileutils, wlmutils, coloutils, db_typ
     test_script = fileutils.get_test_conf_path("smartredis/db_id_err.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # create regular database
     orc = exp.create_database(
@@ -132,7 +132,7 @@ def test_db_identifier_colo_then_standard(fileutils, wlmutils, coloutils, db_typ
     test_script = fileutils.get_test_conf_path("smartredis/db_id_err.py")
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # Create run settings
     colo_settings = exp.create_run_settings("python", test_script)
@@ -175,7 +175,7 @@ def test_db_identifier_colo_then_standard(fileutils, wlmutils, coloutils, db_typ
     exp.stop(orc)
 
 
-def test_db_identifier_standard_twice_not_unique(wlmutils):
+def test_db_identifier_standard_twice_not_unique(wlmutils, fileutils):
     """Test uniqueness of db_identifier several calls to create_database, with non unique names,
     checking error is raised before exp start is called"""
 
@@ -186,9 +186,10 @@ def test_db_identifier_standard_twice_not_unique(wlmutils):
     test_launcher = wlmutils.get_test_launcher()
     test_interface = wlmutils.get_test_interface()
     test_port = wlmutils.get_test_port()
+    test_dir = fileutils.make_test_dir()
 
     # Create SmartSim Experiment
-    exp = Experiment(exp_name, launcher=test_launcher)
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
 
     # CREATE DATABASE with db_identifier
     orc = exp.create_database(
@@ -300,7 +301,9 @@ def test_multidb_colo_once(fileutils, wlmutils, coloutils, db_type):
     test_script = fileutils.get_test_conf_path("smartredis/dbid.py")
 
     # start a new Experiment for this section
-    exp = Experiment("test_multidb_colo_once", launcher=test_launcher)
+    exp = Experiment("test_multidb_colo_once",
+                     launcher=test_launcher,
+                     exp_path=test_dir)
 
     # create run settings
     run_settings = exp.create_run_settings("python", test_script)
@@ -466,8 +469,8 @@ def test_launch_cluster_orc_single_dbid(fileutils, wlmutils):
 
     exp_name = "test_launch_cluster_orc_single_dbid"
     launcher = wlmutils.get_test_launcher()
-    exp = Experiment(exp_name, launcher=launcher)
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -67,8 +67,8 @@ def test_inactive_orc_get_address():
 
 def test_orc_active_functions(fileutils, wlmutils):
     exp_name = "test_orc_active_functions"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     db = Orchestrator(port=wlmutils.get_test_port())
     db.set_path(test_dir)
@@ -95,8 +95,8 @@ def test_orc_active_functions(fileutils, wlmutils):
 
 def test_multiple_interfaces(fileutils, wlmutils):
     exp_name = "test_multiple_interfaces"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     net_if_addrs = psutil.net_if_addrs()
     net_if_addrs = [

--- a/tests/test_pals_settings.py
+++ b/tests/test_pals_settings.py
@@ -31,6 +31,7 @@ import sys
 
 import pytest
 
+import smartsim._core.config.config
 from smartsim.error import SSUnsupportedError
 from smartsim.settings import PalsMpiexecSettings
 from smartsim._core.launcher import PBSLauncher
@@ -38,6 +39,15 @@ from smartsim._core.launcher.step.mpiStep import MpiexecStep
 
 default_exe = sys.executable
 default_kwargs = {"fail_if_missing_exec": False}
+
+
+@pytest.fixture(autouse=True)
+def turn_off_telemetry_indirect(monkeypatch):
+    monkeypatch.setattr(
+        smartsim._core.config.config.Config,
+        "telemetry_enabled", False)
+    yield
+
 
 # Uncomment when
 # @pytest.mark.parametrize(
@@ -53,6 +63,7 @@ default_kwargs = {"fail_if_missing_exec": False}
 #    func = getattr(settings, function_name)
 #    with pytest.raises(SSUnsupportedError):
 #        func(None)
+
 
 def test_affinity_script():
     settings = PalsMpiexecSettings(default_exe, **default_kwargs)

--- a/tests/test_reconnect_orchestrator.py
+++ b/tests/test_reconnect_orchestrator.py
@@ -41,8 +41,8 @@ def test_local_orchestrator(fileutils, wlmutils):
     """Test launching orchestrator locally"""
     global first_dir
     exp_name = "test-orc-launch-local"
-    exp = Experiment(exp_name, launcher="local")
     test_dir = fileutils.make_test_dir()
+    exp = Experiment(exp_name, launcher="local", exp_path=test_dir)
     first_dir = test_dir
 
     orc = Orchestrator(port=wlmutils.get_test_port())
@@ -57,12 +57,13 @@ def test_local_orchestrator(fileutils, wlmutils):
     exp._control._launcher.task_manager.actively_monitoring = False
 
 
-def test_reconnect_local_orc():
+def test_reconnect_local_orc(fileutils):
     """Test reconnecting to orchestrator from first experiment"""
     global first_dir
     # start new experiment
     exp_name = "test-orc-local-reconnect-2nd"
-    exp_2 = Experiment(exp_name, launcher="local")
+    test_dir = fileutils.make_test_dir()
+    exp_2 = Experiment(exp_name, launcher="local", exp_path=test_dir)
 
     checkpoint = osp.join(first_dir, "smartsim_db.dat")
     reloaded_orc = exp_2.reconnect_orchestrator(checkpoint)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -31,13 +31,13 @@ from smartsim import Experiment
 from smartsim._core.utils import serialize
 from smartsim._core.control.manifest import LaunchedManifestBuilder
 
-_REL_MANIFEST_PATH = ".smartsim/telemetry/manifest.json"
+_REL_MANIFEST_PATH = f"{serialize.TELMON_SUBDIR}/{serialize.MANIFEST_FILENAME}"
 
 
 def test_serialize_creates_a_manifest_json_file_if_dne(fileutils):
     test_dir = fileutils.get_test_dir()
-    lmb = LaunchedManifestBuilder()
-    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    lmb = LaunchedManifestBuilder("exp", test_dir, "launcher")
+    serialize.save_launch_manifest(lmb.finalize())
     manifest_json = Path(test_dir) / _REL_MANIFEST_PATH
 
     assert manifest_json.is_file()
@@ -51,17 +51,20 @@ def test_serialize_creates_a_manifest_json_file_if_dne(fileutils):
 
 def test_serialize_appends_a_manifest_json_exists(fileutils):
     test_dir = fileutils.get_test_dir()
-    lmb = LaunchedManifestBuilder()
-    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
     manifest_json = Path(test_dir) / _REL_MANIFEST_PATH
-    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
-    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    serialize.save_launch_manifest(
+        LaunchedManifestBuilder("exp", test_dir, "launcher").finalize())
+    serialize.save_launch_manifest(
+        LaunchedManifestBuilder("exp", test_dir, "launcher").finalize())
+    serialize.save_launch_manifest(
+        LaunchedManifestBuilder("exp", test_dir, "launcher").finalize())
 
     assert manifest_json.is_file()
     with open(manifest_json, 'r') as f:
         manifest = json.load(f)
         assert isinstance(manifest["runs"], list)
         assert len(manifest["runs"]) == 3
+        assert len({run["run_id"] for run in manifest["runs"]}) == 3
 
 
 def test_serialize_overwites_file_if_not_json(fileutils):
@@ -71,8 +74,8 @@ def test_serialize_overwites_file_if_not_json(fileutils):
     with open(manifest_json, 'w') as f:
         f.write("This is not a json\n")
 
-    lmb = LaunchedManifestBuilder()
-    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    lmb = LaunchedManifestBuilder("exp", test_dir, "launcher")
+    serialize.save_launch_manifest(lmb.finalize())
     with open(manifest_json, 'r') as f:
         assert isinstance(json.load(f), dict)
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,108 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from pathlib import Path
+import json
+
+from smartsim import Experiment
+from smartsim._core.utils import serialize
+from smartsim._core.control.manifest import LaunchedManifestBuilder
+
+_REL_MANIFEST_PATH = ".smartsim/telemetry/manifest.json"
+
+
+def test_serialize_creates_a_manifest_json_file_if_dne(fileutils):
+    test_dir = fileutils.get_test_dir()
+    lmb = LaunchedManifestBuilder()
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    manifest_json = Path(test_dir) / _REL_MANIFEST_PATH
+
+    assert manifest_json.is_file()
+    with open(manifest_json, 'r') as f:
+        manifest = json.load(f)
+        assert manifest["experiment"]["name"] == "exp"
+        assert manifest["experiment"]["launcher"] == "launcher"
+        assert isinstance(manifest["runs"], list)
+        assert len(manifest["runs"]) == 1
+
+
+def test_serialize_appends_a_manifest_json_exists(fileutils):
+    test_dir = fileutils.get_test_dir()
+    lmb = LaunchedManifestBuilder()
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    manifest_json = Path(test_dir) / _REL_MANIFEST_PATH
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+
+    assert manifest_json.is_file()
+    with open(manifest_json, 'r') as f:
+        manifest = json.load(f)
+        assert isinstance(manifest["runs"], list)
+        assert len(manifest["runs"]) == 3
+
+
+def test_serialize_overwites_file_if_not_json(fileutils):
+    test_dir = fileutils.get_test_dir()
+    manifest_json = Path(test_dir) / _REL_MANIFEST_PATH
+    manifest_json.parent.mkdir(parents=True, exist_ok=True)
+    with open(manifest_json, 'w') as f:
+        f.write("This is not a json\n")
+
+    lmb = LaunchedManifestBuilder()
+    serialize.save_launch_manifest(lmb.finalize("exp", test_dir, "launcher"))
+    with open(manifest_json, 'r') as f:
+        assert isinstance(json.load(f), dict)
+
+
+def test_started_entities_are_serialized(fileutils):
+    exp_name = "test-exp"
+    test_dir = Path(fileutils.make_test_dir()) / exp_name
+    test_dir.mkdir(parents=True)
+    exp = Experiment(exp_name, exp_path=str(test_dir), launcher="local")
+
+    rs1 = exp.create_run_settings("echo", ["hello", "world"])
+    rs2 = exp.create_run_settings("echo", ["spam", "eggs"])
+
+    hello_world_model = exp.create_model("echo-hello", run_settings=rs1)
+    spam_eggs_model = exp.create_model("echo-spam", run_settings=rs2)
+    hello_ensemble = exp.create_ensemble('echo-ensemble', run_settings=rs1, replicas=3)
+
+    exp.generate(hello_world_model, spam_eggs_model, hello_ensemble)
+    exp.start(hello_world_model, spam_eggs_model, block=False)
+    exp.start(hello_ensemble, block=False)
+
+    manifest_json = Path(exp.exp_path) / _REL_MANIFEST_PATH
+    try:
+        with open(manifest_json, 'r') as f:
+            manifest = json.load(f)
+            assert len(manifest["runs"]) == 2
+            assert len(manifest["runs"][0]["model"]) == 2
+            assert len(manifest["runs"][0]["ensemble"]) == 0
+            assert len(manifest["runs"][1]["model"]) == 0
+            assert len(manifest["runs"][1]["ensemble"]) == 1
+            assert len(manifest["runs"][1]["ensemble"][0]["models"]) == 3
+    finally:
+        exp.stop(hello_world_model, spam_eggs_model, hello_ensemble)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -37,6 +37,8 @@ import smartsim._core.config.config
 _REL_MANIFEST_PATH = f"{serialize.TELMON_SUBDIR}/{serialize.MANIFEST_FILENAME}"
 _CFG_TM_ENABLED_ATTR = "telemetry_enabled"
 
+# The tests in this file belong to the group_b group
+pytestmark = pytest.mark.group_b
 
 @pytest.fixture(autouse=True)
 def turn_on_tm(monkeypatch):

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -473,7 +473,7 @@ def test_telemetry_single_model(fileutils, wlmutils):
     app_settings.set_nodes(1)
     app_settings.set_tasks_per_node(1)
 
-    #  # Create the SmartSim Model
+    # Create the SmartSim Model
     smartsim_model = exp.create_model("perroquet", app_settings)
     exp.generate(smartsim_model)
     exp.start(smartsim_model, block=True)
@@ -509,7 +509,7 @@ def test_telemetry_single_model_nonblocking(fileutils, wlmutils, monkeypatch):
         app_settings.set_nodes(1)
         app_settings.set_tasks_per_node(1)
 
-        #  # Create the SmartSim Model
+        # Create the SmartSim Model
         smartsim_model = exp.create_model("perroquet", app_settings)
         exp.generate(smartsim_model)
         exp.start(smartsim_model)
@@ -549,7 +549,7 @@ def test_telemetry_serial_models(fileutils, wlmutils, monkeypatch):
         app_settings.set_nodes(1)
         app_settings.set_tasks_per_node(1)
 
-        #  # Create the SmartSim Model
+        # Create the SmartSim Model
         smartsim_models = [
             exp.create_model(f"perroquet_{i}", app_settings) for i in range(5)
         ]
@@ -591,7 +591,7 @@ def test_telemetry_serial_models_nonblocking(fileutils, wlmutils, monkeypatch):
         app_settings.set_nodes(1)
         app_settings.set_tasks_per_node(1)
 
-        #  # Create the SmartSim Model
+        # Create the SmartSim Model
         smartsim_models = [
             exp.create_model(f"perroquet_{i}", app_settings) for i in range(5)
         ]

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -89,6 +89,9 @@ requires_wlm = pytest.mark.skipif(
 
 logger = logging.getLogger()
 
+# The tests in this file belong to the slow_tests group
+pytestmark = pytest.mark.slow_tests
+
 
 @pytest.fixture(autouse=True)
 def turn_on_tm(monkeypatch):

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -1,0 +1,799 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2023, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import logging
+import pathlib
+from random import sample
+import pytest
+import typing as t
+import time
+import uuid
+from conftest import FileUtils
+import smartsim._core.config.config as cfg
+from smartsim._core.control.job import Job, JobEntity
+from smartsim.status import STATUS_COMPLETED, STATUS_CANCELLED
+
+
+from smartsim._core.entrypoints.telemetrymonitor import (
+    can_shutdown,
+    get_parser,
+    get_ts,
+    shutdown_when_completed,
+    track_event,
+    load_manifest,
+    hydrate_persistable,
+    ManifestEventHandler,
+)
+from smartsim._core.utils import serialize
+from smartsim import Experiment
+
+
+ALL_ARGS = {"-exp_dir", "-frequency"}
+logger = logging.getLogger()
+
+
+def snooze_nonblocking(test_dir: str, max_delay: int = 20, post_data_delay: int = 2):
+    telmon_subdir = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
+    # let the non-blocking experiment complete.
+    for _ in range(max_delay):
+        time.sleep(1)
+        if telmon_subdir.exists():
+            time.sleep(post_data_delay)
+            break
+
+
+@pytest.mark.parametrize(
+    ["cmd", "missing"],
+    [
+        pytest.param("", {"-exp_dir", "-frequency"}, id="no args"),
+        pytest.param("-exp_dir /foo/bar", {"-frequency"}, id="no freq"),
+        pytest.param("-frequency 123", {"-exp_dir"}, id="no dir"),
+    ],
+)
+def test_parser_reqd_args(capsys, cmd, missing):
+    """Test that the parser reports any missing required arguments"""
+    parser = get_parser()
+
+    args = cmd.split()
+
+    captured = capsys.readouterr()  # throw away existing output
+    with pytest.raises(SystemExit) as ex:
+        ns = parser.parse_args(args)
+
+    captured = capsys.readouterr()
+    assert "the following arguments are required" in captured.err
+    err_desc = captured.err.split("the following arguments are required:")[-1]
+    for arg in missing:
+        assert arg in err_desc
+
+    expected = ALL_ARGS - missing
+    for exp in expected:
+        assert exp not in err_desc
+
+
+def test_parser():
+    """Test that the parser succeeds when receiving expected args"""
+    parser = get_parser()
+
+    test_dir = "/foo/bar"
+    test_freq = "123"
+
+    cmd = f"-exp_dir {test_dir} -frequency {test_freq}"
+    args = cmd.split()
+
+    ns = parser.parse_args(args)
+
+    assert ns.exp_dir == test_dir
+    assert ns.frequency == test_freq
+
+
+def test_ts():
+    """Ensure expected output type"""
+    ts = get_ts()
+    assert isinstance(ts, int)
+
+
+@pytest.mark.parametrize(
+    ["etype", "task_id", "step_id", "timestamp", "evt_type"],
+    [
+        pytest.param(
+            "ensemble", "", "123", get_ts(), "start", id="start event"
+        ),
+        pytest.param(
+            "ensemble", "", "123", get_ts(), "start", id="stop event"
+        ),
+    ],
+)
+def test_track_event(
+    etype: str,
+    task_id: str,
+    step_id: str,
+    timestamp: int,
+    evt_type: str,
+    fileutils,
+):
+    """Ensure that track event writes a file to the expected location"""
+    exp_dir = fileutils.make_test_dir()
+    exp_path = pathlib.Path(exp_dir)
+    track_event(timestamp, task_id, step_id, etype, evt_type, exp_path, logger)
+
+    expected_output = exp_path / f"{evt_type}.json"
+
+    assert expected_output.exists()
+    assert expected_output.is_file()
+
+
+def test_load_manifest(fileutils: FileUtils):
+    """Ensure that the runtime manifest loads correctly"""
+    sample_manifest_path = fileutils.get_test_conf_path("telemetry/telemetry.json")
+    sample_manifest = pathlib.Path(sample_manifest_path)
+    assert sample_manifest.exists()
+
+    test_manifest_path = fileutils.make_test_file(
+        serialize.MANIFEST_FILENAME, serialize.TELMON_SUBDIR, sample_manifest.read_text()
+    )
+    test_manifest = pathlib.Path(test_manifest_path)
+    assert test_manifest.exists()
+
+    manifest = load_manifest(test_manifest_path)
+    assert manifest.name == "my-exp"
+    assert str(manifest.path) == "/lus/cls01029/drozt/playground/ss/dash-int/my-exp"
+    assert manifest.launcher == "Slurm"
+    assert len(manifest.runs) == 6
+
+    assert len(manifest.runs[0].models) == 1
+    assert len(manifest.runs[2].models) == 8  # 8 models in ensemble
+    assert len(manifest.runs[0].orchestrators) == 0
+    assert len(manifest.runs[1].orchestrators) == 3  # 3 shards in db
+    # assert len(manifest.runs[0].ensembles) == 1
+
+
+def test_load_manifest_colo_model(fileutils: FileUtils):
+    """Ensure that the runtime manifest loads correctly when containing a colocated model"""
+    # NOTE: for regeneration, this manifest can use `test_telemetry_colo`
+    sample_manifest_path = fileutils.get_test_conf_path("telemetry/colocatedmodel.json")
+    sample_manifest = pathlib.Path(sample_manifest_path)
+    assert sample_manifest.exists()
+
+    manifest = load_manifest(sample_manifest_path)
+    assert manifest.name == "my-exp"
+    assert str(manifest.path) == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp"
+    assert manifest.launcher == "Slurm"
+    assert len(manifest.runs) == 1
+
+    assert len(manifest.runs[0].models) == 1
+
+
+def test_load_manifest_serial_models(fileutils: FileUtils):
+    """Ensure that the runtime manifest loads correctly when containing multiple models"""
+    # NOTE: for regeneration, this manifest can use `test_telemetry_colo`
+    sample_manifest_path = fileutils.get_test_conf_path("telemetry/serialmodels.json")
+    sample_manifest = pathlib.Path(sample_manifest_path)
+    assert sample_manifest.exists()
+
+    manifest = load_manifest(sample_manifest_path)
+    assert manifest.name == "my-exp"
+    assert str(manifest.path) == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp"
+    assert manifest.launcher == "Slurm"
+    assert len(manifest.runs) == 1
+
+    assert len(manifest.runs[0].models) == 5
+
+
+def test_load_manifest_db_and_models(fileutils: FileUtils):
+    """Ensure that the runtime manifest loads correctly when containing models & orchestrator"""
+    # NOTE: for regeneration, this manifest can use `test_telemetry_colo`
+    sample_manifest_path = fileutils.get_test_conf_path("telemetry/db_and_model.json")
+    sample_manifest = pathlib.Path(sample_manifest_path)
+    assert sample_manifest.exists()
+
+    manifest = load_manifest(sample_manifest_path)
+    assert manifest.name == "my-exp"
+    assert str(manifest.path) == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp"
+    assert manifest.launcher == "Slurm"
+    assert len(manifest.runs) == 2
+
+    assert len(manifest.runs[0].orchestrators) == 1
+    assert len(manifest.runs[1].models) == 1
+
+
+def test_load_manifest_db_and_models_1run(fileutils: FileUtils):
+    """Ensure that the runtime manifest loads correctly when containing models & orchestrator"""
+    # NOTE: for regeneration, this manifest can use `test_telemetry_colo`
+    sample_manifest_path = fileutils.get_test_conf_path("telemetry/db_and_model_1run.json")
+    sample_manifest = pathlib.Path(sample_manifest_path)
+    assert sample_manifest.exists()
+
+    manifest = load_manifest(sample_manifest_path)
+    assert manifest.name == "my-exp"
+    assert str(manifest.path) == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp"
+    assert manifest.launcher == "Slurm"
+    assert len(manifest.runs) == 1
+
+    assert len(manifest.runs[0].orchestrators) == 1
+    assert len(manifest.runs[0].models) == 1
+
+
+@pytest.mark.parametrize(
+    ["task_id", "step_id", "etype", "exp_isorch", "exp_ismanaged"],
+    [
+        pytest.param("123", "", "model", False, False, id="unmanaged, non-orch"),
+        pytest.param("456", "123", "ensemble", False, True, id="managed, non-orch"),
+        pytest.param("789", "987", "orchestrator", True, True, id="managed, orch"),
+        pytest.param("987", "", "orchestrator", True, False, id="unmanaged, orch"),
+    ],
+)
+def test_persistable_computed_properties(
+    task_id: str, step_id: str, etype: str, exp_isorch: bool, exp_ismanaged: bool
+):
+    name = f"test-{etype}-{uuid.uuid4()}"
+    timestamp = get_ts()
+    exp_dir = pathlib.Path("/foo/bar")
+    stored = {
+        "name": name,
+        "run_id": timestamp,
+        "telemetry_metadata": {
+            "status_dir": str(exp_dir),
+            "task_id": task_id,
+            "step_id": step_id,
+        },
+    }
+    persistables = hydrate_persistable(etype, stored, exp_dir)
+    persistable = persistables[0] if persistables else None
+
+    assert persistable.is_managed == exp_ismanaged
+    assert persistable.is_db == exp_isorch
+
+
+def test_deserialize_ensemble(fileutils: FileUtils):
+    """Ensure that the children of ensembles (models) are correctly
+    placed in the models collection"""
+    sample_manifest_path = fileutils.get_test_conf_path("telemetry/ensembles.json")
+    sample_manifest = pathlib.Path(sample_manifest_path)
+    assert sample_manifest.exists()
+
+    manifest = load_manifest(sample_manifest_path)
+    assert manifest
+
+    assert len(manifest.runs) == 1
+
+    # NOTE: no longer returning ensembles, only children...
+    # assert len(manifest.runs[0].ensembles) == 1
+    assert len(manifest.runs[0].models) == 8
+
+
+@pytest.mark.skip(reason="fix in progress")
+def test_shutdown_conditions():
+    """Ensure conditions to shutdown telemetry monitor are correctly evaluated"""
+    job_entity1 = JobEntity()
+    job_entity1.name = "xyz"
+    job_entity1.step_id = "123"
+    job_entity1.task_id = ""
+
+    # show that an event handler w/no monitored jobs can shutdown
+    mani_handler = ManifestEventHandler("xyz", logger)
+    assert can_shutdown(mani_handler)
+
+    # show that an event handler w/a monitored job cannot shutdown
+    mani_handler = ManifestEventHandler("xyz", logger)
+    mani_handler.job_manager.add_job(job_entity1.name,
+                                     job_entity1.step_id,
+                                     job_entity1,
+                                     False)
+    assert not can_shutdown(mani_handler)
+    assert not bool(mani_handler.job_manager.db_jobs)
+    assert bool(mani_handler.job_manager.jobs)
+
+    # show that an event handler w/a monitored db cannot shutdown
+    mani_handler = ManifestEventHandler("xyz", logger)
+    job_entity1.type = "orchestrator"
+    mani_handler.job_manager.add_job(job_entity1.name,
+                                     job_entity1.step_id,
+                                     job_entity1,
+                                     False)
+    assert not can_shutdown(mani_handler)
+    assert bool(mani_handler.job_manager.db_jobs)
+    assert not bool(mani_handler.job_manager.jobs)
+
+    # show that an event handler w/a dbs & tasks cannot shutdown
+    job_entity2 = JobEntity()
+    job_entity2.name = "xyz"
+    job_entity2.step_id = "123"
+    job_entity2.task_id = ""
+
+    mani_handler = ManifestEventHandler("xyz", logger)
+    job_entity1.type = "orchestrator"
+    mani_handler.job_manager.add_job(job_entity1.name,
+                                     job_entity1.step_id,
+                                     job_entity1,
+                                     False)
+
+    mani_handler.job_manager.add_job(job_entity2.name,
+                                    job_entity2.step_id,
+                                    job_entity2,
+                                    False)
+    assert not can_shutdown(mani_handler)
+    assert bool(mani_handler.job_manager.db_jobs)
+    assert bool(mani_handler.job_manager.jobs)
+
+    # ... now, show that removing 1 of 2 jobs still doesn't shutdown
+    mani_handler.job_manager.db_jobs.popitem()
+    assert not can_shutdown(mani_handler)
+
+    # ... now, show that removing final job will allow shutdown
+    mani_handler.job_manager.jobs.popitem()
+    assert can_shutdown(mani_handler)
+
+
+@pytest.mark.skip(reason="fix in progress")
+def test_shutdown_action():
+    """Ensure file system listener is properly shutdown"""
+    class FauxObserver:
+        def __init__(self):
+            self.stop_count = 0
+
+        def stop(self):
+            self.stop_count += 1
+
+    job_entity1 = JobEntity()
+    job_entity1.name = "xyz"
+    job_entity1.step_id = "123"
+    job_entity1.task_id = ""
+
+    # show that an event handler w/no monitored jobs can shutdown
+    mani_handler = ManifestEventHandler("xyz", logger)
+    observer = FauxObserver()
+    shutdown_when_completed(observer, mani_handler)
+    assert observer.stop_count == 1
+
+    # show that an event handler w/a monitored job cannot shutdown
+    mani_handler = ManifestEventHandler("xyz", logger)
+    mani_handler.job_manager.add_job(job_entity1.name,
+                                     job_entity1.step_id,
+                                     job_entity1,
+                                     False)
+    observer = FauxObserver()
+    shutdown_when_completed(observer, mani_handler)
+    assert observer.stop_count == 0
+
+    # show that an event handler w/a monitored db cannot shutdown
+    mani_handler = ManifestEventHandler("xyz", logger)
+    job_entity1.type = "orchestrator"
+    mani_handler.job_manager.add_job(job_entity1.name,
+                                     job_entity1.step_id,
+                                     job_entity1,
+                                     False)
+    observer = FauxObserver()
+    shutdown_when_completed(observer, mani_handler)
+    assert observer.stop_count == 0
+
+    # show that an event handler w/a dbs & tasks cannot shutdown
+    job_entity2 = JobEntity()
+    job_entity2.name = "xyz"
+    job_entity2.step_id = "123"
+    job_entity2.task_id = ""
+
+    mani_handler = ManifestEventHandler("xyz", logger)
+    job_entity1.type = "orchestrator"
+    mani_handler.job_manager.add_job(job_entity1.name,
+                                     job_entity1.step_id,
+                                     job_entity1,
+                                     False)
+
+    mani_handler.job_manager.add_job(job_entity2.name,
+                                    job_entity2.step_id,
+                                    job_entity2,
+                                    False)
+    observer = FauxObserver()
+    shutdown_when_completed(observer, mani_handler)
+    assert observer.stop_count == 0
+
+    # ... now, show that removing 1 of 2 jobs still doesn't shutdown
+    mani_handler.job_manager.db_jobs.popitem()
+    observer = FauxObserver()
+    shutdown_when_completed(observer, mani_handler)
+    assert observer.stop_count == 0
+
+    # ... now, show that removing final job will allow shutdown
+    mani_handler.job_manager.jobs.popitem()
+    observer = FauxObserver()
+    shutdown_when_completed(observer, mani_handler)
+    assert observer.stop_count == 1
+
+
+def test_telemetry_single_model(fileutils, wlmutils):
+    """Test that it is possible to create_database then colocate_db_uds/colocate_db_tcp
+    with unique db_identifiers"""
+
+    # Set experiment name
+    exp_name = "telemetry_single_model"
+
+    # Retrieve parameters from testing environment
+    test_launcher = wlmutils.get_test_launcher()
+    test_dir = fileutils.make_test_dir()
+    test_script = fileutils.get_test_conf_path("echo.py")
+
+    # Create SmartSim Experiment
+    exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
+
+    # create run settings
+    app_settings = exp.create_run_settings("python", test_script)
+    app_settings.set_nodes(1)
+    app_settings.set_tasks_per_node(1)
+
+    #  # Create the SmartSim Model
+    smartsim_model = exp.create_model("perroquet", app_settings)
+    exp.generate(smartsim_model)
+    exp.start(smartsim_model, block=True)
+    assert exp.get_status(smartsim_model)[0] == STATUS_COMPLETED
+
+    telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
+    start_events = list(telemetry_output_path.rglob("start.json"))
+    stop_events = list(telemetry_output_path.rglob("stop.json"))
+
+    assert len(start_events) == 1
+    assert len(stop_events) == 1
+
+
+def test_telemetry_single_model_nonblocking(fileutils, wlmutils, monkeypatch):
+    """Ensure that the telemetry monitor logs exist when the experiment 
+    is non-blocking"""
+    with monkeypatch.context() as ctx:
+        ctx.setattr(cfg.Config, "telemetry_frequency", 1)
+
+        # Set experiment name
+        exp_name = "test_telemetry_single_model_nonblocking"
+
+        # Retrieve parameters from testing environment
+        test_launcher = wlmutils.get_test_launcher()
+        test_dir = fileutils.make_test_dir()
+        test_script = fileutils.get_test_conf_path("echo.py")
+
+        # Create SmartSim Experiment
+        exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
+
+        # create run settings
+        app_settings = exp.create_run_settings("python", test_script)
+        app_settings.set_nodes(1)
+        app_settings.set_tasks_per_node(1)
+
+        #  # Create the SmartSim Model
+        smartsim_model = exp.create_model("perroquet", app_settings)
+        exp.generate(smartsim_model)
+        exp.start(smartsim_model)
+
+        snooze_nonblocking(test_dir, max_delay=60, post_data_delay=30)
+
+        assert exp.get_status(smartsim_model)[0] == STATUS_COMPLETED
+
+        telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
+        start_events = list(telemetry_output_path.rglob("start.json"))
+        stop_events = list(telemetry_output_path.rglob("stop.json"))
+
+        assert len(start_events) == 1
+        assert len(stop_events) == 1
+
+
+def test_telemetry_serial_models(fileutils, wlmutils, monkeypatch):
+    """
+    Test telemetry with models being run in serial (one after each other)
+    """
+    with monkeypatch.context() as ctx:
+        ctx.setattr(cfg.Config, "telemetry_frequency", 1)
+
+        # Set experiment name
+        exp_name = "telemetry_serial_models"
+
+        # Retrieve parameters from testing environment
+        test_launcher = wlmutils.get_test_launcher()
+        test_dir = fileutils.make_test_dir()
+        test_script = fileutils.get_test_conf_path("echo.py")
+
+        # Create SmartSim Experiment
+        exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
+
+        # create run settings
+        app_settings = exp.create_run_settings("python", test_script)
+        app_settings.set_nodes(1)
+        app_settings.set_tasks_per_node(1)
+
+        #  # Create the SmartSim Model
+        smartsim_models = [ exp.create_model(f"perroquet_{i}", app_settings) for i in range(5) ]
+        exp.generate(*smartsim_models)
+        exp.start(*smartsim_models, block=True)
+        assert all([status == STATUS_COMPLETED for status in exp.get_status(*smartsim_models)])
+
+        telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
+        start_events = list(telemetry_output_path.rglob("start.json"))
+        stop_events = list(telemetry_output_path.rglob("stop.json"))
+
+        assert len(start_events) == 5
+        assert len(stop_events) == 5
+
+
+def test_telemetry_serial_models_nonblocking(fileutils, wlmutils, monkeypatch):
+    """
+    Test telemetry with models being run in serial (one after each other)
+    in a non-blocking experiment
+    """
+    with monkeypatch.context() as ctx:
+        ctx.setattr(cfg.Config, "telemetry_frequency", 1)
+    
+        # Set experiment name
+        exp_name = "telemetry_serial_models"
+
+        # Retrieve parameters from testing environment
+        test_launcher = wlmutils.get_test_launcher()
+        test_dir = fileutils.make_test_dir()
+        test_script = fileutils.get_test_conf_path("echo.py")
+
+        # Create SmartSim Experiment
+        exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
+
+        # create run settings
+        app_settings = exp.create_run_settings("python", test_script)
+        app_settings.set_nodes(1)
+        app_settings.set_tasks_per_node(1)
+
+        #  # Create the SmartSim Model
+        smartsim_models = [ exp.create_model(f"perroquet_{i}", app_settings) for i in range(5) ]
+        exp.generate(*smartsim_models)
+        exp.start(*smartsim_models)
+
+        snooze_nonblocking(test_dir, max_delay=60, post_data_delay=10)
+
+        assert all([status == STATUS_COMPLETED for status in exp.get_status(*smartsim_models)])
+
+        telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
+        start_events = list(telemetry_output_path.rglob("start.json"))
+        stop_events = list(telemetry_output_path.rglob("stop.json"))
+
+        assert len(start_events) == 5
+        assert len(stop_events) == 5
+
+
+@pytest.mark.skip(reason="unreliable timing w/WLM")
+def test_telemetry_db_only_with_generate(fileutils, wlmutils, monkeypatch):
+    """
+    Test telemetry with only a database running
+    """
+    with monkeypatch.context() as ctx:
+        ctx.setattr(cfg.Config, "telemetry_frequency", 1)
+
+        # Set experiment name
+        exp_name = "telemetry_db_with_generate"
+
+        # Retrieve parameters from testing environment
+        test_launcher = wlmutils.get_test_launcher()
+        test_interface = wlmutils.get_test_interface()
+        test_port = wlmutils.get_test_port()
+        test_dir = fileutils.make_test_dir()
+
+        # Create SmartSim Experiment
+        exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
+
+        # create regular database
+        orc = exp.create_database(port=test_port, interface=test_interface)
+        exp.generate(orc)
+        try:
+            exp.start(orc, block=True)
+
+            snooze_nonblocking(test_dir, max_delay=90, post_data_delay=45)
+
+            telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
+            start_events = list(telemetry_output_path.rglob("start.json"))
+            stop_events = list(telemetry_output_path.rglob("stop.json"))
+
+            assert len(start_events) == 1
+            assert len(stop_events) <= 1
+        finally:
+            exp.stop(orc)
+            snooze_nonblocking(test_dir, max_delay=30, post_data_delay=10)
+
+        assert exp.get_status(orc)[0] == STATUS_CANCELLED
+
+        stop_events = list(telemetry_output_path.rglob("stop.json"))
+        assert len(stop_events) == 1
+
+
+@pytest.mark.skip(reason="unreliable timing w/WLM")
+def test_telemetry_db_only_without_generate(fileutils, wlmutils, monkeypatch):
+    """
+    Test telemetry with only a database running
+    """
+    with monkeypatch.context() as ctx:
+        ctx.setattr(cfg.Config, "telemetry_frequency", 1)
+
+        # Set experiment name
+        exp_name = "telemetry_db_only_without_generate"
+
+        # Retrieve parameters from testing environment
+        test_launcher = wlmutils.get_test_launcher()
+        test_interface = wlmutils.get_test_interface()
+        test_port = wlmutils.get_test_port()
+        test_dir = fileutils.make_test_dir()
+
+        # Create SmartSim Experiment
+        exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
+
+        # create regular database
+        orc = exp.create_database(port=test_port, interface=test_interface)
+        try:
+            exp.start(orc)
+
+            snooze_nonblocking(test_dir, max_delay=60, post_data_delay=10)
+
+            telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
+            start_events = list(telemetry_output_path.rglob("start.json"))
+            stop_events = list(telemetry_output_path.rglob("stop.json"))
+
+            assert len(start_events) == 1
+            assert len(stop_events) == 0
+        finally:
+            exp.stop(orc)
+        
+        snooze_nonblocking(test_dir, max_delay=60, post_data_delay=30)
+        assert exp.get_status(orc)[0] == STATUS_CANCELLED
+
+        stop_events = list(telemetry_output_path.rglob("stop.json"))
+        assert len(stop_events) == 1
+
+
+@pytest.mark.skip(reason="unreliable timing w/WLM")
+def test_telemetry_db_and_model(fileutils, wlmutils, monkeypatch):
+    """
+    Test telemetry with only a database running
+    """
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(cfg.Config, "telemetry_frequency", 1)
+
+        # Set experiment name
+        exp_name = "telemetry_db_and_model"
+
+        # Retrieve parameters from testing environment
+        test_launcher = wlmutils.get_test_launcher()
+        test_interface = wlmutils.get_test_interface()
+        test_port = wlmutils.get_test_port()
+        test_dir = fileutils.make_test_dir()
+        test_script = fileutils.get_test_conf_path("echo.py")
+
+        # Create SmartSim Experiment
+        exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
+
+        # create regular database
+        orc = exp.create_database(port=test_port, interface=test_interface)
+        try:
+            exp.start(orc)
+
+            snooze_nonblocking(test_dir, max_delay=60, post_data_delay=30)
+
+            # create run settings
+            app_settings = exp.create_run_settings("python", test_script)
+            app_settings.set_nodes(1)
+            app_settings.set_tasks_per_node(1)
+
+            # Create the SmartSim Model
+            smartsim_model = exp.create_model("perroquet", app_settings)
+            exp.generate(smartsim_model)
+            exp.start(smartsim_model, block=True)
+        finally:
+            exp.stop(orc)
+            
+        snooze_nonblocking(test_dir, max_delay=30, post_data_delay=30)
+
+        assert exp.get_status(orc)[0] == STATUS_CANCELLED
+        assert exp.get_status(smartsim_model)[0] == STATUS_COMPLETED
+
+        telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
+
+        start_events = list(telemetry_output_path.rglob("database/**/start.json"))
+        stop_events = list(telemetry_output_path.rglob("database/**/stop.json"))
+
+        assert len(start_events) == 1
+        assert len(stop_events) == 1
+
+        start_events = list(telemetry_output_path.rglob("model/**/start.json"))
+        stop_events = list(telemetry_output_path.rglob("model/**/stop.json"))
+        assert len(start_events) == 1
+        assert len(stop_events) == 1
+
+@pytest.mark.skip(reason="unreliable timing w/WLM")
+def test_telemetry_ensemble(fileutils, wlmutils, monkeypatch):
+    """
+    Test telemetry with only a database running
+    """
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(cfg.Config, "telemetry_frequency", 1)
+
+        # Set experiment name
+        exp_name = "telemetry_ensemble"
+
+        # Retrieve parameters from testing environment
+        test_launcher = wlmutils.get_test_launcher()
+        test_dir = fileutils.make_test_dir()
+        test_script = fileutils.get_test_conf_path("echo.py")
+
+        # Create SmartSim Experiment
+        exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
+
+        app_settings = exp.create_run_settings("python", test_script)
+        app_settings.set_nodes(1)
+        app_settings.set_tasks_per_node(1)
+
+        ens = exp.create_ensemble("troupeau", run_settings=app_settings, replicas=5)
+        exp.generate(ens)
+        exp.start(ens, block=True)
+        assert all([status == STATUS_COMPLETED for status in exp.get_status(ens)])
+
+        snooze_nonblocking(test_dir, max_delay=60, post_data_delay=30)
+        telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
+        start_events = list(telemetry_output_path.rglob("start.json"))
+        stop_events = list(telemetry_output_path.rglob("stop.json"))
+
+        assert len(start_events) == 5
+        assert len(stop_events) == 5
+
+
+def test_telemetry_colo(fileutils, wlmutils, coloutils, monkeypatch):
+    """
+    Test telemetry with only a database running
+    """
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(cfg.Config, "telemetry_frequency", 1)
+
+        # Set experiment name
+        exp_name = "telemetry_ensemble"
+
+        # Retrieve parameters from testing environment
+        test_launcher = wlmutils.get_test_launcher()
+        test_dir = fileutils.make_test_dir()
+
+        # Create SmartSim Experiment
+        exp = Experiment(exp_name, launcher=test_launcher, exp_path=test_dir)
+
+        smartsim_model = coloutils.setup_test_colo(
+            fileutils,
+            "uds",
+            exp,
+            "echo.py",
+            {},
+        )
+
+        exp.generate(smartsim_model)
+        exp.start(smartsim_model, block=True)
+        assert all([status == STATUS_COMPLETED for status in exp.get_status(smartsim_model)])
+
+        telemetry_output_path = pathlib.Path(test_dir) / serialize.TELMON_SUBDIR
+        start_events = list(telemetry_output_path.rglob("start.json"))
+        stop_events = list(telemetry_output_path.rglob("stop.json"))
+
+        # the colodb does NOT show up as a unique entity in the telemetry
+        assert len(start_events) == 1
+        assert len(stop_events) == 1

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -205,7 +205,7 @@ def test_load_manifest(fileutils: FileUtils):
 
     manifest = load_manifest(test_manifest_path)
     assert manifest.name == "my-exp"
-    assert str(manifest.path) == "/lus/cls01029/drozt/playground/ss/dash-int/my-exp"
+    assert str(manifest.path) == "/path/to/my-exp"
     assert manifest.launcher == "Slurm"
     assert len(manifest.runs) == 6
 
@@ -226,7 +226,7 @@ def test_load_manifest_colo_model(fileutils: FileUtils):
     assert manifest.name == "my-exp"
     assert (
         str(manifest.path)
-        == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_load_manifest_colo_model/my-exp"
+        == "/tmp/my-exp"
     )
     assert manifest.launcher == "Slurm"
     assert len(manifest.runs) == 1
@@ -243,10 +243,7 @@ def test_load_manifest_serial_models(fileutils: FileUtils):
 
     manifest = load_manifest(sample_manifest_path)
     assert manifest.name == "my-exp"
-    assert (
-        str(manifest.path)
-        == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_serial_models/my-exp"
-    )
+    assert str(manifest.path) == "/tmp/my-exp"
     assert manifest.launcher == "Slurm"
     assert len(manifest.runs) == 1
 
@@ -263,10 +260,7 @@ def test_load_manifest_db_and_models(fileutils: FileUtils):
 
     manifest = load_manifest(sample_manifest_path)
     assert manifest.name == "my-exp"
-    assert (
-        str(manifest.path)
-        == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp"
-    )
+    assert str(manifest.path) == "/tmp/my-exp"
     assert manifest.launcher == "Slurm"
     assert len(manifest.runs) == 2
 
@@ -286,10 +280,7 @@ def test_load_manifest_db_and_models_1run(fileutils: FileUtils):
 
     manifest = load_manifest(sample_manifest_path)
     assert manifest.name == "my-exp"
-    assert (
-        str(manifest.path)
-        == "/lus/cls01029/mcbridch/ss/tests/test_output/test_telemetry_monitor/test_telemetry_db_and_model/my-exp"
-    )
+    assert str(manifest.path) == "/tmp/my-exp"
     assert manifest.launcher == "Slurm"
     assert len(manifest.runs) == 1
 


### PR DESCRIPTION
Add support for producing & consuming dashboard outputs.

- Adds `telemetry monitor` to check for updates and produce events for the dashboard
- Updates `controller` to conditionally start `telemetry monitor`
- Updates `controller` to produce a runtime manifest to trigger telemetry collection
- Adds `indirect proxy` to produce events for the dashboard for unmanaged tasks
- Adds CLI capability to launch dashboard