### PR TITLE
handle interrupt, avoid displaying stack trace

### DIFF
--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -45,11 +45,11 @@ def main() -> int:
     except SmartSimInterrupt as ssi:
         logger.debug(ssi, exc_info=True)
         print(ssi)
-    except KeyboardInterrupt as ki:
+    except KeyboardInterrupt:
         msg = "SmartSim was terminated by user"
         logger.debug(msg, exc_info=True)
         print(msg)
-    
+
     return 0
 
 

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -27,11 +27,12 @@
 import sys
 
 from smartsim._core._cli.cli import default_cli
+from smartsim._core._cli.utils import SMART_LOGGER_FORMAT
 from smartsim.error.errors import SmartSimCLIActionCancelled
 from smartsim.log import get_logger
 
 
-logger = get_logger(__name__)
+logger = get_logger("Smart", fmt=SMART_LOGGER_FORMAT)
 
 
 def main() -> int:

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -42,11 +42,11 @@ def main() -> int:
         return smart_cli.execute(sys.argv)
     except SmartSimCLIActionCancelled as ssi:
         logger.debug(ssi, exc_info=True)
-        print(ssi)
+        logger.info(ssi)
     except KeyboardInterrupt:
         msg = "SmartSim was terminated by user"
         logger.debug(msg, exc_info=True)
-        print(msg)
+        logger.info(msg)
 
     return 0
 

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -28,7 +28,7 @@ import logging
 import sys
 
 from smartsim._core._cli.cli import default_cli
-from smartsim.error.errors import SmartSimInterrupt
+from smartsim.error.errors import SmartSimCLIActionCancelled
 from smartsim.log import _get_log_level
 
 
@@ -42,7 +42,7 @@ def main() -> int:
 
     try:
         return smart_cli.execute(sys.argv)
-    except SmartSimInterrupt as ssi:
+    except SmartSimCLIActionCancelled as ssi:
         logger.debug(ssi, exc_info=True)
         print(ssi)
     except KeyboardInterrupt:

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -24,10 +24,17 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import sys
 
 from smartsim._core._cli.cli import default_cli
 from smartsim.error.errors import SmartSimInterrupt
+from smartsim.log import _get_log_level
+
+
+logger = logging.getLogger(__name__)
+logger.propagate = False
+logger.setLevel(_get_log_level().upper())
 
 
 def main() -> int:
@@ -36,9 +43,12 @@ def main() -> int:
     try:
         return smart_cli.execute(sys.argv)
     except SmartSimInterrupt as ssi:
+        logger.debug(ssi, exc_info=True)
         print(ssi)
     except KeyboardInterrupt as ki:
-        print("SmartSim was terminated by user")
+        msg = "SmartSim was terminated by user"
+        logger.debug(msg, exc_info=True)
+        print(msg)
     
     return 0
 

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -27,6 +27,7 @@
 import sys
 
 from smartsim._core._cli.cli import default_cli
+from smartsim.error.errors import SmartSimInterrupt
 
 
 def main() -> int:
@@ -34,9 +35,12 @@ def main() -> int:
 
     try:
         return smart_cli.execute(sys.argv)
-    except KeyboardInterrupt:
-        print("Dashboard terminated by user")
-        return 0
+    except SmartSimInterrupt as ssi:
+        print(ssi)
+    except KeyboardInterrupt as ki:
+        print("SmartSim was terminated by user")
+    
+    return 0
 
 
 if __name__ == "__main__":

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -32,7 +32,11 @@ from smartsim._core._cli.cli import default_cli
 def main() -> int:
     smart_cli = default_cli()
 
-    return smart_cli.execute(sys.argv)
+    try:
+        return smart_cli.execute(sys.argv)
+    except KeyboardInterrupt:
+        print("Dashboard terminated by user")
+        return 1
 
 
 if __name__ == "__main__":

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -24,17 +24,14 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import logging
 import sys
 
 from smartsim._core._cli.cli import default_cli
 from smartsim.error.errors import SmartSimCLIActionCancelled
-from smartsim.log import _get_log_level
+from smartsim.log import get_logger
 
 
-logger = logging.getLogger(__name__)
-logger.propagate = False
-logger.setLevel(_get_log_level().upper())
+logger = get_logger(__name__)
 
 
 def main() -> int:

--- a/smartsim/_core/_cli/__main__.py
+++ b/smartsim/_core/_cli/__main__.py
@@ -36,7 +36,7 @@ def main() -> int:
         return smart_cli.execute(sys.argv)
     except KeyboardInterrupt:
         print("Dashboard terminated by user")
-        return 1
+        return 0
 
 
 if __name__ == "__main__":

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -8,7 +8,9 @@ from smartsim._core._cli.utils import MenuItemConfig
 from smartsim.error.errors import SmartSimInterrupt
 
 
-def dynamic_execute(cmd: str, plugin_name: str) -> t.Callable[[argparse.Namespace, t.List[str]], int]:
+def dynamic_execute(
+    cmd: str, plugin_name: str
+) -> t.Callable[[argparse.Namespace, t.List[str]], int]:
     def process_execute(
         _args: argparse.Namespace, unparsed_args: t.List[str], /
     ) -> int:
@@ -22,7 +24,7 @@ def dynamic_execute(cmd: str, plugin_name: str) -> t.Callable[[argparse.Namespac
             return 1
 
         combined_cmd = [sys.executable, "-m", cmd] + unparsed_args
-        
+
         try:
             with sp.Popen(combined_cmd, stdout=sp.PIPE, stderr=sp.PIPE) as process:
                 stdout, _ = process.communicate()

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -5,7 +5,7 @@ import subprocess as sp
 import typing as t
 
 from smartsim._core._cli.utils import MenuItemConfig
-from smartsim.error.errors import SmartSimInterrupt
+from smartsim.error.errors import SmartSimCLIActionCancelled
 
 
 def dynamic_execute(
@@ -36,7 +36,7 @@ def dynamic_execute(
                 return process.returncode
         except KeyboardInterrupt as ex:
             msg = f"{plugin_name} terminated by user"
-            raise SmartSimInterrupt(msg) from ex
+            raise SmartSimCLIActionCancelled(msg) from ex
 
     return process_execute
 

--- a/smartsim/_core/_cli/plugin.py
+++ b/smartsim/_core/_cli/plugin.py
@@ -5,9 +5,10 @@ import subprocess as sp
 import typing as t
 
 from smartsim._core._cli.utils import MenuItemConfig
+from smartsim.error.errors import SmartSimInterrupt
 
 
-def dynamic_execute(cmd: str) -> t.Callable[[argparse.Namespace, t.List[str]], int]:
+def dynamic_execute(cmd: str, plugin_name: str) -> t.Callable[[argparse.Namespace, t.List[str]], int]:
     def process_execute(
         _args: argparse.Namespace, unparsed_args: t.List[str], /
     ) -> int:
@@ -21,14 +22,19 @@ def dynamic_execute(cmd: str) -> t.Callable[[argparse.Namespace, t.List[str]], i
             return 1
 
         combined_cmd = [sys.executable, "-m", cmd] + unparsed_args
-        with sp.Popen(combined_cmd, stdout=sp.PIPE, stderr=sp.PIPE) as process:
-            stdout, _ = process.communicate()
-            while process.returncode is None:
+        
+        try:
+            with sp.Popen(combined_cmd, stdout=sp.PIPE, stderr=sp.PIPE) as process:
                 stdout, _ = process.communicate()
+                while process.returncode is None:
+                    stdout, _ = process.communicate()
 
-            plugin_stdout = stdout.decode("utf-8")
-            print(plugin_stdout)
-            return process.returncode
+                plugin_stdout = stdout.decode("utf-8")
+                print(plugin_stdout)
+                return process.returncode
+        except KeyboardInterrupt as ex:
+            msg = f"{plugin_name} terminated by user"
+            raise SmartSimInterrupt(msg) from ex
 
     return process_execute
 
@@ -37,7 +43,7 @@ def dashboard() -> MenuItemConfig:
     return MenuItemConfig(
         "dashboard",
         "Start the SmartSim dashboard",
-        dynamic_execute("smartdashboard.Experiment_Overview"),
+        dynamic_execute("smartdashboard.Experiment_Overview", "Dashboard"),
         is_plugin=True,
     )
 

--- a/smartsim/error/errors.py
+++ b/smartsim/error/errors.py
@@ -143,4 +143,4 @@ class UnproxyableStepError(TelemetryError):
     """
 
 class SmartSimCLIActionCancelled(SmartSimError):
-    """Raised when the SmartSim application is terminated"""
+    """Raised when a `smart` CLI command is terminated"""

--- a/smartsim/error/errors.py
+++ b/smartsim/error/errors.py
@@ -141,3 +141,7 @@ class UnproxyableStepError(TelemetryError):
     """Raised when a user attempts to proxy a managed ``Step`` through the
     unmanaged step proxy entry point
     """
+
+class SmartSimInterrupt(SmartSimError):
+    """Raised when the SmartSim application is terminated"""
+

--- a/smartsim/error/errors.py
+++ b/smartsim/error/errors.py
@@ -144,4 +144,3 @@ class UnproxyableStepError(TelemetryError):
 
 class SmartSimInterrupt(SmartSimError):
     """Raised when the SmartSim application is terminated"""
-

--- a/smartsim/error/errors.py
+++ b/smartsim/error/errors.py
@@ -142,5 +142,5 @@ class UnproxyableStepError(TelemetryError):
     unmanaged step proxy entry point
     """
 
-class SmartSimInterrupt(SmartSimError):
+class SmartSimCLIActionCancelled(SmartSimError):
     """Raised when the SmartSim application is terminated"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -368,7 +368,7 @@ def test_cli_plugin_invalid(capsys: pytest.CaptureFixture, monkeypatch: pytest.M
         lambda: MenuItemConfig(
             "dashboard",
             "Start the SmartSim dashboard",
-            plugin.dynamic_execute(plugin_module),
+            plugin.dynamic_execute(plugin_module, "Dashboard!"),
             is_plugin=True,
         )
     ]


### PR DESCRIPTION
Users terminating the dashboard via ctrl-c are currently shown a stacktrace:

```
(ss39) ankona@horizon:/lus/cls01029/ankona/ss> smart dashboard           
^CTraceback (most recent call last):
  File "/lus/cls01029/ankona/.pyenv/versions/ss39/bin/smart", line 8, in <module>
    sys.exit(main())
  File "/lus/cls01029/ankona/ss/smartsim/_core/_cli/__main__.py", line 36, in main
    return smart_cli.execute(sys.argv)
  File "/lus/cls01029/ankona/ss/smartsim/_core/_cli/cli.py", line 87, in execute
    return menu_item.handler(args, unparsed_args)
  File "/lus/cls01029/ankona/ss/smartsim/_core/_cli/plugin.py", line 25, in process_execute
    stdout, _ = process.communicate()
  File "/lus/cls01029/ankona/.pyenv/versions/3.9.18/lib/python3.9/subprocess.py", line 1134, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/lus/cls01029/ankona/.pyenv/versions/3.9.18/lib/python3.9/subprocess.py", line 1995, in _communicate
    ready = selector.select(timeout)
  File "/lus/cls01029/ankona/.pyenv/versions/3.9.18/lib/python3.9/selectors.py", line 416, in select
    fd_event_list = self._selector.poll(timeout)
KeyboardInterrupt
```

This fix catches the `KeyboardInterrupt` and shuts down gracefully with an appropriate message:

```
(ss39) ankona@horizon:/lus/cls01029/ankona/ss> smart dashboard
^CDashboard terminated by user
(ss39) ankona@horizon:/lus/cls01029/ankona/ss> 
```
