### PR TITLE
Add concurrency group to test workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,6 +34,10 @@ on:
     branches:
       - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   HOMEBREW_NO_ANALYTICS: "ON" # Make Homebrew installation a little quicker
   HOMEBREW_NO_AUTO_UPDATE: "ON"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -59,7 +59,6 @@ jobs:
         rai: [1.2.7] # Redis AI versions
         py_v: [3.8, 3.9, '3.10'] # Python versions
 
-
     env:
       SMARTSIM_REDISAI: ${{ matrix.rai }}
 


### PR DESCRIPTION
This PR adds concurrency groups to GitHub's CI/CD workflows, preventing multiple workflows from the same PR to be launched concurrently.