### PR TITLE
Test Docs: Update Number of Required Nodes

### DIFF
--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -66,23 +66,23 @@ of the tests located within the ``on_wlm`` directory.
 
 To run the ``on_wlm`` test suite, users will have to be on a system
 with one of the supported workload managers. Additionally, users will
-need to obtain an allocation of **at least 3 nodes**.
+need to obtain an allocation of **at least 4 nodes**.
 
 Examples of how to obtain allocations on systems with the launchers:
 
 .. code:: bash
 
   # for slurm (with srun)
-  salloc -N 3 -A account --exclusive -t 00:10:00
+  salloc -N 4 -A account --exclusive -t 00:10:00
 
   # for PBSPro (with aprun)
-  qsub -l select=3 -l place=scatter -l walltime=00:10:00 -q queue
+  qsub -l select=4 -l place=scatter -l walltime=00:10:00 -q queue
 
   # for Cobalt (with aprun)
-  qsub -n 3 -t 00:10:00 -A account -q queue -I
+  qsub -n 4 -t 00:10:00 -A account -q queue -I
 
   # for LSF (with jsrun)
-  bsub -Is -W 00:30 -nnodes 3 -P project $SHELL
+  bsub -Is -W 00:30 -nnodes 4 -P project $SHELL
 
 Values for queue, account, or project should be substituted appropriately.
 
@@ -123,7 +123,7 @@ A full example on an internal SLURM system
 
 .. code:: bash
 
-  salloc -N 3 -A account --exclusive -t 03:00:00
+  salloc -N 4 -A account --exclusive -t 03:00:00
   export SMARTSIM_TEST_LAUNCHER=slurm
   export SMARTSIM_TEST_INTERFACE=ipogif0
   export SMARTSIM_TEST_DEVICE=gpu


### PR DESCRIPTION
Bumps the required number of nodes in the test docs from 3 to 4 as required by the tests in #381 and #426.