### PR TITLE
Fix index when installing torch through smart build

### DIFF
--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -229,6 +229,7 @@ def build_redis_ai(
 def check_py_torch_version(versions: Versioner, device: _TDeviceStr = "cpu") -> None:
     """Check Python environment for TensorFlow installation"""
 
+    device = device.lower()
     if BuildEnv.is_macos():
         if device == "gpu":
             raise BuildError("SmartSim does not support GPU on MacOS")
@@ -260,15 +261,11 @@ def check_py_torch_version(versions: Versioner, device: _TDeviceStr = "cpu") -> 
             "Torch version not found in python environment. "
             "Attempting to install via `pip`"
         )
-        if device.lower() == "cpu":
-            index_url = "https://download.pytorch.org/whl/cpu"
-        else:
-            index_url = f"https://download.pytorch.org/whl/{device_suffix}"
-
+        wheel_device = device if device == "cpu" else device_suffix
         pip(
             "install",
             "--extra-index-url",
-            index_url,
+            f"https://download.pytorch.org/whl/{wheel_device}"
             *(f"{package}=={version}" for package, version in torch_deps.items()),
         )
     elif missing or conflicts:

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -226,10 +226,10 @@ def build_redis_ai(
         logger.info("ML Backends and RedisAI build complete!")
 
 
-def check_py_torch_version(versions: Versioner, device: _TDeviceStr = "cpu") -> None:
+def check_py_torch_version(versions: Versioner, device_in: _TDeviceStr = "cpu") -> None:
     """Check Python environment for TensorFlow installation"""
 
-    device = device.lower()
+    device = device_in.lower()
     if BuildEnv.is_macos():
         if device == "gpu":
             raise BuildError("SmartSim does not support GPU on MacOS")

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -260,10 +260,15 @@ def check_py_torch_version(versions: Versioner, device: _TDeviceStr = "cpu") -> 
             "Torch version not found in python environment. "
             "Attempting to install via `pip`"
         )
+        if device.lower() == "cpu":
+            index_url = "https://download.pytorch.org/whl/cpu"
+        else:
+            index_url = f"https://download.pytorch.org/whl/{device_suffix}"
+
         pip(
             "install",
-            "-f",
-            "https://download.pytorch.org/whl/torch_stable.html",
+            "--extra-index-url",
+            index_url,
             *(f"{package}=={version}" for package, version in torch_deps.items()),
         )
     elif missing or conflicts:

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -261,11 +261,11 @@ def check_py_torch_version(versions: Versioner, device: _TDeviceStr = "cpu") -> 
             "Torch version not found in python environment. "
             "Attempting to install via `pip`"
         )
-        wheel_device = device if device == "cpu" else device_suffix
+        wheel_device = device if device == "cpu" else device_suffix.replace("+","")
         pip(
             "install",
             "--extra-index-url",
-            f"https://download.pytorch.org/whl/{wheel_device}"
+            f"https://download.pytorch.org/whl/{wheel_device}",
             *(f"{package}=={version}" for package, version in torch_deps.items()),
         )
     elif missing or conflicts:


### PR DESCRIPTION
Torch changed something in their indexing when trying to install from their provided wheels. This updates the `pip install` command within `smart build` to ensure that the appropriate packages can be found.