### PR TITLE
Override sphinx-tabs background color

### DIFF
--- a/doc/_static/custom_tab_style.css
+++ b/doc/_static/custom_tab_style.css
@@ -2,6 +2,6 @@
     background-color: inherit;
 }
 
-.sphinx-tabs-tab {
+.sphinx-tabs-tab[aria-selected="true"] {
     background-color: inherit;
 }

--- a/doc/_static/custom_tab_style.css
+++ b/doc/_static/custom_tab_style.css
@@ -1,0 +1,7 @@
+.sphinx-tabs-panel {
+    background-color: inherit;
+}
+
+.sphinx-tabs-tab {
+    background-color: inherit;
+}

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,6 +17,17 @@ Development branch
 
 To be released at some future point in time
 
+- Override the sphinx-tabs extension background color
+
+Detailed Notes
+
+- The sphinx-tabs documentation extension uses a white background for the tabs component.
+  A custom CSS for those components to inherit the overall theme color has
+  been added. (SmartSim-PR453_)
+
+.. _SmartSim-PR453: https://github.com/CrayLabs/SmartSim/pull/453
+
+
 
 0.6.0
 -----

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -100,6 +100,11 @@ html_theme_options = {
     "extra_footer": extra_footer,
 }
 
+# Use a custom style sheet to avoid the sphinx-tabs extension from using
+# white background with dark themes.  If sphinx-tabs updates its
+# static/tabs.css, this may need to be updated.
+html_css_files = ['custom_tab_style.css']
+
 autoclass_content = 'both'
 add_module_names = False
 


### PR DESCRIPTION
The sphinx-tabs documentation extension uses a white background for the tabs component.  This causes readability issues with the theme that we have chosen.  This PR overrides the CSS for those components to inherit the overall theme color.