### PR TITLE
Quality of life `smart validate` Improvements

### DIFF
--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -160,12 +160,12 @@ def test_install(
         if with_pt:
             logger.info("Verifying Torch Backend")
             _test_torch_install(client, device)
-        if with_tf:
-            logger.info("Verifying TensorFlow Backend")
-            _test_tf_install(client, location, device)
         if with_onnx:
             logger.info("Verifying ONNX Backend")
             _test_onnx_install(client, device)
+        if with_tf:  # Run last in case TF locks an entire GPU
+            logger.info("Verifying TensorFlow Backend")
+            _test_tf_install(client, location, device)
         logger.info("Success!")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -828,3 +828,33 @@ def test_cli_validation_test_execute(
 
     assert expected_stdout in caplog.text
     assert actual_retval == expected_retval
+
+
+def test_validate_correctly_sets_and_restores_env(monkeypatch):
+    monkeypatch.setenv("FOO", "BAR")
+    monkeypatch.setenv("SPAM", "EGGS")
+    monkeypatch.delenv("TICK", raising=False)
+    monkeypatch.delenv("DNE", raising=False)
+
+    assert os.environ["FOO"] == "BAR"
+    assert os.environ["SPAM"] == "EGGS"
+    assert "TICK" not in os.environ
+    assert "DNE" not in os.environ
+
+    with smartsim._core._cli.validate._env_vars_set_to(
+        {
+            "FOO": "BAZ",  # Redefine
+            "SPAM": None,  # Delete
+            "TICK": "TOCK",  # Add
+            "DNE": None,  # Delete already missing
+        }
+    ):
+        assert os.environ["FOO"] == "BAZ"
+        assert "SPAM" not in os.environ
+        assert os.environ["TICK"] == "TOCK"
+        assert "DNE" not in os.environ
+
+    assert os.environ["FOO"] == "BAR"
+    assert os.environ["SPAM"] == "EGGS"
+    assert "TICK" not in os.environ
+    assert "DNE" not in os.environ


### PR DESCRIPTION
Quality of life `smart validate` improvements:
- Set `CUDA_VISIBLE_DEVICES` environment variable within `smart validate` prior to importing any ML deps to prevent false negatives on multi-GPU systems
- Move SmartRedis logs from standard out to dedicated log file in the validation temporary directory
- Suppress `sklearn` deprecation warning by pinning `KMeans` constructor argument