### PR TITLE
Relax typing extensions required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ extras_require = {
         "types-tqdm",
         "types-tensorflow==2.12.0.9",
         "types-setuptools",
-        "typing_extensions>=4.9.0",
+        "typing_extensions>=4.1.0",
     ],
     # see smartsim/_core/_install/buildenv.py for more details
     **versions.ml_extras_required()


### PR DESCRIPTION
Relaxes the required version `typing_extensions` to prevent the following error when `pip` installing via `pip install -e /path/to/local/smarsim[dev,ml,mypy]`
```sh
(venv) [drozt@hostname ss]$ pip install -e .[dev,ml,mypy]
# ... abridged ...
ERROR: Cannot install smartsim and smartsim[dev,ml,mypy]==0.6.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    smartsim[dev,ml,mypy] 0.6.0 depends on typing-extensions>=4.9.0; extra == "mypy"
    black 24.1a1 depends on typing-extensions>=4.0.1; python_version < "3.11"
    onnx 1.14.1 depends on typing-extensions>=3.6.2.1
    tensorflow 2.13.1 depends on typing-extensions<4.6.0 and >=3.6.6

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```