### PR TITLE
Python 3.11 Support

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -57,7 +57,7 @@ jobs:
         os: [macos-12, ubuntu-20.04] # Operating systems
         compiler: [8] # GNU compiler version
         rai: [1.2.7] # Redis AI versions
-        py_v: [3.8, 3.9, '3.10'] # Python versions
+        py_v: ['3.8', '3.9', '3.10', '3.11'] # Python versions
 
     env:
       SMARTSIM_REDISAI: ${{ matrix.rai }}
@@ -104,10 +104,8 @@ jobs:
       # on developments of the client are brought in.
       - name: Install SmartSim (with ML backends)
         run: |
-
           python -m pip install git+https://github.com/CrayLabs/SmartRedis.git@develop#egg=smartredis
           python -m pip install .[dev,ml]
-
 
       - name: Install ML Runtimes with Smart (with pt, tf, and onnx support)
         run: smart build --device cpu --onnx -v

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,6 +24,7 @@ Description
 - Override the sphinx-tabs extension background color
 - Updated SmartSim's machine learning backends
 - Added ONNX support for Python 3.10
+- Added support for Python 3.11
 
 Detailed Notes
 
@@ -37,14 +38,16 @@ Detailed Notes
   been added. (SmartSim-PR453_)
 - Updated SmartSim's machine learning backends to PyTorch 2.0.1, Tensorflow
   2.13.1, ONNX 1.14.1, and ONNX Runtime 1.16.1. As a result of this change,
-  there is now an available ONNX wheel for use with Python 3.10.
-  (SmartSim-PR451_)
+  there is now an available ONNX wheel for use with Python 3.10, and wheels for
+  all of SmartSim's machine learning backends with Python 3.11.
+  (SmartSim-PR451_) (SmartSim-PR461_)
 
 
 .. _SmartSim-PR446: https://github.com/CrayLabs/SmartSim/pull/446
 .. _SmartSim-PR448: https://github.com/CrayLabs/SmartSim/pull/448
 .. _SmartSim-PR451: https://github.com/CrayLabs/SmartSim/pull/451
 .. _SmartSim-PR453: https://github.com/CrayLabs/SmartSim/pull/453
+.. _SmartSim-PR461: https://github.com/CrayLabs/SmartSim/pull/461
 
 
 0.6.0

--- a/doc/installation_instructions/basic.rst
+++ b/doc/installation_instructions/basic.rst
@@ -18,7 +18,7 @@ Basic
 
 The base prerequisites to install SmartSim and SmartRedis are:
 
-  - Python 3.8-3.10
+  - Python 3.8-3.11
   - Pip
   - Cmake 3.13.x (or later)
   - C compiler
@@ -65,11 +65,11 @@ Supported Versions
    * - MacOS
      - x86_64
      - Not supported
-     - 3.8 - 3.10
+     - 3.8 - 3.11
    * - Linux
      - x86_64
      - Nvidia
-     - 3.8 - 3.10
+     - 3.8 - 3.11
 
 
 .. note::
@@ -241,9 +241,9 @@ SmartSim does.
    * - Platform
      - Python Versions
    * - MacOS
-     - 3.8 - 3.10
+     - 3.8 - 3.11
    * - Linux
-     - 3.8 - 3.10
+     - 3.8 - 3.11
 
 The Python client for SmartRedis is installed through ``pip`` as follows:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: BSD License
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering
@@ -55,7 +56,7 @@ setup_requires =
     setuptools>=39.2
     cmake>=3.13
 include_package_data = True
-python_requires = >=3.8,<3.11
+python_requires = >=3.8,<3.12
 
 [options.packages.find]
 include =

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -175,13 +175,13 @@ def test_context_leak(test_dir: str, turn_on_tm, monkeypatch):
         with monkeypatch.context() as ctx:
             ctx.setattr(smartsim._core.control.jobmanager.JobManager, "start", thrower)
             exp = Experiment("MyExperiment", launcher="local", exp_path=str(test_dir))
-            exp.generate()  # did not affect output dirs on step
 
             sleep_rs = exp.create_run_settings("sleep", ["2"])
             sleep_rs.set_nodes(1)
             sleep_rs.set_tasks(1)
 
             sleep = exp.create_model("SleepModel", sleep_rs)
+            exp.generate(sleep)
             exp.start(sleep, block=True)
     except Exception as ex:
         assert err_msg in ex.args


### PR DESCRIPTION
Adds Python 3.11 to the SmartSim support matrix.

---

TODO before merge:
- [x] Run the full test suite against a super (I was running into "invalid instruction" problems earlier when attempting to start redis through SmartSim. Back of the envelope math says this should be unrelated to Python 3.11 support, there is a good chance I misconfigured my environment, but it's still good practice to check!)
- [x] Run the backends test against a machine with GPUs (again, back of the envelope says they _should_ be fine, but doesn't hurt to confirm!)
- [x] Update the change log!