### PR TITLE
Validate Slurm Timing format

### DIFF
--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -322,11 +322,11 @@ class RunSettings(SettingsBase):
         :type seconds: int
         """
         return self.set_walltime(
-            self.fmt_walltime(int(hours), int(minutes), int(seconds))
+            self._fmt_walltime(int(hours), int(minutes), int(seconds))
         )
 
     @staticmethod
-    def fmt_walltime(hours: int, minutes: int, seconds: int) -> str:
+    def _fmt_walltime(hours: int, minutes: int, seconds: int) -> str:
         """Convert hours, minutes, and seconds into valid walltime format
 
         By defualt the formatted wall time is the total number of seconds.

--- a/smartsim/settings/base.py
+++ b/smartsim/settings/base.py
@@ -322,11 +322,11 @@ class RunSettings(SettingsBase):
         :type seconds: int
         """
         return self.set_walltime(
-            self._fmt_walltime(int(hours), int(minutes), int(seconds))
+            self.fmt_walltime(int(hours), int(minutes), int(seconds))
         )
 
     @staticmethod
-    def _fmt_walltime(hours: int, minutes: int, seconds: int) -> str:
+    def fmt_walltime(hours: int, minutes: int, seconds: int) -> str:
         """Convert hours, minutes, and seconds into valid walltime format
 
         By defualt the formatted wall time is the total number of seconds.

--- a/smartsim/settings/slurmSettings.py
+++ b/smartsim/settings/slurmSettings.py
@@ -244,7 +244,7 @@ class SrunSettings(RunSettings):
         self.run_args["bcast"] = dest_path
 
     @staticmethod
-    def _fmt_walltime(hours: int, minutes: int, seconds: int) -> str:
+    def fmt_walltime(hours: int, minutes: int, seconds: int) -> str:
         """Convert hours, minutes, and seconds into valid walltime format
 
         Converts time to format HH:MM:SS

--- a/smartsim/settings/slurmSettings.py
+++ b/smartsim/settings/slurmSettings.py
@@ -244,7 +244,7 @@ class SrunSettings(RunSettings):
         self.run_args["bcast"] = dest_path
 
     @staticmethod
-    def fmt_walltime(hours: int, minutes: int, seconds: int) -> str:
+    def _fmt_walltime(hours: int, minutes: int, seconds: int) -> str:
         """Convert hours, minutes, and seconds into valid walltime format
 
         Converts time to format HH:MM:SS
@@ -256,13 +256,9 @@ class SrunSettings(RunSettings):
         :param seconds: number of seconds to run job
         :type seconds: int
         :returns: Formatted walltime
-        :rtype
+        :rtype: str
         """
-        delta = datetime.timedelta(hours=hours, minutes=minutes, seconds=seconds)
-        fmt_str = str(delta)
-        if delta.seconds // 3600 < 10:
-            fmt_str = "0" + fmt_str
-        return fmt_str
+        return fmt_walltime(hours, minutes, seconds)
 
     def set_walltime(self, walltime: str) -> None:
         """Set the walltime of the job
@@ -388,6 +384,27 @@ class SrunSettings(RunSettings):
             compound_env.extend(compound_mpmd_fmt)
 
         return fmt_exported_env, compound_env
+
+
+def fmt_walltime(hours: int, minutes: int, seconds: int) -> str:
+    """Helper function walltime format conversion
+
+    Converts time to format HH:MM:SS
+
+    :param hours: number of hours to run job
+    :type hours: int
+    :param minutes: number of minutes to run job
+    :type minutes: int
+    :param seconds: number of seconds to run job
+    :type seconds: int
+    :returns: Formatted walltime
+    :rtype: str
+    """
+    delta = datetime.timedelta(hours=hours, minutes=minutes, seconds=seconds)
+    fmt_str = str(delta)
+    if delta.seconds // 3600 < 10:
+        fmt_str = "0" + fmt_str
+    return fmt_str
 
 
 class SbatchSettings(BatchSettings):

--- a/smartsim/wlm/slurm.py
+++ b/smartsim/wlm/slurm.py
@@ -24,7 +24,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import datetime
 import os
 import typing as t
 from shutil import which
@@ -40,6 +39,7 @@ from ..error import (
     SSReservedKeywordError,
 )
 from ..log import get_logger
+from ..settings.slurmSettings import SrunSettings
 
 logger = get_logger(__name__)
 
@@ -290,11 +290,7 @@ def _validate_time_format(time: str) -> str:
         raise ValueError(
             "Input time must be formatted as `HH:MM:SS` with valid Integers."
         ) from e
-    delta = datetime.timedelta(hours=hours, minutes=minutes, seconds=seconds)
-    fmt_str = str(delta)
-    if delta.seconds // 3600 < 10:
-        fmt_str = "0" + fmt_str
-    return fmt_str
+    return SrunSettings.fmt_walltime(hours, minutes, seconds)
 
 
 def get_hosts() -> t.List[str]:

--- a/smartsim/wlm/slurm.py
+++ b/smartsim/wlm/slurm.py
@@ -284,14 +284,12 @@ def _validate_time_format(time: str) -> str:
     :returns: Formatted walltime
     :rtype: str
     """
-    if ":" not in time:
-        raise ValueError("Input time must be formatted as `HH:MM:SS`")
     try:
         hours, minutes, seconds = map(int, time.split(":"))
-    except ValueError:
+    except ValueError as e:
         raise ValueError(
-            "Invalid time format. Hours, minutes, and seconds must be integers."
-        )
+            "Input time must be formatted as `HH:MM:SS` with valid Integers."
+        ) from e
     delta = datetime.timedelta(hours=hours, minutes=minutes, seconds=seconds)
     fmt_str = str(delta)
     if delta.seconds // 3600 < 10:

--- a/smartsim/wlm/slurm.py
+++ b/smartsim/wlm/slurm.py
@@ -39,7 +39,7 @@ from ..error import (
     SSReservedKeywordError,
 )
 from ..log import get_logger
-from ..settings.slurmSettings import SrunSettings
+from ..settings.slurmSettings import fmt_walltime
 
 logger = get_logger(__name__)
 
@@ -290,7 +290,7 @@ def _validate_time_format(time: str) -> str:
         raise ValueError(
             "Input time must be formatted as `HH:MM:SS` with valid Integers."
         ) from e
-    return SrunSettings.fmt_walltime(hours, minutes, seconds)
+    return fmt_walltime(hours, minutes, seconds)
 
 
 def get_hosts() -> t.List[str]:

--- a/smartsim/wlm/slurm.py
+++ b/smartsim/wlm/slurm.py
@@ -24,10 +24,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import datetime
 import os
 import typing as t
 from shutil import which
-import datetime
 
 from .._core.launcher.slurm.slurmCommands import salloc, scancel, scontrol, sinfo
 from .._core.launcher.slurm.slurmParser import parse_salloc, parse_salloc_error
@@ -277,19 +277,21 @@ def _get_alloc_cmd(
 def _validate_time_format(time: str) -> str:
     """Convert time into valid walltime format
 
-        By defualt the formatted wall time is the total number of seconds.
+    By defualt the formatted wall time is the total number of seconds.
 
-        :param time: number of hours to run job
-        :type time: str
-        :returns: Formatted walltime
-        :rtype: str
-        """
-    if ':' not in time:
+    :param time: number of hours to run job
+    :type time: str
+    :returns: Formatted walltime
+    :rtype: str
+    """
+    if ":" not in time:
         raise ValueError("Input time must be formatted as `HH:MM:SS`")
     try:
-        hours, minutes, seconds = map(int, time.split(':'))
+        hours, minutes, seconds = map(int, time.split(":"))
     except ValueError:
-        raise ValueError("Invalid time format. Hours, minutes, and seconds must be integers.")
+        raise ValueError(
+            "Invalid time format. Hours, minutes, and seconds must be integers."
+        )
     delta = datetime.timedelta(hours=hours, minutes=minutes, seconds=seconds)
     fmt_str = str(delta)
     if delta.seconds // 3600 < 10:

--- a/tests/full_wlm/test_slurm_allocation.py
+++ b/tests/full_wlm/test_slurm_allocation.py
@@ -37,7 +37,7 @@ if pytest.test_launcher != "slurm":
 
 
 def test_invalid_time_format(wlmutils):
-    """test slurm interface for obtaining allocations"""
+    """test slurm interface for formatting walltimes"""
     account = wlmutils.get_test_account()
     with pytest.raises(ValueError) as e:
         alloc = slurm.get_allocation(nodes=1, time="000500", account=account)

--- a/tests/full_wlm/test_slurm_allocation.py
+++ b/tests/full_wlm/test_slurm_allocation.py
@@ -35,6 +35,7 @@ from smartsim.wlm import slurm
 if pytest.test_launcher != "slurm":
     pytestmark = pytest.mark.skip(reason="Test is only for Slurm WLM systems")
 
+
 def test_invalid_time_format(wlmutils):
     """test slurm interface for obtaining allocations"""
     account = wlmutils.get_test_account()
@@ -43,7 +44,7 @@ def test_invalid_time_format(wlmutils):
     with pytest.raises(ValueError):
         alloc = slurm.get_allocation(nodes=1, time="00-05-00", account=account)
     with pytest.raises(ValueError):
-        alloc = slurm.get_allocation(nodes=1, time="TE:HE:HE", account=account)   
+        alloc = slurm.get_allocation(nodes=1, time="TE:HE:HE", account=account)
 
 
 def test_get_release_allocation(wlmutils):

--- a/tests/full_wlm/test_slurm_allocation.py
+++ b/tests/full_wlm/test_slurm_allocation.py
@@ -39,12 +39,24 @@ if pytest.test_launcher != "slurm":
 def test_invalid_time_format(wlmutils):
     """test slurm interface for obtaining allocations"""
     account = wlmutils.get_test_account()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         alloc = slurm.get_allocation(nodes=1, time="000500", account=account)
-    with pytest.raises(ValueError):
+    assert (
+        "Input time must be formatted as `HH:MM:SS` with valid Integers."
+        in e.value.args[0]
+    )
+    with pytest.raises(ValueError) as e:
         alloc = slurm.get_allocation(nodes=1, time="00-05-00", account=account)
-    with pytest.raises(ValueError):
+    assert (
+        "Input time must be formatted as `HH:MM:SS` with valid Integers."
+        in e.value.args[0]
+    )
+    with pytest.raises(ValueError) as e:
         alloc = slurm.get_allocation(nodes=1, time="TE:HE:HE", account=account)
+    assert (
+        "Input time must be formatted as `HH:MM:SS` with valid Integers."
+        in e.value.args[0]
+    )
 
 
 def test_get_release_allocation(wlmutils):

--- a/tests/full_wlm/test_slurm_allocation.py
+++ b/tests/full_wlm/test_slurm_allocation.py
@@ -35,6 +35,16 @@ from smartsim.wlm import slurm
 if pytest.test_launcher != "slurm":
     pytestmark = pytest.mark.skip(reason="Test is only for Slurm WLM systems")
 
+def test_invalid_time_format(wlmutils):
+    """test slurm interface for obtaining allocations"""
+    account = wlmutils.get_test_account()
+    with pytest.raises(ValueError):
+        alloc = slurm.get_allocation(nodes=1, time="000500", account=account)
+    with pytest.raises(ValueError):
+        alloc = slurm.get_allocation(nodes=1, time="00-05-00", account=account)
+    with pytest.raises(ValueError):
+        alloc = slurm.get_allocation(nodes=1, time="TE:HE:HE", account=account)   
+
 
 def test_get_release_allocation(wlmutils):
     """test slurm interface for obtaining allocations"""

--- a/tests/test_slurm_get_alloc.py
+++ b/tests/test_slurm_get_alloc.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.group_b
 
 
 def test_get_alloc_format():
-    time = "10:00:00"
+    time = "10:00:70"
     nodes = 5
     account = "A35311"
     options = {"ntasks-per-node": 5}
@@ -45,7 +45,7 @@ def test_get_alloc_format():
         "-J",
         "SmartSim",
         "-t",
-        "10:00:00",
+        "10:01:10",
         "-A",
         "A35311",
         "--ntasks-per-node=5",


### PR DESCRIPTION
This PR merges in functionality to validate the timing format when requesting a slurm allocation. Previously, no check was required leading to the WLM responsibility to throw an error. With the new code, SmartSim will catch and throw.