### PR TITLE
Add eval() to remove Torch warnings during testing

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -45,12 +45,12 @@ Detailed Notes
   all of SmartSim's machine learning backends with Python 3.11.
   (SmartSim-PR451_) (SmartSim-PR461_)
 
-.. _SmartSim-PR472: https://github.com/CrayLabs/SmartSim/pull/472
 .. _SmartSim-PR446: https://github.com/CrayLabs/SmartSim/pull/446
 .. _SmartSim-PR448: https://github.com/CrayLabs/SmartSim/pull/448
 .. _SmartSim-PR451: https://github.com/CrayLabs/SmartSim/pull/451
 .. _SmartSim-PR453: https://github.com/CrayLabs/SmartSim/pull/453
 .. _SmartSim-PR461: https://github.com/CrayLabs/SmartSim/pull/461
+.. _SmartSim-PR472: https://github.com/CrayLabs/SmartSim/pull/472
 
 
 0.6.0

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,6 +19,7 @@ To be released at some future point in time
 
 Description
 
+- Updated tests to address Torch warning
 - Updated GitHub actions to latest versions in CI/CD
 - Dropped Cobalt support
 - Override the sphinx-tabs extension background color
@@ -28,6 +29,8 @@ Description
 
 Detailed Notes
 
+- Tests that were saving Torch models were emitting warnings.  These warnings
+  were addressed by updating the model save test function. (SmartSim-PR472_)
 - Some actions in the current GitHub CI/CD workflows were outdated. They were
   replaced with their latest versions. (SmartSim-PR446_)
 - As the Cobalt workload manager is not used on any system we are aware of,
@@ -42,7 +45,7 @@ Detailed Notes
   all of SmartSim's machine learning backends with Python 3.11.
   (SmartSim-PR451_) (SmartSim-PR461_)
 
-
+.. _SmartSim-PR472: https://github.com/CrayLabs/SmartSim/pull/472
 .. _SmartSim-PR446: https://github.com/CrayLabs/SmartSim/pull/446
 .. _SmartSim-PR448: https://github.com/CrayLabs/SmartSim/pull/448
 .. _SmartSim-PR451: https://github.com/CrayLabs/SmartSim/pull/451

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -138,6 +138,7 @@ def create_tf_cnn():
 
 def save_torch_cnn(path, file_name):
     n = PyTorchNet()
+    n.eval()
     example_forward_input = torch.rand(1, 1, 28, 28)
     module = torch.jit.trace(n, example_forward_input)
     torch.jit.save(module, path + "/" + file_name)


### PR DESCRIPTION
When running the SmartSim test suite with the Torch backend installed, warnings are surfaced as shown below:

```
tests/backends/test_dbmodel.py::test_pt_db_model
  /Users/torch/jit/_trace.py:1084: TracerWarning: Output nr 1. of the traced function does not match the corresponding output of the Python function. Detailed error:
  Tensor-likes are not close!
  
  Mismatched elements: 10 / 10 (100.0%)
  Greatest absolute difference: 0.0451509952545166 at index (0, 9) (up to 1e-05 allowed)
  Greatest relative difference: 0.019849935548005467 at index (0, 9) (up to 1e-05 allowed)
    _check_trace(
```

This appears to stem from not having the ``eval()`` function invoked before jit tracing and saving the model.  It appears after adding this call that warnings no longer appear.