### PR TITLE
Use developer log level, protect logger defaults in test

### DIFF
--- a/smartsim/log.py
+++ b/smartsim/log.py
@@ -26,7 +26,6 @@
 
 import functools
 import logging
-import os
 import pathlib
 import sys
 import threading

--- a/smartsim/log.py
+++ b/smartsim/log.py
@@ -63,7 +63,7 @@ if t.TYPE_CHECKING:
     _PR = ParamSpec("_PR")
 
 
-def _get_log_level() -> t.Tuple[str, str]:
+def _translate_log_level(user_log_level: t.Optional[str] = "info") -> str:
     """Get the logging level based on environment variable
        SMARTSIM_LOG_LEVEL.  If not set, default to info.
 
@@ -74,20 +74,19 @@ def _get_log_level() -> t.Tuple[str, str]:
          - developer: Shows everything happening during execution
                       extremely verbose logging.
 
-    :returns: Log level for coloredlogs and value of SMARTSIM_LOG_LEVEL
-    :rtype: tuple[str,str]
+    :returns: Log level for coloredlogs
+    :rtype: str
     """
-    log_level = os.environ.get("SMARTSIM_LOG_LEVEL", "info").lower()
-    if log_level == "quiet":
-        return "warning", log_level
-    if log_level == "info":
-        return "info", log_level
-    if log_level == "debug":
-        return "debug", log_level
+    if user_log_level == "quiet":
+        return "warning"
+    if user_log_level == "info":
+        return "info"
+    if user_log_level == "debug":
+        return "debug"
     # extremely verbose logging used internally
-    if log_level == "developer":
-        return "debug", log_level
-    return "info", log_level
+    if user_log_level == "developer":
+        return "debug"
+    return "info"
 
 
 def get_exp_log_paths() -> t.Tuple[t.Optional[pathlib.Path], t.Optional[pathlib.Path]]:
@@ -205,17 +204,16 @@ def get_logger(
     """
     # if name is None, then logger is the root logger
     # if not root logger, get the name of file without prefix.
-    user_log_level, env_log_level = _get_log_level()
-
-    if env_log_level != "developer":
+    user_log_level = os.environ.get("SMARTSIM_LOG_LEVEL", "info")
+    if user_log_level != "developer":
         name = "SmartSim"
 
     logging.setLoggerClass(ContextAwareLogger)
     logger = logging.getLogger(name)
-    if not log_level:
-        log_level = user_log_level
-    if isinstance(log_level, str):
-        logger.setLevel(log_level.upper())
+    if log_level:
+        logger.setLevel(log_level)
+    else:
+        log_level = _translate_log_level(user_log_level)
     coloredlogs.install(level=log_level, logger=logger, fmt=fmt, stream=sys.stdout)
     return logger
 

--- a/smartsim/log.py
+++ b/smartsim/log.py
@@ -63,9 +63,9 @@ if t.TYPE_CHECKING:
     _PR = ParamSpec("_PR")
 
 
-def _translate_log_level(user_log_level: t.Optional[str] = "info") -> str:
-    """Get the logging level based on environment variable
-       SMARTSIM_LOG_LEVEL.  If not set, default to info.
+def _translate_log_level(user_log_level: str = "info") -> str:
+    """Translate value of CONFIG.log_level to one
+    accepted as ``level`` option by Python's logging module.
 
        Logging levels
          - quiet: Just shows errors and warnings
@@ -74,15 +74,16 @@ def _translate_log_level(user_log_level: t.Optional[str] = "info") -> str:
          - developer: Shows everything happening during execution
                       extremely verbose logging.
 
+    :param user_log_level: log level specified by user, defaults to info
+    :type user_log_level: str
     :returns: Log level for coloredlogs
     :rtype: str
     """
+    user_log_level = user_log_level.lower()
+    if user_log_level in ["info", "debug", "warning"]:
+        return user_log_level
     if user_log_level == "quiet":
         return "warning"
-    if user_log_level == "info":
-        return "info"
-    if user_log_level == "debug":
-        return "debug"
     # extremely verbose logging used internally
     if user_log_level == "developer":
         return "debug"
@@ -204,7 +205,7 @@ def get_logger(
     """
     # if name is None, then logger is the root logger
     # if not root logger, get the name of file without prefix.
-    user_log_level = os.environ.get("SMARTSIM_LOG_LEVEL", "info")
+    user_log_level = CONFIG.log_level
     if user_log_level != "developer":
         name = "SmartSim"
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -116,6 +116,25 @@ def test_get_logger(test_dir: str, turn_on_tm, monkeypatch):
     assert isinstance(logger, smartsim.log.ContextAwareLogger)
 
 
+@pytest.mark.parametrize(
+    "input_level,exp_level",
+    [
+        pytest.param("INFO", "info", id="lowercasing only, INFO"),
+        pytest.param("info", "info", id="input back, info"),
+        pytest.param("WARNING", "warning", id="lowercasing only, WARNING"),
+        pytest.param("warning", "warning", id="input back, warning"),
+        pytest.param("QUIET", "warning", id="lowercasing only, QUIET"),
+        pytest.param("quiet", "warning", id="translation back, quiet"),
+        pytest.param("DEVELOPER", "debug", id="lowercasing only, DEVELOPER"),
+        pytest.param("developer", "debug", id="translation back, developer"),
+    ],
+)
+def test_translate_log_level(input_level: str, exp_level: str, turn_on_tm):
+    """Ensure the correct logger type is instantiated"""
+    translated_level = smartsim.log._translate_log_level(input_level)
+    assert exp_level == translated_level
+
+
 def test_exp_logs(test_dir: str, turn_on_tm, monkeypatch):
     """Ensure that experiment loggers are added when context info exists"""
     monkeypatch.setenv("SMARTSIM_LOG_LEVEL", "developer")

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -109,14 +109,16 @@ def test_add_exp_loggers(test_dir):
     assert err_file.is_file()
 
 
-def test_get_logger(test_dir: str, turn_on_tm):
+def test_get_logger(test_dir: str, turn_on_tm, monkeypatch):
     """Ensure the correct logger type is instantiated"""
+    monkeypatch.setenv("SMARTSIM_LOG_LEVEL", "developer")
     logger = smartsim.log.get_logger("SmartSimTest", "INFO")
     assert isinstance(logger, smartsim.log.ContextAwareLogger)
 
 
-def test_exp_logs(test_dir: str, turn_on_tm):
+def test_exp_logs(test_dir: str, turn_on_tm, monkeypatch):
     """Ensure that experiment loggers are added when context info exists"""
+    monkeypatch.setenv("SMARTSIM_LOG_LEVEL", "developer")
     test_dir = pathlib.Path(test_dir)
     test_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
The current `log.get_logger()` function has two issues.

1. it uses `_get_log_level()` to access the value of `SMARTSIM_LOG_LEVEL`, and uses its return value to define whether the logger name should just be SmartSim, or the user-provided one. The problem is that the user-provided one is used only when `_get_log_level()` returns `developer`, but that is never the case, as `developer` gets translated to `debug`.
2. As a consequence of 1, calling `get_logger(name="MY_LOGGER", log_level="INFO")` will always get the logger named `SmartSim` and set its level to info. When this is done in a test, then the log level will be set for all subsequent tests, no matter what the name is set to.

I proposed to replace the `_get_log_level()` with `_translate_log_level()` and use the return value to set the log level when log level is not set to `developer`. To be honest, I think it is kind of weird that users can provide a name for the logger and that it gets thrown away 99.9% of the times, but I guess they could also use a different logger if they wanted something more flexible, and with the changes of this PR, the API is consistent with the docs.