### PR TITLE
Duplicate DBModel/Script prevention

### DIFF
--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -422,6 +422,11 @@ class Ensemble(EntityList[Model]):
             inputs=inputs,
             outputs=outputs,
         )
+        dupe = next((db_model.name for ensemble_ml_model in self._db_models if ensemble_ml_model.name == db_model.name), None)
+        if dupe:
+            raise SSUnsupportedError(
+                f'A ML model with name "{db_model.name}" already exists'
+            )
         self._db_models.append(db_model)
         for entity in self.models:
             self._extend_entity_db_models(entity, [db_model])
@@ -471,6 +476,11 @@ class Ensemble(EntityList[Model]):
             devices_per_node=devices_per_node,
             first_device=first_device,
         )
+        dupe = next((db_script.name for ensemble_script in self._db_scripts if ensemble_script.name == db_script.name), None)
+        if dupe:
+            raise SSUnsupportedError(
+                f'A Script with name "{db_script.name}" already exists'
+            )
         self._db_scripts.append(db_script)
         for entity in self.models:
             self._extend_entity_db_scripts(entity, [db_script])
@@ -517,6 +527,11 @@ class Ensemble(EntityList[Model]):
             devices_per_node=devices_per_node,
             first_device=first_device,
         )
+        dupe = next((db_script.name for ensemble_script in self._db_scripts if ensemble_script.name == db_script.name), None)
+        if dupe:
+            raise SSUnsupportedError(
+                f'A Script with name "{db_script.name}" already exists'
+            )
         self._db_scripts.append(db_script)
         for entity in self.models:
             self._extend_entity_db_scripts(entity, [db_script])
@@ -536,13 +551,13 @@ class Ensemble(EntityList[Model]):
         :param db_models: List of DBModels to append to the Ensemble.
         :type db_models: t.List[DBModel]
         """
-        entity_db_models = [db_model.name for db_model in model.db_models]
-        for db_model in db_models:
-            if db_model.name in entity_db_models:
+        for add_ml_model in db_models:
+            dupe = next((db_model.name for db_model in model.db_models if db_model.name == add_ml_model.name), None)
+            if dupe:
                 raise SSUnsupportedError(
-                    f'An ML Model with name "{db_model.name}" already exists'
+                    f'An ML Model with name "{add_ml_model.name}" already exists'
                 )
-            model.add_ml_model_object(db_model)
+            model.add_ml_model_object(add_ml_model)
 
     @staticmethod
     def _extend_entity_db_scripts(model: Model, db_scripts: t.List[DBScript]) -> None:
@@ -559,10 +574,10 @@ class Ensemble(EntityList[Model]):
         :param db_scripts: List of DBScripts to append to the Ensemble.
         :type db_scripts: t.List[DBScript]
         """
-        entity_db_scripts = [db_script.name for db_script in model.db_scripts]
-        for db_script in db_scripts:
-            if db_script.name in entity_db_scripts:
+        for add_script in db_scripts:
+            dupe = next((add_script.name for db_script in model._db_scripts if db_script.name == add_script.name), None)
+            if dupe:
                 raise SSUnsupportedError(
-                    f'A Script with name "{db_script.name}" already exists'
+                    f'A Script with name "{add_script.name}" already exists'
                 )
-            model.add_script_object(db_script)
+            model.add_script_object(add_script)

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -432,7 +432,7 @@ class Ensemble(EntityList[Model]):
         )
         if dupe:
             raise SSUnsupportedError(
-                f'An ML model with name "{db_model.name}" already exists'
+                f'An ML Model with name "{db_model.name}" already exists'
             )
         self._db_models.append(db_model)
         for entity in self.models:

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -422,7 +422,14 @@ class Ensemble(EntityList[Model]):
             inputs=inputs,
             outputs=outputs,
         )
-        dupe = next((db_model.name for ensemble_ml_model in self._db_models if ensemble_ml_model.name == db_model.name), None)
+        dupe = next(
+            (
+                db_model.name
+                for ensemble_ml_model in self._db_models
+                if ensemble_ml_model.name == db_model.name
+            ),
+            None,
+        )
         if dupe:
             raise SSUnsupportedError(
                 f'A ML model with name "{db_model.name}" already exists'
@@ -476,7 +483,14 @@ class Ensemble(EntityList[Model]):
             devices_per_node=devices_per_node,
             first_device=first_device,
         )
-        dupe = next((db_script.name for ensemble_script in self._db_scripts if ensemble_script.name == db_script.name), None)
+        dupe = next(
+            (
+                db_script.name
+                for ensemble_script in self._db_scripts
+                if ensemble_script.name == db_script.name
+            ),
+            None,
+        )
         if dupe:
             raise SSUnsupportedError(
                 f'A Script with name "{db_script.name}" already exists'
@@ -527,7 +541,14 @@ class Ensemble(EntityList[Model]):
             devices_per_node=devices_per_node,
             first_device=first_device,
         )
-        dupe = next((db_script.name for ensemble_script in self._db_scripts if ensemble_script.name == db_script.name), None)
+        dupe = next(
+            (
+                db_script.name
+                for ensemble_script in self._db_scripts
+                if ensemble_script.name == db_script.name
+            ),
+            None,
+        )
         if dupe:
             raise SSUnsupportedError(
                 f'A Script with name "{db_script.name}" already exists'
@@ -552,7 +573,14 @@ class Ensemble(EntityList[Model]):
         :type db_models: t.List[DBModel]
         """
         for add_ml_model in db_models:
-            dupe = next((db_model.name for db_model in model.db_models if db_model.name == add_ml_model.name), None)
+            dupe = next(
+                (
+                    db_model.name
+                    for db_model in model.db_models
+                    if db_model.name == add_ml_model.name
+                ),
+                None,
+            )
             if dupe:
                 raise SSUnsupportedError(
                     f'An ML Model with name "{add_ml_model.name}" already exists'
@@ -575,7 +603,14 @@ class Ensemble(EntityList[Model]):
         :type db_scripts: t.List[DBScript]
         """
         for add_script in db_scripts:
-            dupe = next((add_script.name for db_script in model._db_scripts if db_script.name == add_script.name), None)
+            dupe = next(
+                (
+                    add_script.name
+                    for db_script in model.db_scripts
+                    if db_script.name == add_script.name
+                ),
+                None,
+            )
             if dupe:
                 raise SSUnsupportedError(
                     f'A Script with name "{add_script.name}" already exists'

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -523,15 +523,46 @@ class Ensemble(EntityList[Model]):
 
     @staticmethod
     def _extend_entity_db_models(model: Model, db_models: t.List[DBModel]) -> None:
-        entity_db_models = [db_model.name for db_model in model.db_models]
+        """
+        Ensures that the Machine Learning model names being added to the Ensemble
+        are unique.
 
+        This static method checks if the provided ML model names already exist in
+        the Ensemble. An SSUnsupportedError is raised if any duplicate names are
+        found. Otherwise, it appends the given list of DBModels to the Ensemble.
+
+        :param model: SmartSim Model object.
+        :type model: Model
+        :param db_models: List of DBModels to append to the Ensemble.
+        :type db_models: t.List[DBModel]
+        """
+        entity_db_models = [db_model.name for db_model in model.db_models]
         for db_model in db_models:
-            if db_model.name not in entity_db_models:
-                model.add_ml_model_object(db_model)
+            if db_model.name in entity_db_models:
+                raise SSUnsupportedError(
+                    f'An ML Model with name "{db_model.name}" already exists'
+                )
+            model.add_ml_model_object(db_model)
 
     @staticmethod
     def _extend_entity_db_scripts(model: Model, db_scripts: t.List[DBScript]) -> None:
+        """
+        Ensures that the script/function names being added to the Ensemble are unique.
+
+        This static method checks if the provided script/function names already exist
+        in the Ensemble. An SSUnsupportedError is raised if any duplicate names
+        are found. Otherwise, it appends the given list of DBScripts to the
+        Ensemble.
+
+        :param model: SmartSim Model object.
+        :type model: Model
+        :param db_scripts: List of DBScripts to append to the Ensemble.
+        :type db_scripts: t.List[DBScript]
+        """
         entity_db_scripts = [db_script.name for db_script in model.db_scripts]
         for db_script in db_scripts:
-            if not db_script.name in entity_db_scripts:
-                model.add_script_object(db_script)
+            if db_script.name in entity_db_scripts:
+                raise SSUnsupportedError(
+                    f'A Script with name "{db_script.name}" already exists'
+                )
+            model.add_script_object(db_script)

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -432,7 +432,7 @@ class Ensemble(EntityList[Model]):
         )
         if dupe:
             raise SSUnsupportedError(
-                f'A ML model with name "{db_model.name}" already exists'
+                f'An ML model with name "{db_model.name}" already exists'
             )
         self._db_models.append(db_model)
         for entity in self.models:

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -858,3 +858,83 @@ def test_inconsistent_params_db_model():
         ex.value.args[0]
         == "Cannot set devices_per_node>1 if CPU is specified under devices"
     )
+
+
+@pytest.mark.skipif(not should_run_tf, reason="Test needs TF to run")
+def test_db_model_ensemble_duplicate(fileutils, test_dir, wlmutils, mlutils):
+    """Test DBModels on remote DB, with an ensemble"""
+
+    # Set experiment name
+    exp_name = "test-db-model-ensemble-duplicate"
+
+    # Retrieve parameters from testing environment
+    test_launcher = wlmutils.get_test_launcher()
+    test_interface = wlmutils.get_test_interface()
+    test_port = wlmutils.get_test_port()
+    test_device = mlutils.get_test_device()
+    test_num_gpus = 1  # TF backend fails on multiple GPUs
+
+    test_script = fileutils.get_test_conf_path("run_tf_dbmodel_smartredis.py")
+
+    # Create the SmartSim Experiment
+    exp = Experiment(exp_name, exp_path=test_dir, launcher=test_launcher)
+
+    # Create RunSettings
+    run_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    run_settings.set_nodes(1)
+    run_settings.set_tasks(1)
+
+    # Create ensemble
+    smartsim_ensemble = exp.create_ensemble(
+        "smartsim_model", run_settings=run_settings, replicas=2
+    )
+
+    # Create Model
+    smartsim_model = exp.create_model("smartsim_model", run_settings)
+
+    # Create and save ML model to filesystem
+    model, inputs, outputs = create_tf_cnn()
+    model_file2, inputs2, outputs2 = save_tf_cnn(test_dir, "model2.pb")
+
+    # Add the first ML model to all of the ensemble members
+    smartsim_ensemble.add_ml_model(
+        "cnn",
+        "TF",
+        model=model,
+        device=test_device,
+        devices_per_node=test_num_gpus,
+        first_device=0,
+        inputs=inputs,
+        outputs=outputs,
+    )
+
+    # Attempt to add a duplicate ML model to Ensemble via Ensemble.add_ml_model()
+    with pytest.raises(SSUnsupportedError) as ex:
+        smartsim_ensemble.add_ml_model(
+            "cnn",
+            "TF",
+            model=model,
+            device=test_device,
+            devices_per_node=test_num_gpus,
+            first_device=0,
+            inputs=inputs,
+            outputs=outputs,
+        )
+    assert ex.value.args[0] == 'An ML Model with name "cnn" already exists'
+
+    # Add same name ML model to a new SmartSim Model
+    smartsim_model.add_ml_model(
+        "cnn",
+        "TF",
+        model_path=model_file2,
+        device=test_device,
+        devices_per_node=test_num_gpus,
+        first_device=0,
+        inputs=inputs2,
+        outputs=outputs2,
+    )
+
+    # Attempt to add a duplicate ML model to Ensemble via Ensemble.add_model()
+    with pytest.raises(SSUnsupportedError) as ex:
+        smartsim_ensemble.add_model(smartsim_model)
+    assert ex.value.args[0] == 'An ML Model with name "cnn" already exists'

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -887,7 +887,7 @@ def test_db_model_ensemble_duplicate(fileutils, test_dir, wlmutils, mlutils):
 
     # Create ensemble
     smartsim_ensemble = exp.create_ensemble(
-        "smartsim_model", run_settings=run_settings, replicas=2
+        "smartsim_ensemble", run_settings=run_settings, replicas=2
     )
 
     # Create Model

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -670,7 +670,7 @@ def test_db_script_ensemble_duplicate(fileutils, test_dir, wlmutils, mlutils):
         devices_per_node=test_num_gpus,
         first_device=0,
     )
-    
+
     # Attempt to add a duplicate ML model to Ensemble via Ensemble.add_script()
     with pytest.raises(SSUnsupportedError) as ex:
         ensemble.add_script(

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -623,3 +623,107 @@ def test_inconsistent_params_db_script(fileutils):
         ex.value.args[0]
         == "Cannot set first_device>0 if CPU is specified under devices"
     )
+
+
+@pytest.mark.skipif(not should_run, reason="Test needs Torch to run")
+def test_db_script_ensemble_duplicate(fileutils, test_dir, wlmutils, mlutils):
+    """Test DB scripts on remote DB"""
+
+    # Set experiment name
+    exp_name = "test-db-script"
+
+    # Retrieve parameters from testing environment
+    test_launcher = wlmutils.get_test_launcher()
+    test_interface = wlmutils.get_test_interface()
+    test_port = wlmutils.get_test_port()
+    test_device = mlutils.get_test_device()
+    test_num_gpus = mlutils.get_test_num_gpus() if pytest.test_device == "GPU" else 1
+
+    test_script = fileutils.get_test_conf_path("run_dbscript_smartredis.py")
+    torch_script = fileutils.get_test_conf_path("torchscript.py")
+
+    # Create SmartSim Experiment
+    exp = Experiment(exp_name, exp_path=test_dir, launcher=test_launcher)
+
+    # Create RunSettings
+    run_settings = exp.create_run_settings(exe=sys.executable, exe_args=test_script)
+    run_settings.set_nodes(1)
+    run_settings.set_tasks(1)
+
+    # Create Ensemble with two identical models
+    ensemble = exp.create_ensemble(
+        "dbscript_ensemble", run_settings=run_settings, replicas=2
+    )
+
+    # Create SmartSim model
+    smartsim_model = exp.create_model("smartsim_model", run_settings)
+    # Create 2nd SmartSim model
+    smartsim_model_2 = exp.create_model("smartsim_model", run_settings)
+    # Create the script string
+    torch_script_str = "def negate(x):\n\treturn torch.neg(x)\n"
+
+    # Add the first ML script to all of the ensemble members
+    ensemble.add_script(
+        "test_script1",
+        script_path=torch_script,
+        device=test_device,
+        devices_per_node=test_num_gpus,
+        first_device=0,
+    )
+
+    # Attempt to add a duplicate ML model to Ensemble via Ensemble.add_script()
+    with pytest.raises(SSUnsupportedError) as ex:
+        ensemble.add_script(
+            "test_script1",
+            script_path=torch_script,
+            device=test_device,
+            devices_per_node=test_num_gpus,
+            first_device=0,
+        )
+    assert ex.value.args[0] == 'A Script with name "test_script1" already exists'
+
+    # Add the first function to all of the ensemble members
+    ensemble.add_function(
+        "test_func",
+        function=timestwo,
+        device=test_device,
+        devices_per_node=test_num_gpus,
+        first_device=0,
+    )
+
+    # # Attempt to add a duplicate ML model to Ensemble via Ensemble.add_function()
+    with pytest.raises(SSUnsupportedError) as ex:
+        ensemble.add_function(
+            "test_func",
+            function=timestwo,
+            device=test_device,
+            devices_per_node=test_num_gpus,
+            first_device=0,
+        )
+    assert ex.value.args[0] == 'A Script with name "test_func" already exists'
+
+    # Add a script with a non-unique name to a SmartSim Model
+    smartsim_model.add_script(
+        "test_script1",
+        script_path=torch_script,
+        device=test_device,
+        devices_per_node=test_num_gpus,
+        first_device=0,
+    )
+
+    with pytest.raises(SSUnsupportedError) as ex:
+        ensemble.add_model(smartsim_model)
+    assert ex.value.args[0] == 'A Script with name "test_script1" already exists'
+
+    # Add a function with a non-unique name to a SmartSim Model
+    smartsim_model_2.add_function(
+        "test_func",
+        function=timestwo,
+        device=test_device,
+        devices_per_node=test_num_gpus,
+        first_device=0,
+    )
+
+    with pytest.raises(SSUnsupportedError) as ex:
+        ensemble.add_model(smartsim_model_2)
+    assert ex.value.args[0] == 'A Script with name "test_func" already exists'

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -658,7 +658,7 @@ def test_db_script_ensemble_duplicate(fileutils, test_dir, wlmutils, mlutils):
     # Create SmartSim model
     smartsim_model = exp.create_model("smartsim_model", run_settings)
     # Create 2nd SmartSim model
-    smartsim_model_2 = exp.create_model("smartsim_model", run_settings)
+    smartsim_model_2 = exp.create_model("smartsim_model_2", run_settings)
     # Create the script string
     torch_script_str = "def negate(x):\n\treturn torch.neg(x)\n"
 
@@ -670,7 +670,7 @@ def test_db_script_ensemble_duplicate(fileutils, test_dir, wlmutils, mlutils):
         devices_per_node=test_num_gpus,
         first_device=0,
     )
-
+    
     # Attempt to add a duplicate ML model to Ensemble via Ensemble.add_script()
     with pytest.raises(SSUnsupportedError) as ex:
         ensemble.add_script(
@@ -691,7 +691,7 @@ def test_db_script_ensemble_duplicate(fileutils, test_dir, wlmutils, mlutils):
         first_device=0,
     )
 
-    # # Attempt to add a duplicate ML model to Ensemble via Ensemble.add_function()
+    # Attempt to add a duplicate ML model to Ensemble via Ensemble.add_function()
     with pytest.raises(SSUnsupportedError) as ex:
         ensemble.add_function(
             "test_func",


### PR DESCRIPTION
This PR prevents duplicate ML models and scripts names being added to an Ensemble member if the names exists already.
The checks are performed for `Ensemble.add_ml_model()`, `Ensemble.add_model()`, `Ensemble.add_script()` and `Ensemble.add_function()`.