### PR TITLE
Patch Changes for Release Prep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ deps = [
     "tqdm>=4.50.2",
     "filelock>=3.4.2",
     "protobuf~=3.20",
-    "watchdog>=3.0.0",
+    "watchdog>=3.0.0,<4.0.0",
 ]
 
 # Add SmartRedis at specific version

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -225,7 +225,7 @@ class Config:
 
     @property
     def telemetry_enabled(self) -> bool:
-        return int(os.environ.get("SMARTSIM_FLAG_TELEMETRY", "0")) > 0
+        return int(os.environ.get("SMARTSIM_FLAG_TELEMETRY", "1")) > 0
 
     @property
     def telemetry_cooldown(self) -> int:

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -82,7 +82,7 @@ def save_launch_manifest(manifest: _Manifest[TStepLaunchMetaData]) -> None:
         manifest_dict = {
             "schema info": {
                 "schema_name": "entity manifest",
-                "version": "0.0.2",
+                "version": "0.0.3",
             },
             "experiment": {
                 "name": manifest.metadata.exp_name,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,7 +205,7 @@ def test_redis_cli():
         pytest.param("0", False, id="letter zero"),
         pytest.param("1", True, id="letter one"),
         pytest.param("-1", False, id="letter negative one"),
-        pytest.param(None, False, id="not in env"),
+        pytest.param(None, True, id="not in env"),
     ],
 )
 def test_telemetry_flag(


### PR DESCRIPTION
This PR makes several patch changes to prepare for a SmartSim release including:

- [x] Set the default value of the "enable telemetry" flag to on. Currently this will enable telemetry system wide until finer grain control can be established with #460
- [x] Bump the output `manifest.json` version number to match that of [`smartdashboard`](https://github.com/CrayLabs/SmartDashboard/pull/40/files)
- [x] Pin a watchdog version to avoid build errors