### PR TITLE
Update instructions for Apple Silicon

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -27,6 +27,7 @@ Description
 - Added ONNX support for Python 3.10
 - Added support for Python 3.11
 - Added support for SmartSim with Torch on Apple Silicon
+- Updated install instructions for Apple Silicon
 
 
 Detailed Notes
@@ -49,6 +50,7 @@ Detailed Notes
 - SmartSim can now be built and used on platforms using Apple Silicon
   (ARM64). Currently, only the PyTorch backend is supported. Note that libtorch
   will be downloaded from a CrayLabs github repo. (SmartSim-PR465_)
+- Separate install instructions are now provided for Mac OSX on x64 vs ARM64 (SmartSim-PR478_)
 
 .. _SmartSim-PR446: https://github.com/CrayLabs/SmartSim/pull/446
 .. _SmartSim-PR448: https://github.com/CrayLabs/SmartSim/pull/448
@@ -57,6 +59,7 @@ Detailed Notes
 .. _SmartSim-PR461: https://github.com/CrayLabs/SmartSim/pull/461
 .. _SmartSim-PR465: https://github.com/CrayLabs/SmartSim/pull/465
 .. _SmartSim-PR472: https://github.com/CrayLabs/SmartSim/pull/472
+.. _SmartSim-PR478: https://github.com/CrayLabs/SmartSim/pull/478
 
 
 0.6.0

--- a/doc/installation_instructions/basic.rst
+++ b/doc/installation_instructions/basic.rst
@@ -41,7 +41,7 @@ The machine-learning backends have additional requirements in order to
 use GPUs for inference
 
   - `CUDA Toolkit 11 (tested with 11.8) <https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html>`_
-  - `cuDNN 8 (tested with 8.2.1 and 8.4.0) <https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html#download>`_
+  - `cuDNN 8 (tested with 8.9.1) <https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html#download>`_
   - OS: Linux
   - GPU: Nvidia
 
@@ -62,8 +62,8 @@ Supported Versions
      - CPU
      - GPU
      - Python Versions
-   * - MacOS
-     - x86_64
+   * - Mac OSX
+     - x86_64, aarch64
      - Not supported
      - 3.8 - 3.11
    * - Linux
@@ -74,8 +74,9 @@ Supported Versions
 
 .. note::
 
-    Windows is not supported and there are currently no plans
-    to support Windows.
+    Users have succesfully run SmartSim on Windows using Windows Subsystem for Linux
+    with Nvidia support. Generally, users should follow the Linux instructions here,
+    however we make no guarantee or offer of support.
 
 
 Native support for various machine learning libraries and their
@@ -86,6 +87,11 @@ versions is dictated by our dependency on RedisAI_ 1.2.7.
 +==================+==========+=============+===============+
 | 1.2.7 (default)  | 2.0.1    | 2.13.1      | 1.16.3        |
 +------------------+----------+-------------+---------------+
+
+.. warning::
+
+  On Apple Silicon, only the PyTorch backend is supported for now. Please contact us
+  if you need support for other backends
 
 TensorFlow_ 2.0 and Keras_ are supported through `graph freezing`_.
 
@@ -104,8 +110,8 @@ default due to issues with glibc on a variety of Linux platforms).
 
 ------------------------------------------------------------
 
-MacOS-only
-==========
+Mac OSX-only
+============
 
 We recommend users and contributors install brew_ for managing installed
 packages. For contributors, the following brew packages can be helpful:
@@ -240,7 +246,7 @@ SmartSim does.
 
    * - Platform
      - Python Versions
-   * - MacOS
+   * - Mac OSX
      - 3.8 - 3.11
    * - Linux
      - 3.8 - 3.11
@@ -270,9 +276,25 @@ Install SmartSim from Source
 
 First, clone SmartSim.
 
-.. code-block:: bash
+.. tabs::
 
-  git clone https://github.com/CrayLabs/SmartSim smartsim
+  .. tab:: Linux
+
+    .. code-block:: bash
+
+      git clone https://github.com/CrayLabs/SmartSim smartsim
+
+  .. tab:: Mac OSX (Intel x64)
+
+    .. code-block:: bash
+
+      git clone https://github.com/CrayLabs/SmartSim smartsim
+
+  .. tab:: Mac OSX (Apple Silicon)
+
+    .. code-block:: bash
+
+      git clone --config core.autocrlf=true https://github.com/CrayLabs/SmartSim smartsim
 
 And then install SmartSim with pip in *editable* mode. This way, SmartSim is
 installed in your virtual environment and available on `sys.path`, but the
@@ -286,12 +308,29 @@ source remains at the site of the clone instead of in site-packages.
 
 Use the now installed ``smart`` cli to install the machine learning runtimes.
 
-.. code-block:: bash
+.. tabs::
 
-  # run one of the following
-  smart build -v --device cpu          # verbose install cpu
-  smart build -v --device gpu          # verbose install gpu
-  smart build -v --device gpu --onnx   # install all backends (PT, TF, ONNX) on gpu
+  .. tab:: Linux
+
+    .. code-block:: bash
+
+      # run one of the following
+      smart build --device cpu --onnx  # install with cpu-only support
+      smart build --device gpu --onnx  # install with both cpu and gpu support
+
+
+  .. tab:: Mac OSX (Intel x64)
+
+    .. code-block:: bash
+
+      smart build --device cpu --onnx  # install all backends (PT, TF, ONNX) on gpu
+
+
+  .. tab:: Mac OSX (Apple Silicon)
+
+    .. code-block:: bash
+
+      smart build --device cpu --no_tf # Only install PyTorch (TF/ONNX unsupported)
 
 
 Build the SmartRedis library

--- a/doc/installation_instructions/basic.rst
+++ b/doc/installation_instructions/basic.rst
@@ -34,8 +34,11 @@ The base prerequisites to install SmartSim and SmartRedis are:
   GCC 5-9, 11, and 12 is recommended. There are known bugs with GCC 10.
 
 .. warning::
+
   Apple Clang 15 seems to have issues on MacOS with Apple Silicon. Please modify
-  your path to ensure that a version of GCC installed by brew has priority.
+  your path to ensure that a version of GCC installed by brew has priority. Note
+  this seems to be hardcoded to `gcc` and `g++` in the Redis build so ensure that
+  `which gcc g++` do not point to Apple Clang.
 
 
 GPU Support

--- a/doc/installation_instructions/basic.rst
+++ b/doc/installation_instructions/basic.rst
@@ -62,7 +62,7 @@ Supported Versions
      - CPU
      - GPU
      - Python Versions
-   * - Mac OSX
+   * - MacOS
      - x86_64, aarch64
      - Not supported
      - 3.8 - 3.11
@@ -110,7 +110,7 @@ default due to issues with glibc on a variety of Linux platforms).
 
 ------------------------------------------------------------
 
-Mac OSX-only
+MacOS-only
 ============
 
 We recommend users and contributors install brew_ for managing installed
@@ -246,7 +246,7 @@ SmartSim does.
 
    * - Platform
      - Python Versions
-   * - Mac OSX
+   * - MacOS
      - 3.8 - 3.11
    * - Linux
      - 3.8 - 3.11
@@ -284,13 +284,13 @@ First, clone SmartSim.
 
       git clone https://github.com/CrayLabs/SmartSim smartsim
 
-  .. tab:: Mac OSX (Intel x64)
+  .. tab:: MacOS (Intel x64)
 
     .. code-block:: bash
 
       git clone https://github.com/CrayLabs/SmartSim smartsim
 
-  .. tab:: Mac OSX (Apple Silicon)
+  .. tab:: MacOS (Apple Silicon)
 
     .. code-block:: bash
 
@@ -319,14 +319,14 @@ Use the now installed ``smart`` cli to install the machine learning runtimes.
       smart build --device gpu --onnx  # install with both cpu and gpu support
 
 
-  .. tab:: Mac OSX (Intel x64)
+  .. tab:: MacOS (Intel x64)
 
     .. code-block:: bash
 
       smart build --device cpu --onnx  # install all backends (PT, TF, ONNX) on gpu
 
 
-  .. tab:: Mac OSX (Apple Silicon)
+  .. tab:: MacOS (Apple Silicon)
 
     .. code-block:: bash
 

--- a/doc/installation_instructions/basic.rst
+++ b/doc/installation_instructions/basic.rst
@@ -33,6 +33,10 @@ The base prerequisites to install SmartSim and SmartRedis are:
 
   GCC 5-9, 11, and 12 is recommended. There are known bugs with GCC 10.
 
+.. warning::
+  Apple Clang 15 seems to have issues on MacOS with Apple Silicon. Please modify
+  your path to ensure that a version of GCC installed by brew has priority.
+
 
 GPU Support
 ===========
@@ -276,25 +280,10 @@ Install SmartSim from Source
 
 First, clone SmartSim.
 
-.. tabs::
+.. code-block:: bash
 
-  .. tab:: Linux
+  git clone https://github.com/CrayLabs/SmartSim smartsim
 
-    .. code-block:: bash
-
-      git clone https://github.com/CrayLabs/SmartSim smartsim
-
-  .. tab:: MacOS (Intel x64)
-
-    .. code-block:: bash
-
-      git clone https://github.com/CrayLabs/SmartSim smartsim
-
-  .. tab:: MacOS (Apple Silicon)
-
-    .. code-block:: bash
-
-      git clone --config core.autocrlf=true https://github.com/CrayLabs/SmartSim smartsim
 
 And then install SmartSim with pip in *editable* mode. This way, SmartSim is
 installed in your virtual environment and available on `sys.path`, but the


### PR DESCRIPTION

[docs.tgz](https://github.com/CrayLabs/SmartSim/files/14201965/docs.tgz)

Separate instructions are now included for Mac OSX on Apple Silicon. The most important: 
- `core.autoclrf=true` when cloning SmartSim to avoid errors when building due to line-ending conventions during the Redis build
- Only PyTorch is supported for that platform