### PR TITLE
Update tutorial containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - "8888:8888"
 
   tutorials-prod:
-    image: smartsim-tutorials:v0.6.1
+    image: smartsim-tutorials:v0.6.2
     build:
       context: .
       dockerfile: ./docker/prod/Dockerfile

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -36,9 +36,9 @@ RUN useradd --system --create-home --shell /bin/bash -g root -G sudo craylabs &&
     apt-get update \
     && apt-get install --no-install-recommends -y build-essential \
     git gcc make git-lfs wget libopenmpi-dev openmpi-bin unzip \
-    python3-pip python3 python3-dev cmake \
+    python3-pip python3.9 python3.9-dev cmake \
     && rm -rf /var/lib/apt/lists/* \
-    && ln -s /usr/bin/python3 /usr/bin/python
+    && ln -s /usr/bin/python3.9 /usr/bin/python
 
 WORKDIR /home/craylabs
 RUN git clone https://github.com/CrayLabs/SmartRedis.git --branch develop --depth=1 smartredis \

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -36,9 +36,9 @@ RUN useradd --system --create-home --shell /bin/bash -g root -G sudo craylabs &&
     apt-get update \
     && apt-get install --no-install-recommends -y build-essential \
     git gcc make git-lfs wget libopenmpi-dev openmpi-bin unzip \
-    python3-pip python3 python3-dev cmake \
+    python3.9 python3.9-dev python3-pip cmake \
     && rm -rf /var/lib/apt/lists/* \
-    && ln -s /usr/bin/python3 /usr/bin/python
+    && ln -s /usr/bin/python3.9 /usr/bin/python
 
 WORKDIR /home/craylabs
 COPY --chown=craylabs:root ./tutorials/ /home/craylabs/tutorials/


### PR DESCRIPTION
Currently, the docker container created with `make tutorials-prod` does not work, because the `networkx` version which is pulled is not compatible with Python 3.8 (the default version in Ubuntu 20.04). This PR bumps up the Python version used when building the tutorial containers (both production and development).

A minor bug in the tutorial container version number is also addressed as part of this PR.