### PR TITLE
Change generic t.any in Experiment API

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,7 +24,7 @@ Description
 
 Detailed Notes
 
-- Update the generic t.any typehints in Experiment API. (SmartSim-PR501_)
+- Update the generic t.Any typehints in Experiment API. (SmartSim-PR501_)
 
 
 .. _SmartSim-PR493: https://github.com/CrayLabs/SmartSim/pull/493

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,7 +24,7 @@ Description
 
 Detailed Notes
 
-- Update the generic t.Any typehints in Experiment API. (SmartSim-PR501_)
+- Update the generic `t.Any` typehints in Experiment API. (SmartSim-PR501_)
 
 
 .. _SmartSim-PR493: https://github.com/CrayLabs/SmartSim/pull/493

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,23 @@ SmartSim
 ========
 
 
+Development branch
+------------------
+
+To be released at some future point in time
+
+Description
+
+- Update Experiment API typing
+
+
+Detailed Notes
+
+- Update the generic t.any typehints in Experiment API. (SmartSim-PR501_)
+
+
+.. _SmartSim-PR493: https://github.com/CrayLabs/SmartSim/pull/493
+
 
 0.6.2
 -----

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -36,7 +36,7 @@ from smartsim.error.errors import SSUnsupportedError
 from ._core import Controller, Generator, Manifest
 from ._core.utils import init_default
 from .database import Orchestrator
-from .entity import Ensemble, Model, SmartSimEntity
+from .entity import Ensemble, EntitySequence, Model, SmartSimEntity
 from .error import SmartSimError
 from .log import ctx_exp_path, get_logger, method_contextualizer
 from .settings import Container, base, settings
@@ -149,7 +149,7 @@ class Experiment:
     @_contextualize
     def start(
         self,
-        *args: t.Any,
+        *args: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]],
         block: bool = True,
         summary: bool = False,
         kill_on_interrupt: bool = True,
@@ -221,7 +221,9 @@ class Experiment:
             raise
 
     @_contextualize
-    def stop(self, *args: t.Any) -> None:
+    def stop(
+        self, *args: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]]
+    ) -> None:
         """Stop specific instances launched by this ``Experiment``
 
         Instances of ``Model``, ``Ensemble`` and ``Orchestrator``
@@ -260,7 +262,7 @@ class Experiment:
     @_contextualize
     def generate(
         self,
-        *args: t.Any,
+        *args: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]],
         tag: t.Optional[str] = None,
         overwrite: bool = False,
         verbose: bool = False,
@@ -364,7 +366,9 @@ class Experiment:
             raise
 
     @_contextualize
-    def get_status(self, *args: t.Any) -> t.List[str]:
+    def get_status(
+        self, *args: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]]
+    ) -> t.List[str]:
         """Query the status of launched instances
 
         Return a smartsim.status string representing


### PR DESCRIPTION
Currently, the ``start``, ``stop``, ``generate``, and ``get_status`` API functions list ``t.any`` as the type for ``*args``.  However, that is not specifically true, and underlying methods like ``Controller.start()`` specify ``t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]]``.  This PR updates the typing on the ``Experiment`` API functions to reflect internal API requirements.