### PR TITLE
Increase disk space in container for doc builder

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -30,8 +30,6 @@ name: deploy_dev_docs
 
 on:
   push:
-    branches:
-      - develop
 
 jobs:
   build_docs:
@@ -39,6 +37,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      
+      # Maximize the space in this image
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 30720
+          remove-dotnet: true
+          remove-android: true
+          remove-haskell: true
+          remove-codeql: true
+          remove-docker-images: true
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
@@ -58,15 +68,15 @@ jobs:
       - name: Build documentation with docker
         run: make docks
 
-      - name: Commit files
-        run: |
-          git add -Af
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git commit -m "Update develop documentation"
-
-      - uses: ad-m/github-push-action@v0.6.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: doc
-          force: true
+#      - name: Commit files
+#        run: |
+#          git add -Af
+#          git config --local user.email "action@github.com"
+#          git config --local user.name "GitHub Action"
+#          git commit -m "Update develop documentation"
+#
+#      - uses: ad-m/github-push-action@v0.6.0
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          branch: doc
+#          force: true

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -30,8 +30,6 @@ name: deploy_dev_docs
 
 on:
   push:
-    branches:
-      - develop
 
 jobs:
   build_docs:
@@ -42,7 +40,7 @@ jobs:
       
       # Maximize the space in this image
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: easimon/maximize-build-space@v10
         with:
           root-reserve-mb: 30720
           remove-dotnet: true

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -30,6 +30,8 @@ name: deploy_dev_docs
 
 on:
   push:
+    branches:
+      - develop
 
 jobs:
   build_docs:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -30,6 +30,8 @@ name: deploy_dev_docs
 
 on:
   push:
+    branches:
+      - develop
 
 jobs:
   build_docs:
@@ -68,15 +70,15 @@ jobs:
       - name: Build documentation with docker
         run: make docks
 
-#      - name: Commit files
-#        run: |
-#          git add -Af
-#          git config --local user.email "action@github.com"
-#          git config --local user.name "GitHub Action"
-#          git commit -m "Update develop documentation"
-#
-#      - uses: ad-m/github-push-action@v0.6.0
-#        with:
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          branch: doc
-#          force: true
+      - name: Commit files
+        run: |
+          git add -Af
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m "Update develop documentation"
+
+      - uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: doc
+          force: true

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,7 +11,24 @@ Jump to :ref:`SmartRedis Changelog <sr_changelog>`
 SmartSim
 ========
 
+Development Branch
+------------------
 
+To be released in the future
+
+Description
+
+- Fix publishing of development docs
+
+Detailed notes
+
+- The container which builds the documentation for every merge to develop
+  was failing due to a lack of space within the container. This was fixed
+  by including an additional Github action that removes some unneeded
+  software and files that come from the default Github Ubuntu container.
+  (SmartSim-PR-PR504_)
+
+.. _SmartSim-PR504: https://github.com/CrayLabs/SmartSim/pull/504
 
 0.6.2
 -----


### PR DESCRIPTION
The deploy_dev_docs action was failing due to running out of disk space in the container. This was alleviated by running the `maximize-build-space` Github action.