### PR TITLE
Update Redis dependency to 7.2.4

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -54,10 +54,15 @@ jobs:
       fail-fast: false
       matrix:
         subset: [backends, slow_tests, group_a, group_b]
-        os: [macos-12, ubuntu-20.04] # Operating systems
+        os: [macos-12, macos-14, ubuntu-20.04] # Operating systems
         compiler: [8] # GNU compiler version
         rai: [1.2.7] # Redis AI versions
-        py_v: ['3.8', '3.9', '3.10', '3.11'] # Python versions
+        py_v: ["3.8", "3.9", "3.10", "3.11"] # Python versions
+        exclude:
+          - os: macos-14
+            py_v: "3.9"
+          - os: macos-14
+            py_v: "3.8"
 
     env:
       SMARTSIM_REDISAI: ${{ matrix.rai }}
@@ -108,7 +113,12 @@ jobs:
           python -m pip install .[dev,ml]
 
       - name: Install ML Runtimes with Smart (with pt, tf, and onnx support)
+        if: contains( matrix.os, 'ubuntu' ) || contains( matrix.os, 'macos-12')
         run: smart build --device cpu --onnx -v
+
+      - name: Install ML Runtimes with Smart (no ONNX,TF on Apple Silicon)
+        if: contains( matrix.os, 'macos-14' )
+        run: smart build --device cpu --no_tf -v
 
       - name: Run mypy
         run: |

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,11 +18,14 @@ To be released at some future point in time
 
 Description
 
+- Update the version of Redis from `7.0.4` to `7.2.4`
 - Update Experiment API typing
 - Fix publishing of development docs
 
 Detailed Notes
 
+- Update Redis version to `7.2.4`. This change fixes an issue in the Redis
+  build scripts causing failures on Apple Silicon hosts. (SmartSim-PR507_)
 - The container which builds the documentation for every merge to develop
   was failing due to a lack of space within the container. This was fixed
   by including an additional Github action that removes some unneeded
@@ -30,6 +33,7 @@ Detailed Notes
   (SmartSim-PR-PR504_)
 - Update the generic `t.Any` typehints in Experiment API. (SmartSim-PR501_)
 
+.. _SmartSim-PR507: https://github.com/CrayLabs/SmartSim/pull/507
 .. _SmartSim-PR504: https://github.com/CrayLabs/SmartSim/pull/504
 .. _SmartSim-PR501: https://github.com/CrayLabs/SmartSim/pull/501
 

--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -275,7 +275,7 @@ class Versioner:
     SMARTSIM_SUFFIX = get_env("SMARTSIM_SUFFIX", "")
 
     # Redis
-    REDIS = Version_(get_env("SMARTSIM_REDIS", "7.0.5"))
+    REDIS = Version_(get_env("SMARTSIM_REDIS", "7.2.4"))
     REDIS_URL = get_env("SMARTSIM_REDIS_URL", "https://github.com/redis/redis.git/")
     REDIS_BRANCH = get_env("SMARTSIM_REDIS_BRANCH", REDIS)
 

--- a/smartsim/_core/utils/redis.py
+++ b/smartsim/_core/utils/redis.py
@@ -69,7 +69,7 @@ def create_cluster(hosts: t.List[str], ports: t.List[int]) -> None:  # cov-wlm
     redis_cli = CONFIG.database_cli
     cmd = [redis_cli, "--cluster", "create"]
     cmd += ip_list
-    cmd += ["--cluster-replicas", "0"]
+    cmd += ["--cluster-replicas", "0", "--cluster-yes"]
     returncode, out, err = execute_cmd(cmd, proc_input="yes", shell=False)
 
     if returncode != 0:


### PR DESCRIPTION
A fix in the build scripts of Redis 7.2.4 modifies build behavior on MacOS on Apple Silicon. The change fixes an issue where incorrect compiler flags are defined and result in build failures due to the `redis_fstat` macro