### PR TITLE
Change Status Module

### DIFF
--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -206,7 +206,11 @@ class Controller:
         """
         with JM_LOCK:
             job = self._jobs[entity.name]
-            if job.status not in [SmartSimStatus.STATUS_CANCELLED, SmartSimStatus.STATUS_COMPLETED, SmartSimStatus.STATUS_FAILED]:
+            if job.status not in [
+                SmartSimStatus.STATUS_CANCELLED,
+                SmartSimStatus.STATUS_COMPLETED,
+                SmartSimStatus.STATUS_FAILED,
+            ]:
                 logger.info(
                     " ".join(
                         ("Stopping model", entity.name, "with job name", str(job.name))
@@ -243,7 +247,13 @@ class Controller:
                             continue
 
                         job = self._jobs[node.name]
-                        job.set_status(SmartSimStatus.STATUS_CANCELLED, "", 0, output=None, error=None)
+                        job.set_status(
+                            SmartSimStatus.STATUS_CANCELLED,
+                            "",
+                            0,
+                            output=None,
+                            error=None,
+                        )
                         self._jobs.move_to_completed(job)
 
         db.reset_hosts()
@@ -730,7 +740,15 @@ class Controller:
                     ready = True
                     # TODO remove in favor of by node status check
                     time.sleep(CONFIG.jm_interval)
-                elif any(stat in [SmartSimStatus.STATUS_CANCELLED, SmartSimStatus.STATUS_COMPLETED, SmartSimStatus.STATUS_FAILED] for stat in statuses):
+                elif any(
+                    stat
+                    in [
+                        SmartSimStatus.STATUS_CANCELLED,
+                        SmartSimStatus.STATUS_COMPLETED,
+                        SmartSimStatus.STATUS_FAILED,
+                    ]
+                    for stat in statuses
+                ):
                     self.stop_db(orchestrator)
                     msg = "Orchestrator failed during startup"
                     msg += f" See {orchestrator.path} for details"

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -61,7 +61,7 @@ from ...error import (
 )
 from ...log import get_logger
 from ...servertype import CLUSTERED, STANDALONE
-from ...status import SmartSimStatus
+from ...status import TERMINAL_STATUSES, SmartSimStatus
 from ..config import CONFIG
 from ..launcher import LocalLauncher, LSFLauncher, PBSLauncher, SlurmLauncher
 from ..launcher.launcher import Launcher
@@ -206,11 +206,7 @@ class Controller:
         """
         with JM_LOCK:
             job = self._jobs[entity.name]
-            if job.status not in [
-                SmartSimStatus.STATUS_CANCELLED,
-                SmartSimStatus.STATUS_COMPLETED,
-                SmartSimStatus.STATUS_FAILED,
-            ]:
+            if job.status not in TERMINAL_STATUSES:
                 logger.info(
                     " ".join(
                         ("Stopping model", entity.name, "with job name", str(job.name))
@@ -740,15 +736,7 @@ class Controller:
                     ready = True
                     # TODO remove in favor of by node status check
                     time.sleep(CONFIG.jm_interval)
-                elif any(
-                    stat
-                    in [
-                        SmartSimStatus.STATUS_CANCELLED,
-                        SmartSimStatus.STATUS_COMPLETED,
-                        SmartSimStatus.STATUS_FAILED,
-                    ]
-                    for stat in statuses
-                ):
+                elif any(stat in TERMINAL_STATUSES for stat in statuses):
                     self.stop_db(orchestrator)
                     msg = "Orchestrator failed during startup"
                     msg += f" See {orchestrator.path} for details"

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -288,7 +288,7 @@ class Controller:
         :type entity: SmartSimEntity | EntitySequence
         :raises TypeError: if not SmartSimEntity | EntitySequence
         :return: status of entity
-        :rtype: str
+        :rtype: SmartSimStatus
         """
         if not isinstance(entity, (SmartSimEntity, EntitySequence)):
             raise TypeError(
@@ -306,7 +306,7 @@ class Controller:
                             get statuses of
         :type entity_list: EntitySequence
         :raises TypeError: if not EntitySequence
-        :return: list of str statuses
+        :return: list of SmartSimStatus statuses
         :rtype: list
         """
         if not isinstance(entity_list, EntitySequence):

--- a/smartsim/_core/control/job.py
+++ b/smartsim/_core/control/job.py
@@ -29,7 +29,7 @@ import typing as t
 from dataclasses import dataclass
 
 from ...entity import EntitySequence, SmartSimEntity
-from ...status import STATUS_NEW
+from ...status import SmartSimStatus
 
 
 @dataclass(frozen=True)
@@ -96,7 +96,7 @@ class Job:
         self.name = job_name
         self.jid = job_id
         self.entity = entity
-        self.status = STATUS_NEW
+        self.status = SmartSimStatus.STATUS_NEW
         # status before smartsim status mapping is applied
         self.raw_status: t.Optional[str] = None
         self.returncode: t.Optional[int] = None
@@ -116,7 +116,7 @@ class Job:
 
     def set_status(
         self,
-        new_status: str,
+        new_status: SmartSimStatus,
         raw_status: str,
         returncode: t.Optional[int],
         error: t.Optional[str] = None,
@@ -157,7 +157,7 @@ class Job:
         """
         self.name = new_job_name
         self.jid = new_job_id
-        self.status = STATUS_NEW
+        self.status = SmartSimStatus.STATUS_NEW
         self.returncode = None
         self.output = None
         self.error = None
@@ -213,14 +213,14 @@ class History:
         """
         self.runs = runs
         self.jids: t.Dict[int, t.Optional[str]] = {}
-        self.statuses: t.Dict[int, str] = {}
+        self.statuses: t.Dict[int, SmartSimStatus] = {}
         self.returns: t.Dict[int, t.Optional[int]] = {}
         self.job_times: t.Dict[int, float] = {}
 
     def record(
         self,
         job_id: t.Optional[str],
-        status: str,
+        status: SmartSimStatus,
         returncode: t.Optional[int],
         job_time: float,
     ) -> None:

--- a/smartsim/_core/control/job.py
+++ b/smartsim/_core/control/job.py
@@ -125,9 +125,15 @@ class Job:
         """Set the status  of a job.
 
         :param new_status: The new status of the job
-        :type new_status: str
+        :type new_status: SmartSimStatus
+        :param raw_status: The return code for the launcher
+        :type raw_status: str
         :param returncode: The return code for the job
-        :type return_code: str
+        :type return_code: int
+        :param error: Output message
+        :type error: str
+        :param output: Output message
+        :type output: str
         """
         self.status = new_status
         self.raw_status = raw_status

--- a/smartsim/_core/control/job.py
+++ b/smartsim/_core/control/job.py
@@ -126,13 +126,13 @@ class Job:
 
         :param new_status: The new status of the job
         :type new_status: SmartSimStatus
-        :param raw_status: The return code for the launcher
+        :param raw_status: The raw status of the launcher
         :type raw_status: str
         :param returncode: The return code for the job
         :type return_code: int
-        :param error: Output message
+        :param error: Content produced by stderr
         :type error: str
-        :param output: Output message
+        :param output: Content produced by stdout
         :type output: str
         """
         self.status = new_status

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -35,7 +35,7 @@ from types import FrameType
 from ...database import Orchestrator
 from ...entity import DBNode, EntitySequence, SmartSimEntity
 from ...log import ContextThread, get_logger
-from ...status import SmartSimStatus
+from ...status import TERMINAL_STATUSES, SmartSimStatus
 from ..config import CONFIG
 from ..launcher import Launcher, LocalLauncher
 from ..utils.network import get_ip_from_host
@@ -104,11 +104,7 @@ class JobManager:
             for _, job in self().items():
                 # if the job has errors then output the report
                 # this should only output once
-                if job.returncode is not None and job.status in [
-                    SmartSimStatus.STATUS_CANCELLED,
-                    SmartSimStatus.STATUS_COMPLETED,
-                    SmartSimStatus.STATUS_FAILED,
-                ]:
+                if job.returncode is not None and job.status in TERMINAL_STATUSES:
                     if int(job.returncode) != 0:
                         logger.warning(job)
                         logger.warning(job.error_report())
@@ -364,15 +360,7 @@ class JobManager:
         if self.actively_monitoring and len(self) > 0:
             if self.kill_on_interrupt:
                 for _, job in self().items():
-                    if (
-                        job.status
-                        not in [
-                            SmartSimStatus.STATUS_CANCELLED,
-                            SmartSimStatus.STATUS_COMPLETED,
-                            SmartSimStatus.STATUS_FAILED,
-                        ]
-                        and self._launcher
-                    ):
+                    if job.status not in TERMINAL_STATUSES and self._launcher:
                         self._launcher.stop(job.name)
             else:
                 logger.warning("SmartSim process interrupted before resource cleanup")

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -204,11 +204,7 @@ class JobManager:
         with self._lock:
             job = self[entity.name]  # locked operation
             if entity.name in self.completed:
-                if job.status in [
-                    SmartSimStatus.STATUS_CANCELLED,
-                    SmartSimStatus.STATUS_COMPLETED,
-                    SmartSimStatus.STATUS_FAILED,
-                ]:
+                if job.status in TERMINAL_STATUSES:
                     return True
             return False
 

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -104,7 +104,11 @@ class JobManager:
             for _, job in self().items():
                 # if the job has errors then output the report
                 # this should only output once
-                if job.returncode is not None and job.status in [SmartSimStatus.STATUS_CANCELLED, SmartSimStatus.STATUS_COMPLETED, SmartSimStatus.STATUS_FAILED]:
+                if job.returncode is not None and job.status in [
+                    SmartSimStatus.STATUS_CANCELLED,
+                    SmartSimStatus.STATUS_COMPLETED,
+                    SmartSimStatus.STATUS_FAILED,
+                ]:
                     if int(job.returncode) != 0:
                         logger.warning(job)
                         logger.warning(job.error_report())
@@ -204,7 +208,11 @@ class JobManager:
         with self._lock:
             job = self[entity.name]  # locked operation
             if entity.name in self.completed:
-                if job.status in [SmartSimStatus.STATUS_CANCELLED, SmartSimStatus.STATUS_COMPLETED, SmartSimStatus.STATUS_FAILED]:
+                if job.status in [
+                    SmartSimStatus.STATUS_CANCELLED,
+                    SmartSimStatus.STATUS_COMPLETED,
+                    SmartSimStatus.STATUS_FAILED,
+                ]:
                     return True
             return False
 
@@ -355,7 +363,15 @@ class JobManager:
         if self.actively_monitoring and len(self) > 0:
             if self.kill_on_interrupt:
                 for _, job in self().items():
-                    if job.status not in [SmartSimStatus.STATUS_CANCELLED, SmartSimStatus.STATUS_COMPLETED, SmartSimStatus.STATUS_FAILED] and self._launcher:
+                    if (
+                        job.status
+                        not in [
+                            SmartSimStatus.STATUS_CANCELLED,
+                            SmartSimStatus.STATUS_COMPLETED,
+                            SmartSimStatus.STATUS_FAILED,
+                        ]
+                        and self._launcher
+                    ):
                         self._launcher.stop(job.name)
             else:
                 logger.warning("SmartSim process interrupted before resource cleanup")

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -252,7 +252,8 @@ class JobManager:
 
         :param entity: SmartSimEntity or EntitySequence instance
         :type entity: SmartSimEntity | EntitySequence
-        :returns: tuple of status
+        :returns: a SmartSimStatus status
+        :rtype: SmartSimStatus
         """
         with self._lock:
             if entity.name in self.completed:

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -58,7 +58,7 @@ from smartsim._core.launcher.stepInfo import StepInfo
 from smartsim._core.utils.helpers import get_ts
 from smartsim._core.utils.serialize import MANIFEST_FILENAME
 from smartsim.error.errors import SmartSimError
-from smartsim.status import STATUS_COMPLETED, TERMINAL_STATUSES
+from smartsim.status import SmartSimStatus
 
 """Telemetry Monitor entrypoint"""
 
@@ -283,10 +283,10 @@ def faux_return_code(step_info: StepInfo) -> t.Optional[int]:
     """Create a faux return code for a task run by the WLM. Must not be
     called with non-terminal statuses or results may be confusing
     """
-    if step_info.status not in TERMINAL_STATUSES:
+    if step_info.status not in [SmartSimStatus.STATUS_CANCELLED, SmartSimStatus.STATUS_COMPLETED, SmartSimStatus.STATUS_FAILED]:
         return None
 
-    if step_info.status == STATUS_COMPLETED:
+    if step_info.status == SmartSimStatus.STATUS_COMPLETED:
         return os.EX_OK
 
     return 1
@@ -494,7 +494,7 @@ class ManifestEventHandler(PatternMatchingEventHandler):
             step_updates = self._launcher.get_step_update(list(names.keys()))
 
             for step_name, step_info in step_updates:
-                if step_info and step_info.status in TERMINAL_STATUSES:
+                if step_info and step_info.status in [SmartSimStatus.STATUS_CANCELLED, SmartSimStatus.STATUS_COMPLETED, SmartSimStatus.STATUS_FAILED]:
                     completed_entity = names[step_name]
                     self._to_completed(timestamp, completed_entity, step_info)
 

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -58,7 +58,7 @@ from smartsim._core.launcher.stepInfo import StepInfo
 from smartsim._core.utils.helpers import get_ts
 from smartsim._core.utils.serialize import MANIFEST_FILENAME
 from smartsim.error.errors import SmartSimError
-from smartsim.status import SmartSimStatus
+from smartsim.status import TERMINAL_STATUSES, SmartSimStatus
 
 """Telemetry Monitor entrypoint"""
 
@@ -283,11 +283,7 @@ def faux_return_code(step_info: StepInfo) -> t.Optional[int]:
     """Create a faux return code for a task run by the WLM. Must not be
     called with non-terminal statuses or results may be confusing
     """
-    if step_info.status not in [
-        SmartSimStatus.STATUS_CANCELLED,
-        SmartSimStatus.STATUS_COMPLETED,
-        SmartSimStatus.STATUS_FAILED,
-    ]:
+    if step_info.status not in TERMINAL_STATUSES:
         return None
 
     if step_info.status == SmartSimStatus.STATUS_COMPLETED:
@@ -498,11 +494,7 @@ class ManifestEventHandler(PatternMatchingEventHandler):
             step_updates = self._launcher.get_step_update(list(names.keys()))
 
             for step_name, step_info in step_updates:
-                if step_info and step_info.status in [
-                    SmartSimStatus.STATUS_CANCELLED,
-                    SmartSimStatus.STATUS_COMPLETED,
-                    SmartSimStatus.STATUS_FAILED,
-                ]:
+                if step_info and step_info.status in TERMINAL_STATUSES:
                     completed_entity = names[step_name]
                     self._to_completed(timestamp, completed_entity, step_info)
 

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -283,7 +283,11 @@ def faux_return_code(step_info: StepInfo) -> t.Optional[int]:
     """Create a faux return code for a task run by the WLM. Must not be
     called with non-terminal statuses or results may be confusing
     """
-    if step_info.status not in [SmartSimStatus.STATUS_CANCELLED, SmartSimStatus.STATUS_COMPLETED, SmartSimStatus.STATUS_FAILED]:
+    if step_info.status not in [
+        SmartSimStatus.STATUS_CANCELLED,
+        SmartSimStatus.STATUS_COMPLETED,
+        SmartSimStatus.STATUS_FAILED,
+    ]:
         return None
 
     if step_info.status == SmartSimStatus.STATUS_COMPLETED:
@@ -494,7 +498,11 @@ class ManifestEventHandler(PatternMatchingEventHandler):
             step_updates = self._launcher.get_step_update(list(names.keys()))
 
             for step_name, step_info in step_updates:
-                if step_info and step_info.status in [SmartSimStatus.STATUS_CANCELLED, SmartSimStatus.STATUS_COMPLETED, SmartSimStatus.STATUS_FAILED]:
+                if step_info and step_info.status in [
+                    SmartSimStatus.STATUS_CANCELLED,
+                    SmartSimStatus.STATUS_COMPLETED,
+                    SmartSimStatus.STATUS_FAILED,
+                ]:
                     completed_entity = names[step_name]
                     self._to_completed(timestamp, completed_entity, step_info)
 

--- a/smartsim/_core/launcher/lsf/lsfLauncher.py
+++ b/smartsim/_core/launcher/lsf/lsfLauncher.py
@@ -155,7 +155,9 @@ class LSFLauncher(WLMLauncher):
         if not step_info:
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
-        step_info.status = SmartSimStatus.STATUS_CANCELLED  # set status to cancelled instead of failed
+        step_info.status = (
+            SmartSimStatus.STATUS_CANCELLED
+        )  # set status to cancelled instead of failed
         return step_info
 
     @staticmethod

--- a/smartsim/_core/launcher/lsf/lsfLauncher.py
+++ b/smartsim/_core/launcher/lsf/lsfLauncher.py
@@ -38,7 +38,7 @@ from ....settings import (
     RunSettings,
     SettingsBase,
 )
-from ....status import STATUS_CANCELLED, STATUS_COMPLETED
+from ....status import SmartSimStatus
 from ...config import CONFIG
 from ..launcher import WLMLauncher
 from ..step import (
@@ -155,7 +155,7 @@ class LSFLauncher(WLMLauncher):
         if not step_info:
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
-        step_info.status = STATUS_CANCELLED  # set status to cancelled instead of failed
+        step_info.status = SmartSimStatus.STATUS_CANCELLED  # set status to cancelled instead of failed
         return step_info
 
     @staticmethod
@@ -207,7 +207,7 @@ class LSFLauncher(WLMLauncher):
                 # create LSFBatchStepInfo objects to return
                 batch_info = LSFBatchStepInfo(stat, None)
                 # account for case where job history is not logged by LSF
-                if batch_info.status == STATUS_COMPLETED:
+                if batch_info.status == SmartSimStatus.STATUS_COMPLETED:
                     batch_info.returncode = 0
                 updates.append(batch_info)
         return updates

--- a/smartsim/_core/launcher/pbs/pbsLauncher.py
+++ b/smartsim/_core/launcher/pbs/pbsLauncher.py
@@ -149,7 +149,9 @@ class PBSLauncher(WLMLauncher):
         if not step_info:
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
-        step_info.status = SmartSimStatus.STATUS_CANCELLED  # set status to cancelled instead of failed
+        step_info.status = (
+            SmartSimStatus.STATUS_CANCELLED
+        )  # set status to cancelled instead of failed
         return step_info
 
     @staticmethod

--- a/smartsim/_core/launcher/pbs/pbsLauncher.py
+++ b/smartsim/_core/launcher/pbs/pbsLauncher.py
@@ -39,7 +39,7 @@ from ....settings import (
     RunSettings,
     SettingsBase,
 )
-from ....status import STATUS_CANCELLED, STATUS_COMPLETED
+from ....status import SmartSimStatus
 from ...config import CONFIG
 from ..launcher import WLMLauncher
 from ..step import (
@@ -149,7 +149,7 @@ class PBSLauncher(WLMLauncher):
         if not step_info:
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
-        step_info.status = STATUS_CANCELLED  # set status to cancelled instead of failed
+        step_info.status = SmartSimStatus.STATUS_CANCELLED  # set status to cancelled instead of failed
         return step_info
 
     @staticmethod
@@ -191,7 +191,7 @@ class PBSLauncher(WLMLauncher):
         for stat, _ in zip(stats, step_ids):
             info = PBSStepInfo(stat, None)
             # account for case where job history is not logged by PBS
-            if info.status == STATUS_COMPLETED:
+            if info.status == SmartSimStatus.STATUS_COMPLETED:
                 info.returncode = 0
 
             updates.append(info)

--- a/smartsim/_core/launcher/slurm/slurmLauncher.py
+++ b/smartsim/_core/launcher/slurm/slurmLauncher.py
@@ -218,7 +218,9 @@ class SlurmLauncher(WLMLauncher):
         if not step_info:
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
-        step_info.status = SmartSimStatus.STATUS_CANCELLED  # set status to cancelled instead of failed
+        step_info.status = (
+            SmartSimStatus.STATUS_CANCELLED
+        )  # set status to cancelled instead of failed
         return step_info
 
     @staticmethod

--- a/smartsim/_core/launcher/slurm/slurmLauncher.py
+++ b/smartsim/_core/launcher/slurm/slurmLauncher.py
@@ -40,7 +40,7 @@ from ....settings import (
     SettingsBase,
     SrunSettings,
 )
-from ....status import STATUS_CANCELLED
+from ....status import SmartSimStatus
 from ...config import CONFIG
 from ..launcher import WLMLauncher
 from ..step import (
@@ -218,7 +218,7 @@ class SlurmLauncher(WLMLauncher):
         if not step_info:
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
-        step_info.status = STATUS_CANCELLED  # set status to cancelled instead of failed
+        step_info.status = SmartSimStatus.STATUS_CANCELLED  # set status to cancelled instead of failed
         return step_info
 
     @staticmethod

--- a/smartsim/_core/launcher/stepInfo.py
+++ b/smartsim/_core/launcher/stepInfo.py
@@ -62,7 +62,7 @@ class StepInfo:
         """
         Map the status of the WLM step to a smartsim-specific status
         """
-        if any(statuses.value == status for statuses in SmartSimStatus):
+        if any(ss_status.value == status for ss_status in SmartSimStatus):
             return SmartSimStatus(status)
 
         if status in self.mapping and returncode in [None, 0]:

--- a/smartsim/_core/launcher/stepInfo.py
+++ b/smartsim/_core/launcher/stepInfo.py
@@ -27,21 +27,12 @@
 import typing as t
 
 import psutil
-
-from ...status import (
-    SMARTSIM_STATUS,
-    STATUS_CANCELLED,
-    STATUS_COMPLETED,
-    STATUS_FAILED,
-    STATUS_PAUSED,
-    STATUS_RUNNING,
-)
-
+from ...status import SmartSimStatus
 
 class StepInfo:
     def __init__(
         self,
-        status: str = "",
+        status: SmartSimStatus,
         launcher_status: str = "",
         returncode: t.Optional[int] = None,
         output: t.Optional[str] = None,
@@ -60,42 +51,42 @@ class StepInfo:
         return info_str
 
     @property
-    def mapping(self) -> t.Dict[str, str]:
+    def mapping(self) -> t.Dict[str, SmartSimStatus]:
         raise NotImplementedError
 
     def _get_smartsim_status(
         self, status: str, returncode: t.Optional[int] = None
-    ) -> str:
+    ) -> SmartSimStatus:
         """
         Map the status of the WLM step to a smartsim-specific status
         """
-        if status in SMARTSIM_STATUS:
-            return SMARTSIM_STATUS[status]
+        if any(statuses.value == status for statuses in SmartSimStatus):
+            return SmartSimStatus(status)
 
         if status in self.mapping and returncode in [None, 0]:
             return self.mapping[status]
 
-        return STATUS_FAILED
+        return SmartSimStatus.STATUS_FAILED
 
 
 class UnmanagedStepInfo(StepInfo):
     @property
-    def mapping(self) -> t.Dict[str, str]:
+    def mapping(self) -> t.Dict[str, SmartSimStatus]:
         # see https://github.com/giampaolo/psutil/blob/master/psutil/_pslinux.py
         # see https://github.com/giampaolo/psutil/blob/master/psutil/_common.py
         return {
-            psutil.STATUS_RUNNING: STATUS_RUNNING,
-            psutil.STATUS_SLEEPING: STATUS_RUNNING,  # sleeping thread is still alive
-            psutil.STATUS_WAKING: STATUS_RUNNING,
-            psutil.STATUS_DISK_SLEEP: STATUS_RUNNING,
-            psutil.STATUS_DEAD: STATUS_FAILED,
-            psutil.STATUS_TRACING_STOP: STATUS_PAUSED,
-            psutil.STATUS_WAITING: STATUS_PAUSED,
-            psutil.STATUS_STOPPED: STATUS_PAUSED,
-            psutil.STATUS_LOCKED: STATUS_PAUSED,
-            psutil.STATUS_PARKED: STATUS_PAUSED,
-            psutil.STATUS_IDLE: STATUS_PAUSED,
-            psutil.STATUS_ZOMBIE: STATUS_COMPLETED,
+            psutil.STATUS_RUNNING: SmartSimStatus.STATUS_RUNNING,
+            psutil.STATUS_SLEEPING: SmartSimStatus.STATUS_RUNNING,  # sleeping thread is still alive
+            psutil.STATUS_WAKING: SmartSimStatus.STATUS_RUNNING,
+            psutil.STATUS_DISK_SLEEP: SmartSimStatus.STATUS_RUNNING,
+            psutil.STATUS_DEAD: SmartSimStatus.STATUS_FAILED,
+            psutil.STATUS_TRACING_STOP: SmartSimStatus.STATUS_PAUSED,
+            psutil.STATUS_WAITING: SmartSimStatus.STATUS_PAUSED,
+            psutil.STATUS_STOPPED: SmartSimStatus.STATUS_PAUSED,
+            psutil.STATUS_LOCKED: SmartSimStatus.STATUS_PAUSED,
+            psutil.STATUS_PARKED: SmartSimStatus.STATUS_PAUSED,
+            psutil.STATUS_IDLE: SmartSimStatus.STATUS_PAUSED,
+            psutil.STATUS_ZOMBIE: SmartSimStatus.STATUS_COMPLETED,
         }
 
     def __init__(
@@ -114,30 +105,30 @@ class UnmanagedStepInfo(StepInfo):
 class SlurmStepInfo(StepInfo):  # cov-slurm
     # see https://slurm.schedmd.com/squeue.html#lbAG
     mapping = {
-        "RUNNING": STATUS_RUNNING,
-        "CONFIGURING": STATUS_RUNNING,
-        "STAGE_OUT": STATUS_RUNNING,
-        "COMPLETED": STATUS_COMPLETED,
-        "DEADLINE": STATUS_COMPLETED,
-        "TIMEOUT": STATUS_COMPLETED,
-        "BOOT_FAIL": STATUS_FAILED,
-        "FAILED": STATUS_FAILED,
-        "NODE_FAIL": STATUS_FAILED,
-        "OUT_OF_MEMORY": STATUS_FAILED,
-        "CANCELLED": STATUS_CANCELLED,
-        "CANCELLED+": STATUS_CANCELLED,
-        "REVOKED": STATUS_CANCELLED,
-        "PENDING": STATUS_PAUSED,
-        "PREEMPTED": STATUS_PAUSED,
-        "RESV_DEL_HOLD": STATUS_PAUSED,
-        "REQUEUE_FED": STATUS_PAUSED,
-        "REQUEUE_HOLD": STATUS_PAUSED,
-        "REQUEUED": STATUS_PAUSED,
-        "RESIZING": STATUS_PAUSED,
-        "SIGNALING": STATUS_PAUSED,
-        "SPECIAL_EXIT": STATUS_PAUSED,
-        "STOPPED": STATUS_PAUSED,
-        "SUSPENDED": STATUS_PAUSED,
+        "RUNNING": SmartSimStatus.STATUS_RUNNING,
+        "CONFIGURING": SmartSimStatus.STATUS_RUNNING,
+        "STAGE_OUT": SmartSimStatus.STATUS_RUNNING,
+        "COMPLETED": SmartSimStatus.STATUS_COMPLETED,
+        "DEADLINE": SmartSimStatus.STATUS_COMPLETED,
+        "TIMEOUT": SmartSimStatus.STATUS_COMPLETED,
+        "BOOT_FAIL": SmartSimStatus.STATUS_FAILED,
+        "FAILED": SmartSimStatus.STATUS_FAILED,
+        "NODE_FAIL": SmartSimStatus.STATUS_FAILED,
+        "OUT_OF_MEMORY": SmartSimStatus.STATUS_FAILED,
+        "CANCELLED": SmartSimStatus.STATUS_CANCELLED,
+        "CANCELLED+": SmartSimStatus.STATUS_CANCELLED,
+        "REVOKED": SmartSimStatus.STATUS_CANCELLED,
+        "PENDING": SmartSimStatus.STATUS_PAUSED,
+        "PREEMPTED": SmartSimStatus.STATUS_PAUSED,
+        "RESV_DEL_HOLD": SmartSimStatus.STATUS_PAUSED,
+        "REQUEUE_FED": SmartSimStatus.STATUS_PAUSED,
+        "REQUEUE_HOLD": SmartSimStatus.STATUS_PAUSED,
+        "REQUEUED": SmartSimStatus.STATUS_PAUSED,
+        "RESIZING": SmartSimStatus.STATUS_PAUSED,
+        "SIGNALING": SmartSimStatus.STATUS_PAUSED,
+        "SPECIAL_EXIT": SmartSimStatus.STATUS_PAUSED,
+        "STOPPED": SmartSimStatus.STATUS_PAUSED,
+        "SUSPENDED": SmartSimStatus.STATUS_PAUSED,
     }
 
     def __init__(
@@ -155,23 +146,23 @@ class SlurmStepInfo(StepInfo):  # cov-slurm
 
 class PBSStepInfo(StepInfo):  # cov-pbs
     @property
-    def mapping(self) -> t.Dict[str, str]:
+    def mapping(self) -> t.Dict[str, SmartSimStatus]:
         # pylint: disable=line-too-long
         # see http://nusc.nsu.ru/wiki/lib/exe/fetch.php/doc/pbs/PBSReferenceGuide19.2.1.pdf#M11.9.90788.PBSHeading1.81.Job.States
         return {
-            "R": STATUS_RUNNING,
-            "B": STATUS_RUNNING,
-            "H": STATUS_PAUSED,
-            "M": STATUS_PAUSED,  # Actually means that it was moved to another server,
+            "R": SmartSimStatus.STATUS_RUNNING,
+            "B": SmartSimStatus.STATUS_RUNNING,
+            "H": SmartSimStatus.STATUS_PAUSED,
+            "M": SmartSimStatus.STATUS_PAUSED,  # Actually means that it was moved to another server,
             # TODO: understand what this implies
-            "Q": STATUS_PAUSED,
-            "S": STATUS_PAUSED,
-            "T": STATUS_PAUSED,  # This means in transition, see above for comment
-            "U": STATUS_PAUSED,
-            "W": STATUS_PAUSED,
-            "E": STATUS_COMPLETED,
-            "F": STATUS_COMPLETED,
-            "X": STATUS_COMPLETED,
+            "Q":SmartSimStatus.STATUS_PAUSED,
+            "S": SmartSimStatus.STATUS_PAUSED,
+            "T": SmartSimStatus.STATUS_PAUSED,  # This means in transition, see above for comment
+            "U": SmartSimStatus.STATUS_PAUSED,
+            "W": SmartSimStatus.STATUS_PAUSED,
+            "E": SmartSimStatus.STATUS_COMPLETED,
+            "F": SmartSimStatus.STATUS_COMPLETED,
+            "X": SmartSimStatus.STATUS_COMPLETED,
         }
 
     def __init__(
@@ -183,10 +174,10 @@ class PBSStepInfo(StepInfo):  # cov-pbs
     ) -> None:
         if status == "NOTFOUND":
             if returncode is not None:
-                smartsim_status = "Completed" if returncode == 0 else "Failed"
+                smartsim_status = SmartSimStatus.STATUS_COMPLETED if returncode == 0 else SmartSimStatus.STATUS_FAILED
             else:
                 # if PBS job history isnt available, and job isnt in queue
-                smartsim_status = "Completed"
+                smartsim_status = SmartSimStatus.STATUS_COMPLETED
                 returncode = 0
         else:
             smartsim_status = self._get_smartsim_status(status)
@@ -197,16 +188,16 @@ class PBSStepInfo(StepInfo):  # cov-pbs
 
 class LSFBatchStepInfo(StepInfo):  # cov-lsf
     @property
-    def mapping(self) -> t.Dict[str, str]:
+    def mapping(self) -> t.Dict[str, SmartSimStatus]:
         # pylint: disable=line-too-long
         # see https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=execution-about-job-states
         return {
-            "RUN": STATUS_RUNNING,
-            "PSUSP": STATUS_PAUSED,
-            "USUSP": STATUS_PAUSED,
-            "SSUSP": STATUS_PAUSED,
-            "PEND": STATUS_PAUSED,
-            "DONE": STATUS_COMPLETED,
+            "RUN": SmartSimStatus.STATUS_RUNNING,
+            "PSUSP": SmartSimStatus.STATUS_PAUSED,
+            "USUSP": SmartSimStatus.STATUS_PAUSED,
+            "SSUSP": SmartSimStatus.STATUS_PAUSED,
+            "PEND": SmartSimStatus.STATUS_PAUSED,
+            "DONE": SmartSimStatus.STATUS_COMPLETED,
         }
 
     def __init__(
@@ -218,9 +209,9 @@ class LSFBatchStepInfo(StepInfo):  # cov-lsf
     ) -> None:
         if status == "NOTFOUND":
             if returncode is not None:
-                smartsim_status = "Completed" if returncode == 0 else "Failed"
+                smartsim_status = SmartSimStatus.STATUS_COMPLETED if returncode == 0 else SmartSimStatus.STATUS_FAILED
             else:
-                smartsim_status = "Completed"
+                smartsim_status = SmartSimStatus.STATUS_COMPLETED
                 returncode = 0
         else:
             smartsim_status = self._get_smartsim_status(status)
@@ -231,14 +222,14 @@ class LSFBatchStepInfo(StepInfo):  # cov-lsf
 
 class LSFJsrunStepInfo(StepInfo):  # cov-lsf
     @property
-    def mapping(self) -> t.Dict[str, str]:
+    def mapping(self) -> t.Dict[str, SmartSimStatus]:
         # pylint: disable=line-too-long
         # see https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=execution-about-job-states
         return {
-            "Killed": STATUS_COMPLETED,
-            "Running": STATUS_RUNNING,
-            "Queued": STATUS_PAUSED,
-            "Complete": STATUS_COMPLETED,
+            "Killed": SmartSimStatus.STATUS_COMPLETED,
+            "Running": SmartSimStatus.STATUS_RUNNING,
+            "Queued": SmartSimStatus.STATUS_PAUSED,
+            "Complete": SmartSimStatus.STATUS_COMPLETED,
         }
 
     def __init__(
@@ -250,9 +241,9 @@ class LSFJsrunStepInfo(StepInfo):  # cov-lsf
     ) -> None:
         if status == "NOTFOUND":
             if returncode is not None:
-                smartsim_status = "Completed" if returncode == 0 else "Failed"
+                smartsim_status = SmartSimStatus.STATUS_COMPLETED if returncode == 0 else SmartSimStatus.STATUS_FAILED
             else:
-                smartsim_status = "Completed"
+                smartsim_status = SmartSimStatus.STATUS_COMPLETED
                 returncode = 0
         else:
             smartsim_status = self._get_smartsim_status(status, returncode)

--- a/smartsim/_core/launcher/stepInfo.py
+++ b/smartsim/_core/launcher/stepInfo.py
@@ -27,7 +27,9 @@
 import typing as t
 
 import psutil
+
 from ...status import SmartSimStatus
+
 
 class StepInfo:
     def __init__(
@@ -45,7 +47,7 @@ class StepInfo:
         self.error = error
 
     def __str__(self) -> str:
-        info_str = f"Status: {self.status}"
+        info_str = f"Status: {self.status.value}"
         info_str += f" | Launcher Status {self.launcher_status}"
         info_str += f" | Returncode {str(self.returncode)}"
         return info_str
@@ -76,7 +78,9 @@ class UnmanagedStepInfo(StepInfo):
         # see https://github.com/giampaolo/psutil/blob/master/psutil/_common.py
         return {
             psutil.STATUS_RUNNING: SmartSimStatus.STATUS_RUNNING,
-            psutil.STATUS_SLEEPING: SmartSimStatus.STATUS_RUNNING,  # sleeping thread is still alive
+            psutil.STATUS_SLEEPING: (
+                SmartSimStatus.STATUS_RUNNING
+            ),  # sleeping thread is still alive
             psutil.STATUS_WAKING: SmartSimStatus.STATUS_RUNNING,
             psutil.STATUS_DISK_SLEEP: SmartSimStatus.STATUS_RUNNING,
             psutil.STATUS_DEAD: SmartSimStatus.STATUS_FAILED,
@@ -153,11 +157,15 @@ class PBSStepInfo(StepInfo):  # cov-pbs
             "R": SmartSimStatus.STATUS_RUNNING,
             "B": SmartSimStatus.STATUS_RUNNING,
             "H": SmartSimStatus.STATUS_PAUSED,
-            "M": SmartSimStatus.STATUS_PAUSED,  # Actually means that it was moved to another server,
+            "M": (
+                SmartSimStatus.STATUS_PAUSED
+            ),  # Actually means that it was moved to another server,
             # TODO: understand what this implies
-            "Q":SmartSimStatus.STATUS_PAUSED,
+            "Q": SmartSimStatus.STATUS_PAUSED,
             "S": SmartSimStatus.STATUS_PAUSED,
-            "T": SmartSimStatus.STATUS_PAUSED,  # This means in transition, see above for comment
+            "T": (
+                SmartSimStatus.STATUS_PAUSED
+            ),  # This means in transition, see above for comment
             "U": SmartSimStatus.STATUS_PAUSED,
             "W": SmartSimStatus.STATUS_PAUSED,
             "E": SmartSimStatus.STATUS_COMPLETED,
@@ -174,7 +182,11 @@ class PBSStepInfo(StepInfo):  # cov-pbs
     ) -> None:
         if status == "NOTFOUND":
             if returncode is not None:
-                smartsim_status = SmartSimStatus.STATUS_COMPLETED if returncode == 0 else SmartSimStatus.STATUS_FAILED
+                smartsim_status = (
+                    SmartSimStatus.STATUS_COMPLETED
+                    if returncode == 0
+                    else SmartSimStatus.STATUS_FAILED
+                )
             else:
                 # if PBS job history isnt available, and job isnt in queue
                 smartsim_status = SmartSimStatus.STATUS_COMPLETED
@@ -209,7 +221,11 @@ class LSFBatchStepInfo(StepInfo):  # cov-lsf
     ) -> None:
         if status == "NOTFOUND":
             if returncode is not None:
-                smartsim_status = SmartSimStatus.STATUS_COMPLETED if returncode == 0 else SmartSimStatus.STATUS_FAILED
+                smartsim_status = (
+                    SmartSimStatus.STATUS_COMPLETED
+                    if returncode == 0
+                    else SmartSimStatus.STATUS_FAILED
+                )
             else:
                 smartsim_status = SmartSimStatus.STATUS_COMPLETED
                 returncode = 0
@@ -241,7 +257,11 @@ class LSFJsrunStepInfo(StepInfo):  # cov-lsf
     ) -> None:
         if status == "NOTFOUND":
             if returncode is not None:
-                smartsim_status = SmartSimStatus.STATUS_COMPLETED if returncode == 0 else SmartSimStatus.STATUS_FAILED
+                smartsim_status = (
+                    SmartSimStatus.STATUS_COMPLETED
+                    if returncode == 0
+                    else SmartSimStatus.STATUS_FAILED
+                )
             else:
                 smartsim_status = SmartSimStatus.STATUS_COMPLETED
                 returncode = 0

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -32,6 +32,7 @@ from os import getcwd
 from tabulate import tabulate
 
 from smartsim.error.errors import SSUnsupportedError
+from smartsim.status import SmartSimStatus
 
 from ._core import Controller, Generator, Manifest
 from ._core.utils import init_default
@@ -368,7 +369,7 @@ class Experiment:
     @_contextualize
     def get_status(
         self, *args: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]]
-    ) -> t.List[str]:
+    ) -> t.List[SmartSimStatus]:
         """Query the status of launched instances
 
         Return a smartsim.status string representing
@@ -396,7 +397,7 @@ class Experiment:
         """
         try:
             manifest = Manifest(*args)
-            statuses: t.List[str] = []
+            statuses: t.List[SmartSimStatus] = []
             for entity in manifest.models:
                 statuses.append(self._control.get_entity_status(entity))
             for entity_list in manifest.all_entity_lists:

--- a/smartsim/status.py
+++ b/smartsim/status.py
@@ -26,6 +26,7 @@
 
 from enum import Enum
 
+
 class SmartSimStatus(Enum):
     STATUS_RUNNING = "Running"
     STATUS_COMPLETED = "Completed"

--- a/smartsim/status.py
+++ b/smartsim/status.py
@@ -24,27 +24,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from enum import Enum
 
-# Statuses that are applied to jobs
-STATUS_RUNNING = "Running"
-STATUS_COMPLETED = "Completed"
-STATUS_CANCELLED = "Cancelled"
-STATUS_FAILED = "Failed"
-STATUS_NEW = "New"
-STATUS_PAUSED = "Paused"
-STATUS_NEVER_STARTED = "NeverStarted"
-
-# SmartSim status mapping
-SMARTSIM_STATUS = {
-    "Running": STATUS_RUNNING,
-    "Paused": STATUS_PAUSED,
-    "Completed": STATUS_COMPLETED,
-    "Cancelled": STATUS_CANCELLED,
-    "Failed": STATUS_FAILED,
-    "New": STATUS_NEW,
-    "NeverStarted": STATUS_NEVER_STARTED,
-}
-
-# Status groupings
-TERMINAL_STATUSES = {STATUS_CANCELLED, STATUS_COMPLETED, STATUS_FAILED}
-LIVE_STATUSES = {STATUS_RUNNING, STATUS_PAUSED, STATUS_NEW}
+class SmartSimStatus(Enum):
+    STATUS_RUNNING = "Running"
+    STATUS_COMPLETED = "Completed"
+    STATUS_CANCELLED = "Cancelled"
+    STATUS_FAILED = "Failed"
+    STATUS_NEW = "New"
+    STATUS_PAUSED = "Paused"
+    STATUS_NEVER_STARTED = "NeverStarted"

--- a/smartsim/status.py
+++ b/smartsim/status.py
@@ -35,3 +35,10 @@ class SmartSimStatus(Enum):
     STATUS_NEW = "New"
     STATUS_PAUSED = "Paused"
     STATUS_NEVER_STARTED = "NeverStarted"
+
+
+TERMINAL_STATUSES = {
+    SmartSimStatus.STATUS_CANCELLED,
+    SmartSimStatus.STATUS_COMPLETED,
+    SmartSimStatus.STATUS_FAILED,
+}

--- a/tests/backends/test_dataloader.py
+++ b/tests/backends/test_dataloader.py
@@ -35,7 +35,7 @@ from smartsim.error.errors import SSInternalError
 from smartsim.experiment import Experiment
 from smartsim.log import get_logger
 from smartsim.ml.data import DataInfo, TrainingDataUploader
-from smartsim.status import STATUS_COMPLETED
+from smartsim.status import SmartSimStatus
 
 logger = get_logger(__name__)
 
@@ -289,7 +289,7 @@ def test_torch_dataloaders(fileutils, test_dir, wlmutils):
         trainer = create_trainer_torch(exp, config_dir, wlmutils)
         exp.start(trainer, block=True)
 
-        assert exp.get_status(trainer)[0] == STATUS_COMPLETED
+        assert exp.get_status(trainer)[0] == SmartSimStatus.STATUS_COMPLETED
 
     except Exception as e:
         raise e

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -30,12 +30,12 @@ import sys
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim._core.utils import installed_redisai_backends
 from smartsim.entity import Ensemble
 from smartsim.entity.dbobject import DBModel
 from smartsim.error.errors import SSUnsupportedError
 from smartsim.log import get_logger
+from smartsim.status import SmartSimStatus
 
 logger = get_logger(__name__)
 

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -29,7 +29,8 @@ import sys
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim._core.utils import installed_redisai_backends
 from smartsim.entity import Ensemble
 from smartsim.entity.dbobject import DBModel
@@ -218,7 +219,7 @@ def test_tf_db_model(fileutils, test_dir, wlmutils, mlutils):
         exp.start(db, smartsim_model, block=True)
         statuses = exp.get_status(smartsim_model)
         assert all(
-            stat == status.STATUS_COMPLETED for stat in statuses
+            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(db)
@@ -285,7 +286,7 @@ def test_pt_db_model(fileutils, test_dir, wlmutils, mlutils):
         exp.start(db, smartsim_model, block=True)
         statuses = exp.get_status(smartsim_model)
         assert all(
-            stat == status.STATUS_COMPLETED for stat in statuses
+            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(db)
@@ -386,7 +387,7 @@ def test_db_model_ensemble(fileutils, test_dir, wlmutils, mlutils):
         exp.start(db, smartsim_ensemble, block=True)
         statuses = exp.get_status(smartsim_ensemble)
         assert all(
-            stat == status.STATUS_COMPLETED for stat in statuses
+            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(db)
@@ -458,7 +459,7 @@ def test_colocated_db_model_tf(fileutils, test_dir, wlmutils, mlutils):
         exp.start(colo_model, block=True)
         statuses = exp.get_status(colo_model)
         assert all(
-            stat == status.STATUS_COMPLETED for stat in statuses
+            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(colo_model)
@@ -518,7 +519,7 @@ def test_colocated_db_model_pytorch(fileutils, test_dir, wlmutils, mlutils):
         exp.start(colo_model, block=True)
         statuses = exp.get_status(colo_model)
         assert all(
-            stat == status.STATUS_COMPLETED for stat in statuses
+            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(colo_model)
@@ -620,7 +621,7 @@ def test_colocated_db_model_ensemble(fileutils, test_dir, wlmutils, mlutils):
         exp.start(colo_ensemble, block=True)
         statuses = exp.get_status(colo_ensemble)
         assert all(
-            stat == status.STATUS_COMPLETED for stat in statuses
+            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(colo_ensemble)
@@ -724,7 +725,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, test_dir, wlmutils, ml
         exp.start(colo_ensemble, block=True)
         statuses = exp.get_status(colo_ensemble)
         assert all(
-            stat == status.STATUS_COMPLETED for stat in statuses
+            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(colo_ensemble)

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -31,12 +31,12 @@ import pytest
 from smartredis import *
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim._core.utils import installed_redisai_backends
 from smartsim.entity.dbobject import DBScript
 from smartsim.error.errors import SSUnsupportedError
 from smartsim.log import get_logger
 from smartsim.settings import MpiexecSettings, MpirunSettings
+from smartsim.status import SmartSimStatus
 
 logger = get_logger(__name__)
 

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -30,7 +30,8 @@ import sys
 import pytest
 from smartredis import *
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim._core.utils import installed_redisai_backends
 from smartsim.entity.dbobject import DBScript
 from smartsim.error.errors import SSUnsupportedError
@@ -125,7 +126,7 @@ def test_db_script(fileutils, test_dir, wlmutils, mlutils):
     try:
         exp.start(db, smartsim_model, block=True)
         statuses = exp.get_status(smartsim_model)
-        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
     finally:
         exp.stop(db)
 
@@ -221,7 +222,7 @@ def test_db_script_ensemble(fileutils, test_dir, wlmutils, mlutils):
     try:
         exp.start(db, ensemble, block=True)
         statuses = exp.get_status(ensemble)
-        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
     finally:
         exp.stop(db)
 
@@ -288,7 +289,7 @@ def test_colocated_db_script(fileutils, test_dir, wlmutils, mlutils):
     try:
         exp.start(colo_model, block=True)
         statuses = exp.get_status(colo_model)
-        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
     finally:
         exp.stop(colo_model)
 
@@ -388,7 +389,7 @@ def test_colocated_db_script_ensemble(fileutils, test_dir, wlmutils, mlutils):
     try:
         exp.start(colo_ensemble, block=True)
         statuses = exp.get_status(colo_ensemble)
-        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
     finally:
         exp.stop(colo_ensemble)
 
@@ -486,7 +487,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, test_dir, wlmutils, m
     try:
         exp.start(colo_ensemble, block=True)
         statuses = exp.get_status(colo_ensemble)
-        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
     finally:
         exp.stop(colo_ensemble)
 

--- a/tests/backends/test_onnx.py
+++ b/tests/backends/test_onnx.py
@@ -31,7 +31,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim._core.utils import installed_redisai_backends
-from smartsim.status import STATUS_FAILED
+from smartsim.status import SmartSimStatus
 
 sklearn_available = True
 try:
@@ -98,4 +98,4 @@ def test_sklearn_onnx(test_dir, mlutils, wlmutils):
     exp.stop(db)
     # if model failed, test will fail
     model_status = exp.get_status(model)
-    assert model_status[0] != STATUS_FAILED
+    assert model_status[0] != SmartSimStatus.STATUS_FAILED

--- a/tests/backends/test_tf.py
+++ b/tests/backends/test_tf.py
@@ -32,7 +32,7 @@ import pytest
 from smartsim import Experiment
 from smartsim._core.utils import installed_redisai_backends
 from smartsim.error import SmartSimError
-from smartsim.status import STATUS_FAILED
+from smartsim.status import SmartSimStatus
 
 tf_available = True
 try:
@@ -87,7 +87,7 @@ def test_keras_model(test_dir, mlutils, wlmutils):
     exp.stop(db)
     # if model failed, test will fail
     model_status = exp.get_status(model)[0]
-    assert model_status != STATUS_FAILED
+    assert model_status != SmartSimStatus.STATUS_FAILED
 
 
 def create_tf_model():

--- a/tests/backends/test_torch.py
+++ b/tests/backends/test_torch.py
@@ -31,7 +31,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim._core.utils import installed_redisai_backends
-from smartsim.status import STATUS_FAILED
+from smartsim.status import SmartSimStatus
 
 torch_available = True
 try:
@@ -86,4 +86,4 @@ def test_torch_model_and_script(test_dir, mlutils, wlmutils):
     exp.stop(db)
     # if model failed, test will fail
     model_status = exp.get_status(model)[0]
-    assert model_status != STATUS_FAILED
+    assert model_status != SmartSimStatus.STATUS_FAILED

--- a/tests/full_wlm/test_generic_batch_launch.py
+++ b/tests/full_wlm/test_generic_batch_launch.py
@@ -29,8 +29,8 @@ from time import sleep
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim.settings import QsubBatchSettings
+from smartsim.status import SmartSimStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:

--- a/tests/full_wlm/test_generic_batch_launch.py
+++ b/tests/full_wlm/test_generic_batch_launch.py
@@ -28,7 +28,8 @@ from time import sleep
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim.settings import QsubBatchSettings
 
 # retrieved from pytest fixtures
@@ -67,7 +68,7 @@ def test_batch_model(fileutils, test_dir, wlmutils):
     exp.start(model, block=True)
     statuses = exp.get_status(model)
     assert len(statuses) == 1
-    assert statuses[0] == status.STATUS_COMPLETED
+    assert statuses[0] == SmartSimStatus.STATUS_COMPLETED
 
 
 def test_batch_ensemble(fileutils, test_dir, wlmutils):
@@ -92,7 +93,7 @@ def test_batch_ensemble(fileutils, test_dir, wlmutils):
 
     exp.start(ensemble, block=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 def test_batch_ensemble_replicas(fileutils, test_dir, wlmutils):
@@ -113,4 +114,4 @@ def test_batch_ensemble_replicas(fileutils, test_dir, wlmutils):
 
     exp.start(ensemble, block=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])

--- a/tests/full_wlm/test_generic_orc_launch_batch.py
+++ b/tests/full_wlm/test_generic_orc_launch_batch.py
@@ -29,7 +29,8 @@ import time
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -66,13 +67,13 @@ def test_launch_orc_auto_batch(test_dir, wlmutils):
     statuses = exp.get_status(orc)
 
     # don't use assert so that we don't leave an orphan process
-    if status.STATUS_FAILED in statuses:
+    if SmartSimStatus.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
     statuses = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
 
 
 def test_launch_cluster_orc_batch_single(test_dir, wlmutils):
@@ -102,13 +103,13 @@ def test_launch_cluster_orc_batch_single(test_dir, wlmutils):
     statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in statuses:
+    if SmartSimStatus.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
     statuses = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
 
 
 def test_launch_cluster_orc_batch_multi(test_dir, wlmutils):
@@ -138,13 +139,13 @@ def test_launch_cluster_orc_batch_multi(test_dir, wlmutils):
     statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in statuses:
+    if SmartSimStatus.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
     statuses = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
 
 
 def test_launch_cluster_orc_reconnect(test_dir, wlmutils):
@@ -168,7 +169,7 @@ def test_launch_cluster_orc_reconnect(test_dir, wlmutils):
 
     statuses = exp.get_status(orc)
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in statuses:
+    if SmartSimStatus.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
@@ -185,7 +186,7 @@ def test_launch_cluster_orc_reconnect(test_dir, wlmutils):
 
     statuses = exp_2.get_status(reloaded_orc)
     for stat in statuses:
-        if stat == status.STATUS_FAILED:
+        if stat == SmartSimStatus.STATUS_FAILED:
             exp_2.stop(reloaded_orc)
             assert False
 

--- a/tests/full_wlm/test_mpmd.py
+++ b/tests/full_wlm/test_mpmd.py
@@ -28,7 +28,8 @@ from copy import deepcopy
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim._core.utils.helpers import is_valid_cmd
 
 # retrieved from pytest fixtures
@@ -89,8 +90,8 @@ def test_mpmd(fileutils, test_dir, wlmutils):
         mpmd_model = exp.create_model("mmpd", path=test_dir, run_settings=settings)
         exp.start(mpmd_model, block=True)
         statuses = exp.get_status(mpmd_model)
-        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
         exp.start(mpmd_model, block=True)
         statuses = exp.get_status(mpmd_model)
-        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])

--- a/tests/full_wlm/test_mpmd.py
+++ b/tests/full_wlm/test_mpmd.py
@@ -29,8 +29,8 @@ from copy import deepcopy
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim._core.utils.helpers import is_valid_cmd
+from smartsim.status import SmartSimStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:

--- a/tests/on_wlm/test_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_base_settings_on_wlm.py
@@ -28,7 +28,8 @@ import time
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 
 """
 Test the launch and stop of models and ensembles using base
@@ -54,7 +55,7 @@ def test_model_on_wlm(fileutils, test_dir, wlmutils):
     for _ in range(2):
         exp.start(M1, M2, block=True)
         statuses = exp.get_status(M1, M2)
-        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 def test_model_stop_on_wlm(fileutils, test_dir, wlmutils):
@@ -74,4 +75,4 @@ def test_model_stop_on_wlm(fileutils, test_dir, wlmutils):
     assert M1.name in exp._control._jobs.completed
     assert M2.name in exp._control._jobs.completed
     statuses = exp.get_status(M1, M2)
-    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -29,8 +29,8 @@ import sys
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim.entity import Model
+from smartsim.status import SmartSimStatus
 
 if sys.platform == "darwin":
     supported_dbs = ["tcp", "deprecated"]

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -28,7 +28,8 @@ import sys
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim.entity import Model
 
 if sys.platform == "darwin":
@@ -60,14 +61,14 @@ def test_launch_colocated_model_defaults(fileutils, test_dir, coloutils, db_type
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all(
-        stat == status.STATUS_COMPLETED for stat in statuses
+        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
     # test restarting the colocated model
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all(
-        stat == status.STATUS_COMPLETED for stat in statuses
+        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -91,7 +92,7 @@ def test_colocated_model_disable_pinning(fileutils, test_dir, coloutils, db_type
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all(
-        stat == status.STATUS_COMPLETED for stat in statuses
+        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -114,7 +115,7 @@ def test_colocated_model_pinning_auto_2cpu(fileutils, test_dir, coloutils, db_ty
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all(
-        stat == status.STATUS_COMPLETED for stat in statuses
+        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -139,7 +140,7 @@ def test_colocated_model_pinning_range(fileutils, test_dir, coloutils, db_type):
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all(
-        stat == status.STATUS_COMPLETED for stat in statuses
+        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -164,7 +165,7 @@ def test_colocated_model_pinning_list(fileutils, test_dir, coloutils, db_type):
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all(
-        stat == status.STATUS_COMPLETED for stat in statuses
+        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -189,5 +190,5 @@ def test_colocated_model_pinning_mixed(fileutils, test_dir, coloutils, db_type):
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all(
-        stat == status.STATUS_COMPLETED for stat in statuses
+        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"

--- a/tests/on_wlm/test_containers_wlm.py
+++ b/tests/on_wlm/test_containers_wlm.py
@@ -29,9 +29,9 @@ from shutil import which
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim.entity import Ensemble
 from smartsim.settings.containers import Singularity
+from smartsim.status import SmartSimStatus
 
 """Test SmartRedis container integration on a supercomputer with a WLM."""
 

--- a/tests/on_wlm/test_containers_wlm.py
+++ b/tests/on_wlm/test_containers_wlm.py
@@ -28,7 +28,8 @@ from shutil import which
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim.entity import Ensemble
 from smartsim.settings.containers import Singularity
 
@@ -92,7 +93,7 @@ def test_singularity_wlm_smartredis(fileutils, test_dir, wlmutils):
 
     # get and confirm statuses
     statuses = exp.get_status(ensemble)
-    if not all([stat == status.STATUS_COMPLETED for stat in statuses]):
+    if not all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses]):
         exp.stop(orc)
         assert False  # client ensemble failed
 

--- a/tests/on_wlm/test_generic_orc_launch.py
+++ b/tests/on_wlm/test_generic_orc_launch.py
@@ -26,7 +26,8 @@
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -55,13 +56,13 @@ def test_launch_orc_auto(test_dir, wlmutils):
     statuses = exp.get_status(orc)
 
     # don't use assert so that we don't leave an orphan process
-    if status.STATUS_FAILED in statuses:
+    if SmartSimStatus.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
     statuses = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
 
 
 def test_launch_cluster_orc_single(test_dir, wlmutils):
@@ -88,13 +89,13 @@ def test_launch_cluster_orc_single(test_dir, wlmutils):
     statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in statuses:
+    if SmartSimStatus.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
     statuses = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
 
 
 def test_launch_cluster_orc_multi(test_dir, wlmutils):
@@ -121,10 +122,10 @@ def test_launch_cluster_orc_multi(test_dir, wlmutils):
     statuses = exp.get_status(orc)
 
     # don't use assert so that orc we don't leave an orphan process
-    if status.STATUS_FAILED in statuses:
+    if SmartSimStatus.STATUS_FAILED in statuses:
         exp.stop(orc)
         assert False
 
     exp.stop(orc)
     statuses = exp.get_status(orc)
-    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])

--- a/tests/on_wlm/test_launch_errors.py
+++ b/tests/on_wlm/test_launch_errors.py
@@ -28,7 +28,8 @@ import time
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim.error import SmartSimError
 
 # retrieved from pytest fixtures
@@ -54,7 +55,7 @@ def test_failed_status(fileutils, test_dir, wlmutils):
         time.sleep(2)
     stat = exp.get_status(model)
     assert len(stat) == 1
-    assert stat[0] == status.STATUS_FAILED
+    assert stat[0] == SmartSimStatus.STATUS_FAILED
 
 
 def test_bad_run_command_args(fileutils, test_dir, wlmutils):

--- a/tests/on_wlm/test_launch_errors.py
+++ b/tests/on_wlm/test_launch_errors.py
@@ -29,8 +29,8 @@ import time
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim.error import SmartSimError
+from smartsim.status import SmartSimStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:

--- a/tests/on_wlm/test_launch_ompi_lsf.py
+++ b/tests/on_wlm/test_launch_ompi_lsf.py
@@ -26,7 +26,8 @@
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -49,4 +50,4 @@ def test_launch_openmpi_lsf(fileutils, test_dir, wlmutils):
     model = exp.create_model("ompi-model", path=test_dir, run_settings=settings)
     exp.start(model, block=True)
     statuses = exp.get_status(model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])

--- a/tests/on_wlm/test_local_step.py
+++ b/tests/on_wlm/test_local_step.py
@@ -29,7 +29,7 @@ import uuid
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
 from smartsim.settings import RunSettings
 
 # retrieved from pytest fixtures

--- a/tests/on_wlm/test_restart.py
+++ b/tests/on_wlm/test_restart.py
@@ -28,7 +28,8 @@ from copy import deepcopy
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -48,10 +49,10 @@ def test_restart(fileutils, test_dir, wlmutils):
 
     exp.start(M1, M2, block=True)
     statuses = exp.get_status(M1, M2)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
     exp.start(M1, M2, block=True)
     statuses = exp.get_status(M1, M2)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
     # TODO add job history check here.

--- a/tests/on_wlm/test_simple_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_simple_base_settings_on_wlm.py
@@ -28,7 +28,8 @@ import time
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim.settings.settings import RunSettings
 
 """
@@ -63,7 +64,7 @@ def test_simple_model_on_wlm(fileutils, test_dir, wlmutils):
     # launch model twice to show that it can also be restarted
     for _ in range(2):
         exp.start(M, block=True)
-        assert exp.get_status(M)[0] == status.STATUS_COMPLETED
+        assert exp.get_status(M)[0] == SmartSimStatus.STATUS_COMPLETED
 
 
 def test_simple_model_stop_on_wlm(fileutils, test_dir, wlmutils):
@@ -83,4 +84,4 @@ def test_simple_model_stop_on_wlm(fileutils, test_dir, wlmutils):
     time.sleep(2)
     exp.stop(M)
     assert M.name in exp._control._jobs.completed
-    assert exp.get_status(M)[0] == status.STATUS_CANCELLED
+    assert exp.get_status(M)[0] == SmartSimStatus.STATUS_CANCELLED

--- a/tests/on_wlm/test_simple_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_simple_base_settings_on_wlm.py
@@ -29,8 +29,8 @@ import time
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim.settings.settings import RunSettings
+from smartsim.status import SmartSimStatus
 
 """
 Test the launch and stop of simple models and ensembles that use base

--- a/tests/on_wlm/test_simple_entity_launch.py
+++ b/tests/on_wlm/test_simple_entity_launch.py
@@ -28,7 +28,8 @@ from copy import deepcopy
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 
 """
 Test the launch of simple entity types on pre-existing allocations.
@@ -59,7 +60,7 @@ def test_models(fileutils, test_dir, wlmutils):
 
     exp.start(M1, M2, block=True)
     statuses = exp.get_status(M1, M2)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 def test_ensemble(fileutils, test_dir, wlmutils):
@@ -75,7 +76,7 @@ def test_ensemble(fileutils, test_dir, wlmutils):
 
     exp.start(ensemble, block=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 def test_summary(fileutils, test_dir, wlmutils):
@@ -97,8 +98,8 @@ def test_summary(fileutils, test_dir, wlmutils):
 
     # start and poll
     exp.start(sleep, bad)
-    assert exp.get_status(bad)[0] == status.STATUS_FAILED
-    assert exp.get_status(sleep)[0] == status.STATUS_COMPLETED
+    assert exp.get_status(bad)[0] == SmartSimStatus.STATUS_FAILED
+    assert exp.get_status(sleep)[0] == SmartSimStatus.STATUS_COMPLETED
 
     summary_str = exp.summary(style="plain")
     print(summary_str)

--- a/tests/on_wlm/test_stop.py
+++ b/tests/on_wlm/test_stop.py
@@ -28,7 +28,8 @@ import time
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 
 """
 Test Stopping launched entities.
@@ -55,7 +56,7 @@ def test_stop_entity(fileutils, test_dir, wlmutils):
     time.sleep(5)
     exp.stop(M1)
     assert M1.name in exp._control._jobs.completed
-    assert exp.get_status(M1)[0] == status.STATUS_CANCELLED
+    assert exp.get_status(M1)[0] == SmartSimStatus.STATUS_CANCELLED
 
 
 def test_stop_entity_list(fileutils, test_dir, wlmutils):
@@ -73,5 +74,5 @@ def test_stop_entity_list(fileutils, test_dir, wlmutils):
     time.sleep(5)
     exp.stop(ensemble)
     statuses = exp.get_status(ensemble)
-    assert all([stat == status.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
     assert all([m.name in exp._control._jobs.completed for m in ensemble])

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -28,7 +28,8 @@ import sys
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim.entity import Model
 from smartsim.error import SSUnsupportedError
 
@@ -139,13 +140,13 @@ def test_launch_colocated_model_defaults(
     exp.generate(colo_model)
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
-    assert all(stat == status.STATUS_COMPLETED for stat in statuses)
+    assert all(stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses)
 
     # test restarting the colocated model
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
     assert all(
-        stat == status.STATUS_COMPLETED for stat in statuses
+        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
     ), f"Statuses {statuses}"
 
 
@@ -181,12 +182,12 @@ def test_launch_multiple_colocated_models(
     exp.generate(*colo_models)
     exp.start(*colo_models, block=True)
     statuses = exp.get_status(*colo_models)
-    assert all(stat == status.STATUS_COMPLETED for stat in statuses)
+    assert all(stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses)
 
     # test restarting the colocated model
     exp.start(*colo_models, block=True)
     statuses = exp.get_status(*colo_models)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 @pytest.mark.parametrize("db_type", supported_dbs)
@@ -212,7 +213,7 @@ def test_colocated_model_disable_pinning(
     exp.generate(colo_model)
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 @pytest.mark.parametrize("db_type", supported_dbs)
@@ -245,7 +246,7 @@ def test_colocated_model_pinning_auto_2cpu(
     exp.generate(colo_model)
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 @pytest.mark.skipif(is_mac, reason="unsupported on MacOSX")
@@ -272,7 +273,7 @@ def test_colocated_model_pinning_range(
     exp.generate(colo_model)
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 @pytest.mark.skipif(is_mac, reason="unsupported on MacOSX")
@@ -299,7 +300,7 @@ def test_colocated_model_pinning_list(
     exp.generate(colo_model)
     exp.start(colo_model, block=True)
     statuses = exp.get_status(colo_model)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 def test_colo_uds_verifies_socket_file_name(test_dir, launcher="local"):

--- a/tests/test_colo_model_local.py
+++ b/tests/test_colo_model_local.py
@@ -29,9 +29,9 @@ import sys
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim.entity import Model
 from smartsim.error import SSUnsupportedError
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the slow_tests group
 pytestmark = pytest.mark.slow_tests

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -31,7 +31,8 @@ from shutil import which
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim.database import Orchestrator
 from smartsim.entity import Ensemble
 from smartsim.settings.containers import Singularity
@@ -109,7 +110,7 @@ def test_singularity_basic(fileutils, test_dir):
 
     # get and confirm status
     stat = exp.get_status(model)[0]
-    assert stat == status.STATUS_COMPLETED
+    assert stat == SmartSimStatus.STATUS_COMPLETED
 
     print(exp.summary())
 
@@ -136,7 +137,7 @@ def test_singularity_args(fileutils, test_dir):
 
     # get and confirm status
     stat = exp.get_status(model)[0]
-    assert stat == status.STATUS_COMPLETED
+    assert stat == SmartSimStatus.STATUS_COMPLETED
 
     print(exp.summary())
 
@@ -185,7 +186,7 @@ def test_singularity_smartredis(test_dir, fileutils, wlmutils):
 
     # get and confirm statuses
     statuses = exp.get_status(ensemble)
-    if not all([stat == status.STATUS_COMPLETED for stat in statuses]):
+    if not all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses]):
         exp.stop(orc)
         assert False  # client ensemble failed
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -32,10 +32,10 @@ from shutil import which
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim.database import Orchestrator
 from smartsim.entity import Ensemble
 from smartsim.settings.containers import Singularity
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -33,7 +33,7 @@ from smartsim.entity import Model
 from smartsim.error import SmartSimError
 from smartsim.error.errors import SSUnsupportedError
 from smartsim.settings import RunSettings
-from smartsim.status import STATUS_NEVER_STARTED
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the slow_tests group
 pytestmark = pytest.mark.slow_tests
@@ -88,7 +88,7 @@ def test_status_typeerror():
 def test_status_pre_launch():
     model = Model("name", {}, "./", RunSettings("python"))
     exp = Experiment("test")
-    assert exp.get_status(model)[0] == STATUS_NEVER_STARTED
+    assert exp.get_status(model)[0] == SmartSimStatus.STATUS_NEVER_STARTED
 
 
 def test_bad_ensemble_init_no_rs():

--- a/tests/test_launch_errors.py
+++ b/tests/test_launch_errors.py
@@ -27,7 +27,8 @@
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim.database import Orchestrator
 from smartsim.error import SSUnsupportedError
 from smartsim.settings import JsrunSettings, RunSettings
@@ -57,7 +58,7 @@ def test_model_failure(fileutils, test_dir):
 
     exp.start(M1, block=True)
     statuses = exp.get_status(M1)
-    assert all([stat == status.STATUS_FAILED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_FAILED for stat in statuses])
 
 
 def test_orchestrator_relaunch(test_dir, wlmutils):

--- a/tests/test_launch_errors.py
+++ b/tests/test_launch_errors.py
@@ -28,10 +28,10 @@
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim.database import Orchestrator
 from smartsim.error import SSUnsupportedError
 from smartsim.settings import JsrunSettings, RunSettings
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a

--- a/tests/test_local_launch.py
+++ b/tests/test_local_launch.py
@@ -26,7 +26,8 @@
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a
@@ -49,7 +50,7 @@ def test_models(fileutils, test_dir):
 
     exp.start(M1, M2, block=True, summary=True)
     statuses = exp.get_status(M1, M2)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 def test_ensemble(fileutils, test_dir):
@@ -64,4 +65,4 @@ def test_ensemble(fileutils, test_dir):
 
     exp.start(ensemble, block=True, summary=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])

--- a/tests/test_local_multi_run.py
+++ b/tests/test_local_multi_run.py
@@ -26,7 +26,8 @@
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a
@@ -49,9 +50,9 @@ def test_models(fileutils, test_dir):
 
     exp.start(M1, block=False)
     statuses = exp.get_status(M1)
-    assert all([stat != status.STATUS_FAILED for stat in statuses])
+    assert all([stat != SmartSimStatus.STATUS_FAILED for stat in statuses])
 
     # start another while first model is running
     exp.start(M2, block=True)
     statuses = exp.get_status(M1, M2)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])

--- a/tests/test_local_restart.py
+++ b/tests/test_local_restart.py
@@ -26,7 +26,8 @@
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the group_b group
 pytestmark = pytest.mark.group_b
@@ -48,12 +49,12 @@ def test_restart(fileutils, test_dir):
 
     exp.start(M1, block=True)
     statuses = exp.get_status(M1)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
     # restart the model
     exp.start(M1, block=True)
     statuses = exp.get_status(M1)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
 
 def test_ensemble(fileutils, test_dir):
@@ -68,9 +69,9 @@ def test_ensemble(fileutils, test_dir):
 
     exp.start(ensemble, block=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
 
     # restart the ensemble
     exp.start(ensemble, block=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])

--- a/tests/test_multidb.py
+++ b/tests/test_multidb.py
@@ -27,7 +27,8 @@ from contextlib import contextmanager
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim.database import Orchestrator
 from smartsim.entity.entity import SmartSimEntity
 from smartsim.error.errors import SSDBIDConflictError
@@ -51,7 +52,7 @@ def make_entity_context(exp: Experiment, entity: SmartSimEntity):
     try:
         yield entity
     finally:
-        if exp.get_status(entity)[0] == status.STATUS_RUNNING:
+        if exp.get_status(entity)[0] == SmartSimStatus.STATUS_RUNNING:
             exp.stop(entity)
 
 
@@ -65,7 +66,7 @@ def choose_host(wlmutils, index=0):
 
 def check_not_failed(exp, *args):
     statuses = exp.get_status(*args)
-    assert all(stat is not status.STATUS_FAILED for stat in statuses)
+    assert all(stat is not SmartSimStatus.STATUS_FAILED for stat in statuses)
 
 
 @pytest.mark.parametrize("db_type", supported_dbs)

--- a/tests/test_multidb.py
+++ b/tests/test_multidb.py
@@ -28,11 +28,11 @@ from contextlib import contextmanager
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim.database import Orchestrator
 from smartsim.entity.entity import SmartSimEntity
 from smartsim.error.errors import SSDBIDConflictError
 from smartsim.log import get_logger
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the group_b group
 pytestmark = pytest.mark.group_b

--- a/tests/test_reconnect_orchestrator.py
+++ b/tests/test_reconnect_orchestrator.py
@@ -29,7 +29,8 @@ import time
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim.database import Orchestrator
 
 # The tests in this file belong to the group_b group
@@ -54,7 +55,7 @@ def test_local_orchestrator(test_dir, wlmutils):
 
     exp.start(orc)
     statuses = exp.get_status(orc)
-    assert [stat != status.STATUS_FAILED for stat in statuses]
+    assert [stat != SmartSimStatus.STATUS_FAILED for stat in statuses]
 
     # simulate user shutting down main thread
     exp._control._jobs.actively_monitoring = False
@@ -76,7 +77,7 @@ def test_reconnect_local_orc(test_dir):
 
     statuses = exp_2.get_status(reloaded_orc)
     for stat in statuses:
-        if stat == status.STATUS_FAILED:
+        if stat == SmartSimStatus.STATUS_FAILED:
             exp_2.stop(reloaded_orc)
             assert False
     exp_2.stop(reloaded_orc)

--- a/tests/test_reconnect_orchestrator.py
+++ b/tests/test_reconnect_orchestrator.py
@@ -30,8 +30,8 @@ import time
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim.database import Orchestrator
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the group_b group
 pytestmark = pytest.mark.group_b

--- a/tests/test_smartredis.py
+++ b/tests/test_smartredis.py
@@ -28,10 +28,10 @@
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
 from smartsim._core.utils import installed_redisai_backends
 from smartsim.database import Orchestrator
 from smartsim.entity import Ensemble, Model
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the group_b group
 pytestmark = pytest.mark.group_b

--- a/tests/test_smartredis.py
+++ b/tests/test_smartredis.py
@@ -27,7 +27,8 @@
 
 import pytest
 
-from smartsim import Experiment, status
+from smartsim import Experiment
+from smartsim.status import SmartSimStatus
 from smartsim._core.utils import installed_redisai_backends
 from smartsim.database import Orchestrator
 from smartsim.entity import Ensemble, Model
@@ -97,7 +98,7 @@ def test_exchange(fileutils, test_dir, wlmutils):
     # get and confirm statuses
     statuses = exp.get_status(ensemble)
     try:
-        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
     finally:
         # stop the orchestrator
         exp.stop(orc)
@@ -146,7 +147,7 @@ def test_consumer(fileutils, test_dir, wlmutils):
     # get and confirm statuses
     statuses = exp.get_status(ensemble)
     try:
-        assert all([stat == status.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
     finally:
         # stop the orchestrator
         exp.stop(orc)

--- a/tests/test_step_info.py
+++ b/tests/test_step_info.py
@@ -26,8 +26,8 @@
 
 import pytest
 
-from smartsim.status import SmartSimStatus
 from smartsim._core.launcher.stepInfo import *
+from smartsim.status import SmartSimStatus
 
 # The tests in this file belong to the group_b group
 pytestmark = pytest.mark.group_b
@@ -35,7 +35,9 @@ pytestmark = pytest.mark.group_b
 
 def test_str():
     step_info = StepInfo(
-        status=SmartSimStatus.STATUS_COMPLETED, launcher_status="COMPLETED", returncode=0
+        status=SmartSimStatus.STATUS_COMPLETED,
+        launcher_status="COMPLETED",
+        returncode=0,
     )
     expected_output = "Status: Completed | Launcher Status COMPLETED | Returncode 0"
 

--- a/tests/test_step_info.py
+++ b/tests/test_step_info.py
@@ -26,7 +26,7 @@
 
 import pytest
 
-from smartsim import status
+from smartsim.status import SmartSimStatus
 from smartsim._core.launcher.stepInfo import *
 
 # The tests in this file belong to the group_b group
@@ -35,7 +35,7 @@ pytestmark = pytest.mark.group_b
 
 def test_str():
     step_info = StepInfo(
-        status=status.STATUS_COMPLETED, launcher_status="COMPLETED", returncode=0
+        status=SmartSimStatus.STATUS_COMPLETED, launcher_status="COMPLETED", returncode=0
     )
     expected_output = "Status: Completed | Launcher Status COMPLETED | Returncode 0"
 
@@ -45,4 +45,4 @@ def test_str():
 def test_default():
     step_info = UnmanagedStepInfo()
 
-    assert step_info._get_smartsim_status(None) == status.STATUS_FAILED
+    assert step_info._get_smartsim_status(None) == SmartSimStatus.STATUS_FAILED

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -527,7 +527,10 @@ def test_telemetry_serial_models(fileutils, test_dir, wlmutils, monkeypatch, con
         exp.generate(*smartsim_models)
         exp.start(*smartsim_models, block=True)
         assert all(
-            [status == SmartSimStatus.STATUS_COMPLETED for status in exp.get_status(*smartsim_models)]
+            [
+                status == SmartSimStatus.STATUS_COMPLETED
+                for status in exp.get_status(*smartsim_models)
+            ]
         )
 
         telemetry_output_path = pathlib.Path(test_dir) / config.telemetry_subdir
@@ -574,7 +577,10 @@ def test_telemetry_serial_models_nonblocking(
         snooze_nonblocking(telemetry_output_path, max_delay=60, post_data_delay=10)
 
         assert all(
-            [status == SmartSimStatus.STATUS_COMPLETED for status in exp.get_status(*smartsim_models)]
+            [
+                status == SmartSimStatus.STATUS_COMPLETED
+                for status in exp.get_status(*smartsim_models)
+            ]
         )
 
         start_events = list(telemetry_output_path.rglob("start.json"))
@@ -752,7 +758,12 @@ def test_telemetry_ensemble(fileutils, test_dir, wlmutils, monkeypatch, config):
         ens = exp.create_ensemble("troupeau", run_settings=app_settings, replicas=5)
         exp.generate(ens)
         exp.start(ens, block=True)
-        assert all([status == SmartSimStatus.STATUS_COMPLETED for status in exp.get_status(ens)])
+        assert all(
+            [
+                status == SmartSimStatus.STATUS_COMPLETED
+                for status in exp.get_status(ens)
+            ]
+        )
 
         telemetry_output_path = pathlib.Path(test_dir) / config.telemetry_subdir
         snooze_nonblocking(telemetry_output_path, max_delay=60, post_data_delay=30)
@@ -791,7 +802,10 @@ def test_telemetry_colo(fileutils, test_dir, wlmutils, coloutils, monkeypatch, c
         exp.generate(smartsim_model)
         exp.start(smartsim_model, block=True)
         assert all(
-            [status == SmartSimStatus.STATUS_COMPLETED for status in exp.get_status(smartsim_model)]
+            [
+                status == SmartSimStatus.STATUS_COMPLETED
+                for status in exp.get_status(smartsim_model)
+            ]
         )
 
         telemetry_output_path = pathlib.Path(test_dir) / config.telemetry_subdir
@@ -1056,12 +1070,18 @@ def test_faux_rc(status_in: str, expected_out: t.Optional[int]):
 @pytest.mark.parametrize(
     "status_in, expected_out, expected_has_jobs",
     [
-        pytest.param(SmartSimStatus.STATUS_CANCELLED, 1, False, id="failure on cancellation"),
-        pytest.param(SmartSimStatus.STATUS_COMPLETED, 0, False, id="success on completion"),
+        pytest.param(
+            SmartSimStatus.STATUS_CANCELLED, 1, False, id="failure on cancellation"
+        ),
+        pytest.param(
+            SmartSimStatus.STATUS_COMPLETED, 0, False, id="success on completion"
+        ),
         pytest.param(SmartSimStatus.STATUS_FAILED, 1, False, id="failure on failed"),
         pytest.param(SmartSimStatus.STATUS_NEW, None, True, id="failure on new"),
         pytest.param(SmartSimStatus.STATUS_PAUSED, None, True, id="failure on paused"),
-        pytest.param(SmartSimStatus.STATUS_RUNNING, None, True, id="failure on running"),
+        pytest.param(
+            SmartSimStatus.STATUS_RUNNING, None, True, id="failure on running"
+        ),
     ],
 )
 def test_wlm_completion_handling(


### PR DESCRIPTION
This PR refactors the SmartSim status module.

Additionally, `Experiment.get_status()` now returns a list of type `SmartSimStatus`. 