### PR TITLE
Improve Orchestrator launch and hosts detection

### DIFF
--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -329,7 +329,7 @@ class Orchestrator(EntityList[DBNode]):
 
         :raises SmartSimError: If database address cannot be found or is not active
         """
-        if not self._hosts:
+        if not self.hosts:
             raise SmartSimError("Could not find database address")
         if not self.is_active():
             raise SmartSimError("Database is not active")
@@ -338,7 +338,7 @@ class Orchestrator(EntityList[DBNode]):
     def _get_address(self) -> t.List[str]:
         return [
             f"{host}:{port}"
-            for host, port in itertools.product(self._hosts, self.ports)
+            for host, port in itertools.product(self.hosts, self.ports)
         ]
 
     def is_active(self) -> bool:
@@ -347,10 +347,10 @@ class Orchestrator(EntityList[DBNode]):
         :return: True if database is active, False otherwise
         :rtype: bool
         """
-        if not self._hosts:
+        if not self.hosts:
             return False
 
-        return db_is_active(self._hosts, self.ports, self.num_shards)
+        return db_is_active(self.hosts, self.ports, self.num_shards)
 
     @property
     def _rai_module(self) -> t.Tuple[str, ...]:


### PR DESCRIPTION
The `_orchestrator_launch_and_wait` method had an extra `time.sleep(CONFIG.jm_interval)` that was being called even after the Orchestrator was flagged as ready. This ends up potentially creating an additional latency. To rectify this, while also making the test robust, the ready condition was updated to include a call to `Orchestrator.is_active`. This further necessitated an update to other methods on `Orchestrator` which were referencing `self._hosts` instead of calling the getter method for hosts. This distinction led to false negatives for is_active (and other methods) which depend on the `self._hosts` being populated, but the getter method was never called.