### PR TITLE
Update watchdog dependency

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,7 @@ To be released at some future point in time
 
 Description
 
+- Update watchdog dependency
 - Promote device options to an Enum
 - Update telemetry monitor, add telemetry collectors
 - Add method to specify node features for a Slurm job
@@ -34,6 +35,7 @@ Description
 
 Detailed Notes
 
+- Update watchdog dependency from 3.x to 4.x, fix new type issues (SmartSim-PR540_)
 - Promote devices to a dedicated Enum type throughout the SmartSim code base.
 - Update the telemetry monitor to enable retrieval of metrics on a scheduled
   interval. Switch basic experiment tracking telemetry to default to on. Add
@@ -74,6 +76,7 @@ Detailed Notes
 - Remove previously deprecated behavior present in test suite on machines with
   Slurm and Open MPI. (SmartSim-PR520_)
 
+.. _SmartSim-PR540: https://github.com/CrayLabs/SmartSim/pull/540
 .. _SmartSim-PR498: https://github.com/CrayLabs/SmartSim/pull/498
 .. _SmartSim-PR460: https://github.com/CrayLabs/SmartSim/pull/460
 .. _SmartSim-PR512: https://github.com/CrayLabs/SmartSim/pull/512

--- a/setup.py
+++ b/setup.py
@@ -108,8 +108,11 @@ versions = buildenv.Versioner()
 
 # check for compatible python versions
 if not build_env.is_compatible_python(versions.PYTHON_MIN):
-    print("You are using Python {}. Python >={} is required.".format(build_env.python_version,
-                                                                     ".".join((versions.PYTHON_MIN))))
+    print(
+        "You are using Python {}. Python >={} is required.".format(
+            build_env.python_version, ".".join((versions.PYTHON_MIN))
+        )
+    )
     sys.exit(-1)
 
 if build_env.is_windows():
@@ -121,8 +124,10 @@ if build_env.is_windows():
 # __version__ in smartsim/__init__.py
 smartsim_version = versions.write_version(setup_path)
 
+
 class BuildError(Exception):
     pass
+
 
 # Hacky workaround for solving CI build "purelib" issue
 # see https://github.com/google/or-tools/issues/616
@@ -132,15 +137,15 @@ class InstallPlatlib(install):
         if self.distribution.has_ext_modules():
             self.install_lib = self.install_platlib
 
+
 class SmartSimBuild(build_py):
 
     def run(self):
-        database_builder = builder.DatabaseBuilder(build_env(),
-                                             build_env.MALLOC,
-                                             build_env.JOBS)
+        database_builder = builder.DatabaseBuilder(
+            build_env(), build_env.MALLOC, build_env.JOBS
+        )
         if not database_builder.is_built:
-            database_builder.build_from_git(versions.REDIS_URL,
-                                         versions.REDIS)
+            database_builder.build_from_git(versions.REDIS_URL, versions.REDIS)
 
             database_builder.cleanup()
 
@@ -152,9 +157,10 @@ class SmartSimBuild(build_py):
 class BinaryDistribution(Distribution):
     """Distribution which always forces a binary package with platform name
 
-       We use this because we want to pre-package Redis for certain
-       platforms to use.
+    We use this because we want to pre-package Redis for certain
+    platforms to use.
     """
+
     def has_ext_modules(_placeholder):
         return True
 
@@ -168,7 +174,7 @@ deps = [
     "tqdm>=4.50.2",
     "filelock>=3.4.2",
     "protobuf~=3.20",
-    "watchdog>=3.0.0,<4.0.0",
+    "watchdog>=4.0.0",
 ]
 
 # Add SmartRedis at specific version
@@ -195,7 +201,7 @@ extras_require = {
         "typing_extensions>=4.1.0",
     ],
     # see smartsim/_core/_install/buildenv.py for more details
-    **versions.ml_extras_required()
+    **versions.ml_extras_required(),
 }
 
 
@@ -214,5 +220,5 @@ setup(
         "console_scripts": [
             "smart = smartsim._core._cli.__main__:main",
         ]
-    }
+    },
 )

--- a/smartsim/_core/utils/telemetry/telemetry.py
+++ b/smartsim/_core/utils/telemetry/telemetry.py
@@ -228,7 +228,7 @@ class ManifestEventHandler(PatternMatchingEventHandler):
 
         :param event: event representing file/directory modification.
         :type event: FileSystemEvent"""
-        super().on_modified(event)  # type: ignore
+        super().on_modified(event)
         logger.debug(f"Processing manifest modified @ {event.src_path}")
         self.process_manifest(event.src_path)
 
@@ -237,7 +237,7 @@ class ManifestEventHandler(PatternMatchingEventHandler):
 
         :param event: event representing file/directory creation.
         :type event: FileSystemEvent"""
-        super().on_created(event)  # type: ignore
+        super().on_created(event)
         logger.debug(f"processing manifest created @ {event.src_path}")
         self.process_manifest(event.src_path)
 
@@ -544,7 +544,7 @@ class TelemetryMonitor:
         frequency_ms = int(self._args.frequency * 1000)
 
         # Create event handlers to trigger when target files are changed
-        log_handler = LoggingEventHandler(logger)  # type: ignore
+        log_handler = LoggingEventHandler(logger)
         self._action_handler = ManifestEventHandler(
             str(MANIFEST_FILENAME),
             timeout_ms=frequency_ms,


### PR DESCRIPTION
Updated watchdog dependency pin to next major version and removed `type: ignore` where possible due to new type hints added to watchdog