### PR TITLE
Dragon status update fix

### DIFF
--- a/smartsim/_core/control/job.py
+++ b/smartsim/_core/control/job.py
@@ -137,6 +137,7 @@ class JobEntity:
         entity_dict: t.Dict[str, t.Any],
         entity: "JobEntity",
         exp_dir: str,
+        raw_experiment: t.Dict[str, t.Any],
     ) -> None:
         """Map universal properties from a runtime manifest onto a `JobEntity`
 
@@ -147,13 +148,21 @@ class JobEntity:
         :param entity: The entity instance to modify
         :type entity: JobEntity
         :param exp_dir: The path to the experiment working directory
-        :type exp_dir: str"""
+        :type exp_dir: str
+        :param raw_experiment: The raw experiment dictionary deserialized from
+        manifest JSON
+        :type raw_experiment: Dict[str, Any]"""
         metadata = entity_dict["telemetry_metadata"]
         status_dir = pathlib.Path(metadata.get("status_dir"))
+        is_dragon = raw_experiment["launcher"].lower() == "dragon"
 
         # all entities contain shared properties that identify the task
         entity.type = entity_type
-        entity.name = entity_dict["name"]
+        entity.name = (
+            entity_dict["name"]
+            if not is_dragon
+            else entity_dict["telemetry_metadata"]["step_id"]
+        )
         entity.step_id = str(metadata.get("step_id") or "")
         entity.task_id = str(metadata.get("task_id") or "")
         entity.timestamp = int(entity_dict.get("timestamp", "0"))
@@ -162,19 +171,25 @@ class JobEntity:
 
     @classmethod
     def from_manifest(
-        cls, entity_type: str, entity_dict: t.Dict[str, t.Any], exp_dir: str
+        cls,
+        entity_type: str,
+        entity_dict: t.Dict[str, t.Any],
+        exp_dir: str,
+        raw_experiment: t.Dict[str, t.Any],
     ) -> "JobEntity":
         """Instantiate a `JobEntity` from the dictionary deserialized from manifest JSON
 
         :param entity_type: The type of the associated `SmartSimEntity`
         :type entity_type: str
-        :param entity_dict: The raw dictionary deserialized from manifest JSON
-        :type entity_dict: Dict[str, Any]
+        :param raw_experiment: raw experiment deserialized from manifest JSON
+        :type raw_experiment: Dict[str, Any]
         :param exp_dir: The path to the experiment working directory
         :type exp_dir: str"""
         entity = JobEntity()
 
-        cls._map_standard_metadata(entity_type, entity_dict, entity, exp_dir)
+        cls._map_standard_metadata(
+            entity_type, entity_dict, entity, exp_dir, raw_experiment
+        )
         cls._map_db_metadata(entity_dict, entity)
 
         return entity

--- a/smartsim/_core/entrypoints/dragon.py
+++ b/smartsim/_core/entrypoints/dragon.py
@@ -55,15 +55,13 @@ def handle_signal(signo: int, _frame: t.Optional[FrameType]) -> None:
     if not signo:
         logger.info("Received signal with no signo")
     else:
-        logger.info(f"Received {signo}")
+        logger.info(f"Received signal {signo}")
     cleanup()
 
 
 """
 Dragon server entrypoint script
 """
-
-DBPID: t.Optional[int] = None
 
 
 def print_summary(network_interface: str, ip_address: str) -> None:
@@ -86,10 +84,9 @@ def print_summary(network_interface: str, ip_address: str) -> None:
 
 
 def run(
+    zmq_context: "zmq.Context[t.Any]",
     dragon_head_address: str,
     dragon_pid: int,
-    zmq_context: zmq.Context[t.Any],
-    zmq_authenticator: zmq.auth.thread.ThreadAuthenticator,
 ) -> None:
     logger.debug(f"Opening socket {dragon_head_address}")
 
@@ -98,9 +95,7 @@ def run(
     zmq_context.setsockopt(zmq.REQ_CORRELATE, 1)
     zmq_context.setsockopt(zmq.REQ_RELAXED, 1)
 
-    dragon_head_socket, zmq_authenticator = dragonSockets.get_secure_socket(
-        context, zmq.REP, True, zmq_authenticator
-    )
+    dragon_head_socket = dragonSockets.get_secure_socket(zmq_context, zmq.REP, True)
     dragon_head_socket.bind(dragon_head_address)
     dragon_backend = DragonBackend(pid=dragon_pid)
 
@@ -133,7 +128,7 @@ def run(
             break
 
 
-def main(args: argparse.Namespace, zmq_context: zmq.Context[t.Any]) -> int:
+def main(args: argparse.Namespace) -> int:
     if_config = get_best_interface_and_address()
     interface = if_config.interface
     address = if_config.address
@@ -142,39 +137,50 @@ def main(args: argparse.Namespace, zmq_context: zmq.Context[t.Any]) -> int:
     dragon_head_address = f"tcp://{address}"
 
     if args.launching_address:
+        zmq_context = zmq.Context()
+
         if str(args.launching_address).split(":", maxsplit=1)[0] == dragon_head_address:
             address = "localhost"
             dragon_head_address = "tcp://localhost:5555"
         else:
             dragon_head_address += ":5555"
 
-        launcher_socket, authenticator = dragonSockets.get_secure_socket(
-            context, zmq.REQ, False
-        )
+        zmq_authenticator = dragonSockets.get_authenticator(zmq_context)
+
+        logger.debug("Getting launcher socket")
+        launcher_socket = dragonSockets.get_secure_socket(zmq_context, zmq.REQ, False)
+
+        logger.debug(f"Connecting launcher socket to: {args.launching_address}")
         launcher_socket.connect(args.launching_address)
         client = dragonSockets.as_client(launcher_socket)
 
+        logger.debug(
+            f"Sending bootstrap request to launcher_socket with {dragon_head_address}"
+        )
         client.send(DragonBootstrapRequest(address=dragon_head_address))
         response = client.recv()
+
+        logger.debug(f"Received bootstrap response: {response}")
         if not isinstance(response, DragonBootstrapResponse):
             raise ValueError(
                 "Could not receive connection confirmation from launcher. Aborting."
             )
 
         print_summary(interface, dragon_head_address)
+
         try:
+            logger.debug("Executing event loop")
             run(
+                zmq_context=zmq_context,
                 dragon_head_address=dragon_head_address,
                 dragon_pid=response.dragon_pid,
-                zmq_context=zmq_context,
-                zmq_authenticator=authenticator,
             )
         except Exception as e:
             logger.error(f"Dragon server failed with {e}", exc_info=True)
             return os.EX_SOFTWARE
         finally:
-            if authenticator.is_alive():
-                authenticator.stop()
+            if zmq_authenticator is not None and zmq_authenticator.is_alive():
+                zmq_authenticator.stop()
 
     logger.info("Shutting down! Bye bye!")
     return 0
@@ -210,6 +216,4 @@ if __name__ == "__main__":
     for sig in SIGNALS:
         signal.signal(sig, handle_signal)
 
-    context = zmq.Context()
-
-    sys.exit(main(args_, context))
+    sys.exit(main(args_))

--- a/smartsim/_core/entrypoints/telemetrymonitor.py
+++ b/smartsim/_core/entrypoints/telemetrymonitor.py
@@ -158,6 +158,7 @@ if __name__ == "__main__":
     # Must register cleanup before the main loop is running
     def cleanup_telemetry_monitor(_signo: int, _frame: t.Optional[FrameType]) -> None:
         """Create an enclosure on `manifest_observer` to avoid global variables"""
+        logger.info("Shutdown signal received by telemetry monitor entrypoint")
         telemetry_monitor.cleanup()
 
     register_signal_handlers(cleanup_telemetry_monitor)

--- a/smartsim/_core/launcher/dragon/dragonBackend.py
+++ b/smartsim/_core/launcher/dragon/dragonBackend.py
@@ -23,7 +23,6 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 import collections
 import functools
 import typing as t
@@ -33,12 +32,10 @@ from threading import RLock
 # pylint: disable=import-error
 # isort: off
 from dragon.infrastructure.policy import Policy
-from dragon.native.process import Process, TemplateProcess
+from dragon.native.process import Process, ProcessTemplate
 from dragon.native.process_group import (
     ProcessGroup,
     DragonProcessGroupError,
-    Error,
-    Running,
 )
 from dragon.native.machine import System, Node
 
@@ -61,8 +58,8 @@ from smartsim._core.schemas import (
 from smartsim._core.utils.helpers import create_short_id_str
 from smartsim.status import TERMINAL_STATUSES, SmartSimStatus
 
-DRG_ERROR_STATUS = str(Error())
-DRG_RUNNING_STATUS = str(Running())
+DRG_ERROR_STATUS = "Error"
+DRG_RUNNING_STATUS = "Running"
 
 
 @dataclass
@@ -206,7 +203,7 @@ class DragonBackend:
                 local_policy = Policy(
                     placement=Policy.Placement.HOST_NAME, host_name=node_name
                 )
-                tmp_proc = TemplateProcess(
+                tmp_proc = ProcessTemplate(
                     target=request.exe,
                     args=request.exe_args,
                     cwd=request.path,

--- a/smartsim/_core/launcher/dragon/dragonSockets.py
+++ b/smartsim/_core/launcher/dragon/dragonSockets.py
@@ -33,10 +33,14 @@ from smartsim._core.schemas import dragonRequests as _dragonRequests
 from smartsim._core.schemas import dragonResponses as _dragonResponses
 from smartsim._core.schemas import utils as _utils
 from smartsim._core.utils.security import KeyManager
+from smartsim.log import get_logger
 
 if t.TYPE_CHECKING:
     from zmq import Context
     from zmq.sugar.socket import Socket
+
+
+logger = get_logger(__name__)
 
 
 def as_server(
@@ -62,11 +66,10 @@ def as_client(
 
 
 def get_secure_socket(
-    context: "Context[t.Any]",
+    context: "zmq.Context[t.Any]",
     socket_type: int,
     is_server: bool,
-    authenticator: t.Optional[zmq.auth.thread.ThreadAuthenticator] = None,
-) -> "t.Tuple[Socket[t.Any], zmq.auth.thread.ThreadAuthenticator]":
+) -> "Socket[t.Any]":
     """Create secured socket that consumes & produces encrypted messages
 
     :param context: ZMQ context object
@@ -76,29 +79,18 @@ def get_secure_socket(
     :param is_server: Pass `True` to secure the socket as server. Pass `False`
     to secure the socket as a client.
     :type is_server: bool
-    :param authenticator: (optional) An existing authenticator that will be used
-    to authenticate secure communications.
-    :type authenticator: Optional[zmq.auth.thread.ThreadAuthenticator]
-    :returns: the secured socket prepared for sending encrypted messages and
-    an active authenticator if one was not supplied as a parameter.
-    :rtype: Tuple[zmq.Socket, zmq.auth.thread.ThreadAuthenticator]"""
+    :returns: the secured socket prepared for sending encrypted messages
+    :rtype: zmq.Socket"""
     config = get_config()
-    socket = context.socket(socket_type)
+    socket: "Socket[t.Any]" = context.socket(socket_type)
 
     key_manager = KeyManager(config, as_server=is_server, as_client=not is_server)
     server_keys, client_keys = key_manager.get_keys()
-
-    # start an auth thread to provide encryption services on the socket
-    if authenticator is None:
-        authenticator = zmq.auth.thread.ThreadAuthenticator(context)
-
-        # allow all keys in the client key directory to connect
-        authenticator.configure_curve(domain="*", location=key_manager.client_keys_dir)
-
-    if not authenticator.is_alive():
-        authenticator.start()
+    logger.debug(f"Applying keys to socket: {server_keys}, {client_keys}")
 
     if is_server:
+        logger.debug("Configuring socket as server")
+
         # configure the server keys on the socket
         socket.curve_secretkey = server_keys.private
         socket.curve_publickey = client_keys.public
@@ -110,5 +102,32 @@ def get_secure_socket(
 
         # set the server public key for decrypting incoming messages
         socket.curve_serverkey = server_keys.public
+    return socket
 
-    return socket, authenticator
+
+def get_authenticator(
+    context: "zmq.Context[t.Any]",
+) -> "zmq.auth.thread.ThreadAuthenticator":
+    """Create an authenticator to handle encryption of ZMQ communications
+
+    :param context: ZMQ context object
+    :type context: zmq.Context
+    :returns: the activated `Authenticator`
+    :rtype: zmq.auth.thread.ThreadAuthenticator"""
+    config = get_config()
+
+    key_manager = KeyManager(config, as_client=True)
+    server_keys, client_keys = key_manager.get_keys()
+    logger.debug(f"Applying keys to authenticator: {server_keys}, {client_keys}")
+
+    authenticator = zmq.auth.thread.ThreadAuthenticator(context)
+
+    # allow all keys in the client key directory to connect
+    logger.debug(f"Securing with client keys in {key_manager.client_keys_dir}")
+    authenticator.configure_curve(domain="*", location=key_manager.client_keys_dir)
+
+    if not authenticator.is_alive():
+        logger.debug("Starting authenticator")
+        authenticator.start()
+
+    return authenticator

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -402,7 +402,8 @@ def test_persistable_computed_properties(
             "step_id": step_id,
         },
     }
-    persistables = Run.load_entity(etype, stored, exp_dir)
+    faux_experiment = {"launcher": "local"}
+    persistables = Run.load_entity(etype, stored, exp_dir, faux_experiment)
     persistable = persistables[0] if persistables else None
 
     assert persistable.is_managed == exp_ismanaged

--- a/tests/utils/test_security.py
+++ b/tests/utils/test_security.py
@@ -209,26 +209,26 @@ def test_key_manager_applied_permissions(
         s_pub_stat = km._server_locator.public_dir.stat()
         c_pub_stat = km._client_locator.public_dir.stat()
 
-        assert stat.S_IMODE(s_pub_stat.st_mode) == _KeyPermissions.WORLD_R
-        assert stat.S_IMODE(c_pub_stat.st_mode) == _KeyPermissions.WORLD_R
+        assert stat.S_IMODE(s_pub_stat.st_mode) == _KeyPermissions.PUBLIC_DIR
+        assert stat.S_IMODE(c_pub_stat.st_mode) == _KeyPermissions.PUBLIC_DIR
 
         # ensure private dirs are open only to owner
         s_priv_stat = km._server_locator.private_dir.stat()
         c_priv_stat = km._client_locator.private_dir.stat()
 
-        assert stat.S_IMODE(s_priv_stat.st_mode) == _KeyPermissions.OWNER_FULL
-        assert stat.S_IMODE(c_priv_stat.st_mode) == _KeyPermissions.OWNER_FULL
+        assert stat.S_IMODE(s_priv_stat.st_mode) == _KeyPermissions.PRIVATE_DIR
+        assert stat.S_IMODE(c_priv_stat.st_mode) == _KeyPermissions.PRIVATE_DIR
 
         # ensure public files are open for reading by others
         s_pub_stat = km._server_locator.public.stat()
         c_pub_stat = km._client_locator.public.stat()
 
-        assert stat.S_IMODE(s_pub_stat.st_mode) == _KeyPermissions.WORLD_R
-        assert stat.S_IMODE(c_pub_stat.st_mode) == _KeyPermissions.WORLD_R
+        assert stat.S_IMODE(s_pub_stat.st_mode) == _KeyPermissions.PUBLIC_KEY
+        assert stat.S_IMODE(c_pub_stat.st_mode) == _KeyPermissions.PUBLIC_KEY
 
         # ensure private files are read-only for owner
         s_priv_stat = km._server_locator.private.stat()
         c_priv_stat = km._client_locator.private.stat()
 
-        assert stat.S_IMODE(s_priv_stat.st_mode) == _KeyPermissions.OWNER_RW
-        assert stat.S_IMODE(c_priv_stat.st_mode) == _KeyPermissions.OWNER_RW
+        assert stat.S_IMODE(s_priv_stat.st_mode) == _KeyPermissions.PRIVATE_KEY
+        assert stat.S_IMODE(c_priv_stat.st_mode) == _KeyPermissions.PRIVATE_KEY


### PR DESCRIPTION
## Fix a defect in retrieving status updates for the dragon launcher. 

Pre-dragon launchers used the task/step name to retrieve updates while the dragon launcher uses the `task_id`. This fix ensures that the name for dragon tasks is mapped appropriately.