### PR TITLE
[no-merge] Jobs Have Update Methods

### DIFF
--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -521,26 +521,6 @@ class Controller:
 
         # set the jobs in the job manager to provide SSDB variable to entities
         # if _host isnt set within each
-        # XXX: Why on earth does the launching process set the hosts attrs of
-        #      the launched job? Especially since `hosts` is a user writeable
-        #      attr on both the `Orchestrator` and the `DBNode` instances via
-        #      the `set_hosts` method.  Since the `Job` (theoretically)
-        #      correlates to a launched entity, shouldn't it be the one
-        #      responsible for knowing what hosts it is actually running on??
-        # XXX: IMO, it is a MASSIVE code smell that we need to query into the
-        #      `_entity_to_job_monitor_id` even though we assume that
-        #      `_launch_step` will make the insertion. If we need to modify the
-        #      `Job` why does `launch_step` not return a job? Why do we need to
-        #      modify the `Job` at all?
-        if orchestrator.batch:
-            self._job_manager[
-                self._entity_to_job_monitor_id[orchestrator.name]
-            ].hosts = orchestrator.hosts
-        else:
-            for dbnode in orchestrator.entities:
-                self._job_manager[self._entity_to_job_monitor_id[dbnode.name]].hosts = (
-                    dbnode.hosts
-                )
 
         # create the database cluster
         if orchestrator.num_shards > 2:

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -559,7 +559,6 @@ class Controller:
                     else:
                         # surface SSInternalError as we have no way to recover
                         raise
-        # XXX: This needs to be put back if we want to reload an orc
         self._save_orchestrator(
             orchestrator,
             ((self._job_manager[step.entity_name], step, self._launcher.step_mapping[step.name])

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -570,7 +570,8 @@ class Controller:
                     else:
                         # surface SSInternalError as we have no way to recover
                         raise
-        self._save_orchestrator(orchestrator)
+        # XXX: This needs to be put back if we want to reload an orc
+        # self._save_orchestrator(orchestrator)
         logger.debug(f"Orchestrator launched on nodes: {orchestrator.hosts}")
 
     def _launch_step(

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -40,6 +40,7 @@ from os import environ
 
 from smartredis import Client, ConfigOptions
 
+from smartsim._core.types import StepName
 from smartsim._core.utils.network import get_ip_from_host
 
 from ..._core.launcher.step import Step
@@ -78,6 +79,7 @@ from .manifest import LaunchedManifest, LaunchedManifestBuilder, Manifest
 if t.TYPE_CHECKING:
     from types import FrameType
 
+    from ...entity import types as _entity_types
     from ..utils.serialize import TStepLaunchMetaData
 
 
@@ -275,7 +277,7 @@ class Controller:
             for entity in entity_list.entities:
                 self.stop_entity(entity)
 
-    def get_jobs(self) -> t.Dict[str, Job]:
+    def get_jobs(self) -> t.Dict["_entity_types.EntityName", Job]:
         """Return a dictionary of completed job data
 
         :returns: dict[str, Job]
@@ -389,7 +391,7 @@ class Controller:
 
     def _launch(
         self, exp_name: str, exp_path: str, manifest: Manifest
-    ) -> LaunchedManifest[t.Tuple[str, Step]]:
+    ) -> LaunchedManifest[t.Tuple[StepName, Step]]:
         """Main launching function of the controller
 
         Orchestrators are always launched first so that the
@@ -403,7 +405,7 @@ class Controller:
         :type manifest: Manifest
         """
 
-        manifest_builder = LaunchedManifestBuilder[t.Tuple[str, Step]](
+        manifest_builder = LaunchedManifestBuilder[t.Tuple[StepName, Step]](
             exp_name=exp_name,
             exp_path=exp_path,
             launcher_name=str(self._launcher),
@@ -494,7 +496,7 @@ class Controller:
     def _launch_orchestrator(
         self,
         orchestrator: Orchestrator,
-        manifest_builder: LaunchedManifestBuilder[t.Tuple[str, Step]],
+        manifest_builder: LaunchedManifestBuilder[t.Tuple[StepName, Step]],
     ) -> None:
         """Launch an Orchestrator instance
 

--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -148,9 +148,7 @@ class Controller:
     @property
     def orchestrator_active(self) -> bool:
         with JM_LOCK:
-            if len(self._jobs.db_jobs) > 0:
-                return True
-            return False
+            return len(self._jobs.db_jobs) > 0
 
     def poll(
         self, interval: int, verbose: bool, kill_on_interrupt: bool = True
@@ -799,7 +797,7 @@ class Controller:
                 time.sleep(CONFIG.jm_interval)
                 # manually trigger job update if JM not running
                 if not self._jobs.actively_monitoring:
-                    self._jobs.check_jobs()
+                    self._jobs.update_statuses()
 
                 # _jobs.get_status acquires JM lock for main thread, no need for locking
                 statuses = self.get_entity_list_status(orchestrator)

--- a/smartsim/_core/control/controller_utils.py
+++ b/smartsim/_core/control/controller_utils.py
@@ -36,17 +36,14 @@ from ..launcher.launcher import Launcher
 
 if t.TYPE_CHECKING:
     from ..utils.serialize import TStepLaunchMetaData
+    from .. import types as _core_types
 
 
 class _AnonymousBatchJob(EntityList[Model]):
-    @staticmethod
-    def _validate(model: Model) -> None:
-        if model.batch_settings is None:
-            msg = "Unable to create _AnonymousBatchJob without batch_settings"
-            raise SmartSimError(msg)
-
     def __init__(self, model: Model) -> None:
-        self._validate(model)
+        if model.batch_settings is None:
+            msg = f"Unable to create {type(self).__name__} without batch_settings"
+            raise SmartSimError(msg)
         super().__init__(model.name, model.path)
         self.entities = [model]
         self.batch_settings = model.batch_settings
@@ -56,8 +53,8 @@ class _AnonymousBatchJob(EntityList[Model]):
 
 def _look_up_launched_data(
     launcher: Launcher,
-) -> t.Callable[[t.Tuple[str, Step]], "TStepLaunchMetaData"]:
-    def _unpack_launched_data(data: t.Tuple[str, Step]) -> "TStepLaunchMetaData":
+) -> t.Callable[[t.Tuple["_core_types.StepName", Step]], "TStepLaunchMetaData"]:
+    def _unpack_launched_data(data: t.Tuple["_core_types.StepName", Step]) -> "TStepLaunchMetaData":
         # NOTE: we cannot assume that the name of the launched step
         # ``launched_step_name`` is equal to the name of the step referring to
         # the entity ``step.name`` as is the case when an entity list is

--- a/smartsim/_core/control/job.py
+++ b/smartsim/_core/control/job.py
@@ -241,7 +241,6 @@ class Job:
         # output is only populated if it's system related (e.g. cmd failed immediately)
         self.output: t.Optional[str] = None
         self.error: t.Optional[str] = None  # same as output
-        self.hosts: t.List[str] = []  # currently only used for DB jobs
         self.launched_with: t.Final = launcher
         self.is_task = is_task
         self.start_time = time.time()
@@ -393,7 +392,6 @@ class Job:
         self.returncode = None
         self.output = None
         self.error = None
-        self.hosts = []
         self.is_task = is_task
         self.start_time = time.time()
         self.history.new_run()

--- a/smartsim/_core/control/job.py
+++ b/smartsim/_core/control/job.py
@@ -313,12 +313,7 @@ class Job:
         :returns: A user-readable string of the Job
         :rtype: str
         """
-        if self.jid:
-            job = "{}({}): {}"
-            return job.format(self.ename, self.jid, self.status)
-
-        job = "{}: {}"
-        return job.format(self.ename, self.status)
+        return f"{self.ename}{f'({self.jid})' if self.jid else ''}: {self.status}"
 
 
 class History:

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -295,7 +295,9 @@ class JobManager:
                 dict_entry: t.List[str] = address_dict.get(db_entity.db_identifier, [])
                 dict_entry.extend(
                     f"{get_ip_from_host(host)}:{port}"
-                    for host, port in itertools.product(job.hosts, db_entity.ports)
+                    for host, port in itertools.product(
+                        db_entity.hosts, db_entity.ports
+                    )
                 )
                 address_dict[db_entity.db_identifier] = dict_entry
 

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -38,7 +38,6 @@ from ...log import ContextThread, get_logger
 from ...status import TERMINAL_STATUSES, SmartSimStatus
 from ..config import CONFIG
 from ..utils import helpers as _helpers
-from ..launcher import Launcher, LocalLauncher
 from ..utils.network import get_ip_from_host
 from .job import Job, JobEntity
 
@@ -65,14 +64,9 @@ class JobManager:
     def __init__(
         self,
         lock: RLock,
-        launcher: t.Optional[Launcher] = None,
         poll_status_interval: int = CONFIG.jm_interval,
     ) -> None:
-        """Initialize a Jobmanager
-
-        :param launcher: a Launcher object to manage jobs
-        :type: SmartSim.Launcher
-        """
+        """Initialize a Jobmanager"""
         self.monitor: t.Optional[Thread] = None
 
         # active jobs

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -179,13 +179,13 @@ class JobManager:
         :param is_task: process monitored by TaskManager (True) or the WLM (True)
         :type is_task: bool
         """
-        # all operations here should be atomic
-        if isinstance(job.entity, (DBNode, Orchestrator)):
-            self.db_jobs[job.entity.name] = job
-        elif isinstance(job.entity, JobEntity) and job.entity.is_db:
-            self.db_jobs[job.entity.name] = job
-        else:
-            self.jobs[job.entity.name] = job
+        with self._lock:
+            if isinstance(job.entity, (DBNode, Orchestrator)):
+                self.db_jobs[job.entity.name] = job
+            elif isinstance(job.entity, JobEntity) and job.entity.is_db:
+                self.db_jobs[job.entity.name] = job
+            else:
+                self.jobs[job.entity.name] = job
 
     def is_finished(self, entity: SmartSimEntity) -> bool:
         """Detect if a job has completed

--- a/smartsim/_core/launcher/launcher.py
+++ b/smartsim/_core/launcher/launcher.py
@@ -55,7 +55,32 @@ class Launcher(abc.ABC):  # pragma: no cover
     def create_step(
         self, name: "_entity_types.EntityName", cwd: str, step_settings: SettingsBase
     ) -> Step:
+        # XXX: There appears to always be a 1-to-1 mapping of `Settings Type`
+        #      to `Step Type` across all launchers. If that is true, why do we
+        #      need to query the query the launcher for the type of step to
+        #      build when the settings should know it intrinsically?
         raise NotImplementedError
+
+    # ==========================================================================
+    # XXX: These methods have very little right to exist! Ideally we should
+    #      move all of the logic for deciding what type of step to create from
+    #      the controller/launcher into the step constructor(s) including
+    #      knowing which settings to use!
+    # --------------------------------------------------------------------------
+    def create_step_from(self, entity: "_core_types.RunSettingsStepable") -> Step:
+        return self.create_step(entity.name, entity.path, entity.run_settings)
+
+    def create_batch_step_from(
+        self, entity: "_core_types.BatchSettingsStepable"
+    ) -> Step:
+        if not entity.batch_settings:
+            raise ValueError(
+                f"{type(self).__name__}:{entity.name} must have a non-null "
+                "`batch_setting` attribute to be launched as batch"
+            )
+        return self.create_step(entity.name, entity.path, entity.batch_settings)
+
+    # ==========================================================================
 
     @abc.abstractmethod
     def get_step_update(

--- a/smartsim/_core/launcher/launcher.py
+++ b/smartsim/_core/launcher/launcher.py
@@ -173,9 +173,6 @@ class WLMLauncher(Launcher):  # cov-wlm
             updates.append(update)
         return updates
 
-    # pylint: disable-next=no-self-use
-    def _get_managed_step_update(
-        self,
-        step_ids: t.List[str],  # pylint: disable=unused-argument
-    ) -> t.List[StepInfo]:  # pragma: no cover
-        return []
+    @abc.abstractmethod
+    def _get_managed_step_update(self, step_ids: t.List[str]) -> t.List[StepInfo]:
+        raise NotImplementedError

--- a/smartsim/_core/launcher/launcher.py
+++ b/smartsim/_core/launcher/launcher.py
@@ -34,6 +34,10 @@ from .stepInfo import StepInfo, UnmanagedStepInfo
 from .stepMapping import StepMapping
 from .taskManager import TaskManager
 
+if t.TYPE_CHECKING:
+    from smartsim._core import types as _core_types
+    from smartsim.entity import types as _entity_types
+
 
 class Launcher(abc.ABC):  # pragma: no cover
     """Abstract base class of all launchers
@@ -48,25 +52,29 @@ class Launcher(abc.ABC):  # pragma: no cover
     task_manager: TaskManager
 
     @abc.abstractmethod
-    def create_step(self, name: str, cwd: str, step_settings: SettingsBase) -> Step:
+    def create_step(
+        self, name: "_entity_types.EntityName", cwd: str, step_settings: SettingsBase
+    ) -> Step:
         raise NotImplementedError
 
     @abc.abstractmethod
     def get_step_update(
-        self, step_names: t.List[str]
-    ) -> t.List[t.Tuple[str, t.Union[StepInfo, None]]]:
+        self, step_names: t.List["_core_types.StepName"]
+    ) -> t.List[t.Tuple["_core_types.StepName", t.Union[StepInfo, None]]]:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_step_nodes(self, step_names: t.List[str]) -> t.List[t.List[str]]:
+    def get_step_nodes(
+        self, step_names: t.List["_core_types.StepName"]
+    ) -> t.List[t.List[str]]:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def run(self, step: Step) -> t.Optional[str]:
+    def run(self, step: Step) -> "_core_types.JobIdType":
         raise NotImplementedError
 
     @abc.abstractmethod
-    def stop(self, step_name: str) -> StepInfo:
+    def stop(self, step_name: "_core_types.StepName") -> StepInfo:
         raise NotImplementedError
 
 
@@ -81,6 +89,10 @@ class WLMLauncher(Launcher):  # cov-wlm
         self.task_manager = TaskManager()
         self.step_mapping = StepMapping()
 
+    @abc.abstractmethod
+    def run(self, step: Step) -> t.Optional["_core_types.StepID"]:
+        raise NotImplementedError
+
     @property
     @abc.abstractmethod
     def supported_rs(self) -> t.Dict[t.Type[SettingsBase], t.Type[Step]]:
@@ -89,7 +101,7 @@ class WLMLauncher(Launcher):  # cov-wlm
     # every launcher utilizing this interface must have a map
     # of supported RunSettings types (see slurmLauncher.py for ex)
     def create_step(
-        self, name: str, cwd: str, step_settings: SettingsBase
+        self, name: "_entity_types.EntityName", cwd: str, step_settings: SettingsBase
     ) -> Step:  # cov-wlm
         """Create a WLM job step
 
@@ -119,13 +131,13 @@ class WLMLauncher(Launcher):  # cov-wlm
     # don't need to be covered here.
 
     def get_step_nodes(
-        self, step_names: t.List[str]
+        self, step_names: t.List["_core_types.StepName"]
     ) -> t.List[t.List[str]]:  # pragma: no cover
         raise SSUnsupportedError("Node acquisition not supported for this launcher")
 
     def get_step_update(
-        self, step_names: t.List[str]
-    ) -> t.List[t.Tuple[str, t.Union[StepInfo, None]]]:  # cov-wlm
+        self, step_names: t.List["_core_types.StepName"]
+    ) -> t.List[t.Tuple["_core_types.StepName", t.Union[StepInfo, None]]]:  # cov-wlm
         """Get update for a list of job steps
 
         :param step_names: list of job steps to get updates for
@@ -133,7 +145,7 @@ class WLMLauncher(Launcher):  # cov-wlm
         :return: list of name, job update tuples
         :rtype: list[(str, StepInfo)]
         """
-        updates: t.List[t.Tuple[str, t.Union[StepInfo, None]]] = []
+        updates: t.List[t.Tuple["_core_types.StepName", t.Union[StepInfo, None]]] = []
 
         # get updates of jobs managed by workload manager (PBS, Slurm, etc)
         # this is primarily batch jobs.

--- a/smartsim/_core/launcher/local/local.py
+++ b/smartsim/_core/launcher/local/local.py
@@ -33,6 +33,10 @@ from ..stepInfo import StepInfo, UnmanagedStepInfo
 from ..stepMapping import StepMapping
 from ..taskManager import TaskManager
 
+if t.TYPE_CHECKING:
+    from smartsim._core import types as _core_types
+    from smartsim.entity import types as _entity_types
+
 
 class LocalLauncher(Launcher):
     """Launcher used for spawning proceses on a localhost machine."""
@@ -41,7 +45,9 @@ class LocalLauncher(Launcher):
         self.task_manager = TaskManager()
         self.step_mapping = StepMapping()
 
-    def create_step(self, name: str, cwd: str, step_settings: SettingsBase) -> Step:
+    def create_step(
+        self, name: "_entity_types.EntityName", cwd: str, step_settings: SettingsBase
+    ) -> Step:
         """Create a job step to launch an entity locally
 
         :return: Step object
@@ -54,8 +60,8 @@ class LocalLauncher(Launcher):
         return LocalStep(name, cwd, step_settings)
 
     def get_step_update(
-        self, step_names: t.List[str]
-    ) -> t.List[t.Tuple[str, t.Optional[StepInfo]]]:
+        self, step_names: t.List["_core_types.StepName"]
+    ) -> t.List[t.Tuple["_core_types.StepName", t.Optional[StepInfo]]]:
         """Get status updates of each job step name provided
 
         :param step_names: list of step_names
@@ -65,7 +71,7 @@ class LocalLauncher(Launcher):
         """
         # step ids are process ids of the tasks
         # as there is no WLM intermediary
-        updates: t.List[t.Tuple[str, t.Optional[StepInfo]]] = []
+        updates: t.List[t.Tuple["_core_types.StepName", t.Optional[StepInfo]]] = []
         s_names, s_ids = self.step_mapping.get_ids(step_names, managed=False)
         for step_name, step_id in zip(s_names, s_ids):
             status, ret_code, out, err = self.task_manager.get_task_update(str(step_id))
@@ -74,7 +80,9 @@ class LocalLauncher(Launcher):
             updates.append(update)
         return updates
 
-    def get_step_nodes(self, step_names: t.List[str]) -> t.List[t.List[str]]:
+    def get_step_nodes(
+        self, step_names: t.List["_core_types.StepName"]
+    ) -> t.List[t.List[str]]:
         """Return the address of nodes assigned to the step
 
         :param step_names: list of step_names
@@ -86,7 +94,7 @@ class LocalLauncher(Launcher):
         """
         return [["127.0.0.1"] * len(step_names)]
 
-    def run(self, step: Step) -> str:
+    def run(self, step: Step) -> "_core_types.TaskID":
         """Run a local step created by this launcher. Utilize the shell
            library to execute the command with a Popen. Output and error
            files will be written to the entity path.
@@ -114,7 +122,7 @@ class LocalLauncher(Launcher):
         self.step_mapping.add(step.name, task_id=task_id, managed=False)
         return task_id
 
-    def stop(self, step_name: str) -> UnmanagedStepInfo:
+    def stop(self, step_name: "_core_types.StepName") -> UnmanagedStepInfo:
         """Stop a job step
 
         :param step_name: name of the step to be stopped

--- a/smartsim/_core/launcher/lsf/lsfLauncher.py
+++ b/smartsim/_core/launcher/lsf/lsfLauncher.py
@@ -27,6 +27,8 @@
 import time
 import typing as t
 
+from smartsim._core import types as _core_types
+
 from ....error import LauncherError
 from ....log import get_logger
 from ....settings import (
@@ -87,7 +89,7 @@ class LSFLauncher(WLMLauncher):
             RunSettings: LocalStep,
         }
 
-    def run(self, step: Step) -> t.Optional[str]:
+    def run(self, step: Step) -> t.Optional[_core_types.StepID]:
         """Run a job step through LSF
 
         :param step: a job step instance
@@ -130,7 +132,7 @@ class LSFLauncher(WLMLauncher):
         self.step_mapping.add(step.name, step_id, task_id, step.managed)
         return step_id
 
-    def stop(self, step_name: str) -> StepInfo:
+    def stop(self, step_name: _core_types.StepName) -> StepInfo:
         """Stop/cancel a job step
 
         :param step_name: name of the job to stop
@@ -161,7 +163,7 @@ class LSFLauncher(WLMLauncher):
         return step_info
 
     @staticmethod
-    def _get_lsf_step_id(step: Step, interval: int = 2) -> str:
+    def _get_lsf_step_id(step: Step, interval: int = 2) -> _core_types.StepID:
         """Get the step_id of last launched step from jslist"""
         time.sleep(interval)
         step_id: t.Optional[str] = None
@@ -179,7 +181,7 @@ class LSFLauncher(WLMLauncher):
         if not hasattr(step, "alloc"):
             raise LauncherError("Could not find alloc for launched job step")
 
-        return f"{step.alloc}.{step_id}"
+        return _core_types.StepID(f"{step.alloc}.{step_id}")
 
     def _get_managed_step_update(self, step_ids: t.List[str]) -> t.List[StepInfo]:
         """Get step updates for WLM managed jobs

--- a/smartsim/_core/launcher/lsf/lsfParser.py
+++ b/smartsim/_core/launcher/lsf/lsfParser.py
@@ -26,8 +26,10 @@
 
 import typing as t
 
+from smartsim._core.types import StepID
 
-def parse_bsub(output: str) -> str:
+
+def parse_bsub(output: str) -> StepID:
     """Parse bsub output and return job id.
 
     :param output: stdout of bsub command
@@ -37,8 +39,8 @@ def parse_bsub(output: str) -> str:
     """
     for line in output.split("\n"):
         if line.startswith("Job"):
-            return line.split()[1][1:-1]
-    return ""
+            return StepID(line.split()[1][1:-1])
+    return StepID("")
 
 
 def parse_bsub_error(output: str) -> str:

--- a/smartsim/_core/launcher/pbs/pbsParser.py
+++ b/smartsim/_core/launcher/pbs/pbsParser.py
@@ -27,6 +27,8 @@
 import json
 import typing as t
 
+from smartsim._core.types import StepID, StepName
+
 
 def parse_qsub(output: str) -> str:
     """Parse qsub output and return job id. For PBS, the
@@ -112,7 +114,7 @@ def parse_qstat_nodes(output: str) -> t.List[str]:
     return list(sorted(set(nodes)))
 
 
-def parse_step_id_from_qstat(output: str, step_name: str) -> t.Optional[str]:
+def parse_step_id_from_qstat(output: str, step_name: StepName) -> t.Optional[StepID]:
     """Parse and return the step id from a qstat command
 
     :param output: output qstat
@@ -122,18 +124,15 @@ def parse_step_id_from_qstat(output: str, step_name: str) -> t.Optional[str]:
     :return: the step_id
     :rtype: str
     """
-    step_id: t.Optional[str] = None
     out_json = load_and_clean_json(output)
 
     if "Jobs" not in out_json:
-        return step_id
+        return None
     jobs = out_json["Jobs"]
     for key, val in jobs.items():
         if val["Job_Name"] == step_name:
-            step_id = key
-            return step_id
-
-    return step_id
+            return StepID(key)
+    return None
 
 
 def load_and_clean_json(out: str) -> t.Any:

--- a/smartsim/_core/launcher/slurm/slurmParser.py
+++ b/smartsim/_core/launcher/slurm/slurmParser.py
@@ -27,6 +27,8 @@
 import typing as t
 from shutil import which
 
+from smartsim._core.types import StepID, StepName
+
 """
 Parsers for various slurm functions.
 """
@@ -129,7 +131,7 @@ def parse_sstat_nodes(output: str, job_id: str) -> t.List[str]:
     return list(set(nodes))
 
 
-def parse_step_id_from_sacct(output: str, step_name: str) -> t.Optional[str]:
+def parse_step_id_from_sacct(output: str, step_name: StepName) -> t.Optional[StepID]:
     """Parse and return the step id from a sacct command
 
     :param output: output of sacct --noheader -p
@@ -145,5 +147,5 @@ def parse_step_id_from_sacct(output: str, step_name: str) -> t.Optional[str]:
         sacct_string = line.split("|")
         if len(sacct_string) >= 2:
             if sacct_string[0] == step_name:
-                step_id = sacct_string[1]
+                step_id = StepID(sacct_string[1])
     return step_id

--- a/smartsim/_core/launcher/step/alpsStep.py
+++ b/smartsim/_core/launcher/step/alpsStep.py
@@ -34,11 +34,16 @@ from ....log import get_logger
 from ....settings import AprunSettings, RunSettings, Singularity
 from .step import Step, proxyable_launch_cmd
 
+if t.TYPE_CHECKING:
+    from smartsim.entity import types as _entity_types
+
 logger = get_logger(__name__)
 
 
 class AprunStep(Step):
-    def __init__(self, name: str, cwd: str, run_settings: AprunSettings) -> None:
+    def __init__(
+        self, name: "_entity_types.EntityName", cwd: str, run_settings: AprunSettings
+    ) -> None:
         """Initialize a ALPS aprun job step
 
         :param name: name of the entity to be launched

--- a/smartsim/_core/launcher/step/localStep.py
+++ b/smartsim/_core/launcher/step/localStep.py
@@ -32,9 +32,14 @@ from ....settings import Singularity
 from ....settings.base import RunSettings
 from .step import Step, proxyable_launch_cmd
 
+if t.TYPE_CHECKING:
+    from smartsim.entity import types as _entity_types
+
 
 class LocalStep(Step):
-    def __init__(self, name: str, cwd: str, run_settings: RunSettings):
+    def __init__(
+        self, name: "_entity_types.EntityName", cwd: str, run_settings: RunSettings
+    ):
         super().__init__(name, cwd, run_settings)
         self.run_settings = run_settings
         self._env = self._set_env()

--- a/smartsim/_core/launcher/step/lsfStep.py
+++ b/smartsim/_core/launcher/step/lsfStep.py
@@ -34,11 +34,19 @@ from ....settings import BsubBatchSettings, JsrunSettings
 from ....settings.base import RunSettings
 from .step import Step
 
+if t.TYPE_CHECKING:
+    from smartsim.entity import types as _entity_types
+
 logger = get_logger(__name__)
 
 
 class BsubBatchStep(Step):
-    def __init__(self, name: str, cwd: str, batch_settings: BsubBatchSettings) -> None:
+    def __init__(
+        self,
+        name: "_entity_types.EntityName",
+        cwd: str,
+        batch_settings: BsubBatchSettings,
+    ) -> None:
         """Initialize a LSF bsub step
 
         :param name: name of the entity to launch
@@ -109,7 +117,9 @@ class BsubBatchStep(Step):
 
 
 class JsrunStep(Step):
-    def __init__(self, name: str, cwd: str, run_settings: RunSettings):
+    def __init__(
+        self, name: "_entity_types.EntityName", cwd: str, run_settings: RunSettings
+    ):
         """Initialize a LSF jsrun job step
 
         :param name: name of the entity to be launched

--- a/smartsim/_core/launcher/step/lsfStep.py
+++ b/smartsim/_core/launcher/step/lsfStep.py
@@ -58,8 +58,11 @@ class BsubBatchStep(Step):
         """
         super().__init__(name, cwd, batch_settings)
         self.step_cmds: t.List[t.List[str]] = []
-        self.managed = True
         self.batch_settings = batch_settings
+
+    @property
+    def managed(self) -> bool:
+        return True
 
     def get_launch_cmd(self) -> t.List[str]:
         """Get the launch command for the batch
@@ -131,10 +134,13 @@ class JsrunStep(Step):
         """
         super().__init__(name, cwd, run_settings)
         self.alloc: t.Optional[str] = None
-        self.managed = True
         self.run_settings = run_settings
         if not self.run_settings.in_batch:
             self._set_alloc()
+
+    @property
+    def managed(self) -> bool:
+        return True
 
     def get_output_files(self) -> t.Tuple[str, str]:
         """Return two paths to error and output files based on cwd"""

--- a/smartsim/_core/launcher/step/mpiStep.py
+++ b/smartsim/_core/launcher/step/mpiStep.py
@@ -35,11 +35,17 @@ from ....settings import MpiexecSettings, MpirunSettings, OrterunSettings
 from ....settings.base import RunSettings
 from .step import Step, proxyable_launch_cmd
 
+if t.TYPE_CHECKING:
+    from smartsim.entity import types as _entity_types
+
+
 logger = get_logger(__name__)
 
 
 class _BaseMPIStep(Step):
-    def __init__(self, name: str, cwd: str, run_settings: RunSettings) -> None:
+    def __init__(
+        self, name: "_entity_types.EntityName", cwd: str, run_settings: RunSettings
+    ) -> None:
         """Initialize a job step conforming to the MPI standard
 
         :param name: name of the entity to be launched
@@ -157,7 +163,9 @@ class _BaseMPIStep(Step):
 
 
 class MpiexecStep(_BaseMPIStep):
-    def __init__(self, name: str, cwd: str, run_settings: MpiexecSettings) -> None:
+    def __init__(
+        self, name: "_entity_types.EntityName", cwd: str, run_settings: MpiexecSettings
+    ) -> None:
         """Initialize an mpiexec job step
 
         :param name: name of the entity to be launched
@@ -175,7 +183,9 @@ class MpiexecStep(_BaseMPIStep):
 
 
 class MpirunStep(_BaseMPIStep):
-    def __init__(self, name: str, cwd: str, run_settings: MpirunSettings) -> None:
+    def __init__(
+        self, name: "_entity_types.EntityName", cwd: str, run_settings: MpirunSettings
+    ) -> None:
         """Initialize an mpirun job step
 
         :param name: name of the entity to be launched
@@ -193,7 +203,9 @@ class MpirunStep(_BaseMPIStep):
 
 
 class OrterunStep(_BaseMPIStep):
-    def __init__(self, name: str, cwd: str, run_settings: OrterunSettings) -> None:
+    def __init__(
+        self, name: "_entity_types.EntityName", cwd: str, run_settings: OrterunSettings
+    ) -> None:
         """Initialize an orterun job step
 
         :param name: name of the entity to be launched

--- a/smartsim/_core/launcher/step/pbsStep.py
+++ b/smartsim/_core/launcher/step/pbsStep.py
@@ -54,8 +54,11 @@ class QsubBatchStep(Step):
         """
         super().__init__(name, cwd, batch_settings)
         self.step_cmds: t.List[t.List[str]] = []
-        self.managed = True
         self.batch_settings = batch_settings
+
+    @property
+    def managed(self) -> bool:
+        return True
 
     def get_launch_cmd(self) -> t.List[str]:
         """Get the launch command for the batch

--- a/smartsim/_core/launcher/step/pbsStep.py
+++ b/smartsim/_core/launcher/step/pbsStep.py
@@ -30,11 +30,19 @@ from ....log import get_logger
 from ....settings import QsubBatchSettings
 from .step import Step
 
+if t.TYPE_CHECKING:
+    from smartsim.entity import types as _entity_types
+
 logger = get_logger(__name__)
 
 
 class QsubBatchStep(Step):
-    def __init__(self, name: str, cwd: str, batch_settings: QsubBatchSettings) -> None:
+    def __init__(
+        self,
+        name: "_entity_types.EntityName",
+        cwd: str,
+        batch_settings: QsubBatchSettings,
+    ) -> None:
         """Initialize a PBSpro qsub step
 
         :param name: name of the entity to launch

--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -55,8 +55,11 @@ class SbatchStep(Step):
         """
         super().__init__(name, cwd, batch_settings)
         self.step_cmds: t.List[t.List[str]] = []
-        self.managed = True
         self.batch_settings = batch_settings
+
+    @property
+    def managed(self) -> bool:
+        return True
 
     def get_launch_cmd(self) -> t.List[str]:
         """Get the launch command for the batch
@@ -123,10 +126,13 @@ class SrunStep(Step):
         """
         super().__init__(name, cwd, run_settings)
         self.alloc: t.Optional[str] = None
-        self.managed = True
         self.run_settings = run_settings
         if not self.run_settings.in_batch:
             self._set_alloc()
+
+    @property
+    def managed(self) -> bool:
+        return True
 
     def get_launch_cmd(self) -> t.List[str]:
         """Get the command to launch this step

--- a/smartsim/_core/launcher/step/slurmStep.py
+++ b/smartsim/_core/launcher/step/slurmStep.py
@@ -34,11 +34,16 @@ from ....log import get_logger
 from ....settings import RunSettings, SbatchSettings, Singularity, SrunSettings
 from .step import Step
 
+if t.TYPE_CHECKING:
+    from smartsim.entity import types as _entity_types
+
 logger = get_logger(__name__)
 
 
 class SbatchStep(Step):
-    def __init__(self, name: str, cwd: str, batch_settings: SbatchSettings) -> None:
+    def __init__(
+        self, name: "_entity_types.EntityName", cwd: str, batch_settings: SbatchSettings
+    ) -> None:
         """Initialize a Slurm Sbatch step
 
         :param name: name of the entity to launch
@@ -104,7 +109,9 @@ class SbatchStep(Step):
 
 
 class SrunStep(Step):
-    def __init__(self, name: str, cwd: str, run_settings: SrunSettings) -> None:
+    def __init__(
+        self, name: "_entity_types.EntityName", cwd: str, run_settings: SrunSettings
+    ) -> None:
         """Initialize a srun job step
 
         :param name: name of the entity to be launched

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -35,6 +35,7 @@ import typing as t
 from os import makedirs
 
 from smartsim._core.config import CONFIG
+from smartsim._core.types import StepName
 from smartsim.error.errors import SmartSimError, UnproxyableStepError
 
 from ....log import get_logger
@@ -44,10 +45,15 @@ from ..colocated import write_colocated_launch_script
 
 logger = get_logger(__name__)
 
+if t.TYPE_CHECKING:
+    from smartsim.entity import types as _entity_types
+
 
 class Step:
-    def __init__(self, name: str, cwd: str, step_settings: SettingsBase) -> None:
-        self.name = self._create_unique_name(name)
+    def __init__(
+        self, name: "_entity_types.EntityName", cwd: str, step_settings: SettingsBase
+    ) -> None:
+        self.name: t.Final = self._create_unique_name(name)
         self.entity_name = name
         self.cwd = cwd
         self.managed = False
@@ -63,9 +69,8 @@ class Step:
         raise NotImplementedError
 
     @staticmethod
-    def _create_unique_name(entity_name: str) -> str:
-        step_name = entity_name + "-" + get_base_36_repr(time.time_ns())
-        return step_name
+    def _create_unique_name(entity_name: "_entity_types.EntityName") -> StepName:
+        return StepName(f"{entity_name}-{get_base_36_repr(time.time_ns())}")
 
     @staticmethod
     def _ensure_output_directory_exists(output_dir: str) -> None:

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -54,11 +54,17 @@ class Step:
         self, name: "_entity_types.EntityName", cwd: str, step_settings: SettingsBase
     ) -> None:
         self.name: t.Final = self._create_unique_name(name)
-        self.entity_name = name
-        self.cwd = cwd
-        self.managed = False
+        self.entity_name: t.Final = name
+        self.cwd: t.Final = cwd
         self.step_settings = step_settings
-        self.meta: t.Dict[str, str] = {}
+        self.meta: t.Final[t.Dict[str, str]] = {}
+
+    @property
+    def managed(cls) -> bool:
+        # XXX: keeping this as an instance attr for now, this is really more
+        #      a class property than an instance propery. Even better would
+        #      be to have different classes for managed and unmanaged steps
+        return False
 
     @property
     def env(self) -> t.Optional[t.Dict[str, str]]:

--- a/smartsim/_core/launcher/stepInfo.py
+++ b/smartsim/_core/launcher/stepInfo.py
@@ -25,32 +25,28 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import typing as t
+import textwrap
+import dataclasses
 
 import psutil
 
 from ...status import SmartSimStatus
 
 
+@dataclasses.dataclass
 class StepInfo:
-    def __init__(
-        self,
-        status: SmartSimStatus,
-        launcher_status: str = "",
-        returncode: t.Optional[int] = None,
-        output: t.Optional[str] = None,
-        error: t.Optional[str] = None,
-    ) -> None:
-        self.status = status
-        self.launcher_status = launcher_status
-        self.returncode = returncode
-        self.output = output
-        self.error = error
+    status: SmartSimStatus
+    launcher_status: str = ""
+    returncode: t.Optional[int] = None
+    output: t.Optional[str] = None
+    error: t.Optional[str] = None
 
     def __str__(self) -> str:
-        info_str = f"Status: {self.status.value}"
-        info_str += f" | Launcher Status {self.launcher_status}"
-        info_str += f" | Returncode {str(self.returncode)}"
-        return info_str
+        return (
+            f"Status: {self.status.value} "
+            f"| Launcher Status {self.launcher_status} "
+            f"| Returncode {self.returncode}"
+        )
 
     @property
     def mapping(self) -> t.Dict[str, SmartSimStatus]:

--- a/smartsim/_core/launcher/stepInfo.py
+++ b/smartsim/_core/launcher/stepInfo.py
@@ -24,9 +24,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import typing as t
-import textwrap
 import dataclasses
+import typing as t
 
 import psutil
 

--- a/smartsim/_core/launcher/stepMapping.py
+++ b/smartsim/_core/launcher/stepMapping.py
@@ -24,46 +24,42 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import dataclasses
 import typing as t
+
+from smartsim._core import types as _core_types
 
 from ...log import get_logger
 
 logger = get_logger(__name__)
 
 
+@dataclasses.dataclass
 class StepMap:
-    def __init__(
-        self,
-        step_id: t.Optional[str] = None,
-        task_id: t.Optional[str] = None,
-        managed: t.Optional[bool] = None,
-    ) -> None:
-        self.step_id = step_id
-        self.task_id = task_id
-        self.managed = managed
+    step_id: t.Optional[_core_types.StepID] = None
+    task_id: t.Optional[_core_types.TaskID] = None
+    managed: t.Optional[bool] = None
 
 
 class StepMapping:
     def __init__(self) -> None:
-        # step_name : wlm_id, pid, wlm_managed?
-        self.mapping: t.Dict[str, StepMap] = {}
+        self.mapping: t.Dict["_core_types.StepName", StepMap] = {}
 
-    def __getitem__(self, step_name: str) -> StepMap:
+    def __getitem__(self, step_name: "_core_types.StepName") -> StepMap:
         return self.mapping[step_name]
 
-    def __setitem__(self, step_name: str, step_map: StepMap) -> None:
+    def __setitem__(self, step_name: "_core_types.StepName", step_map: StepMap) -> None:
         self.mapping[step_name] = step_map
 
     def add(
         self,
-        step_name: str,
-        step_id: t.Optional[str] = None,
-        task_id: t.Optional[str] = None,
+        step_name: _core_types.StepName,
+        step_id: t.Optional[_core_types.StepID] = None,
+        task_id: t.Optional[_core_types.TaskID] = None,
         managed: bool = True,
     ) -> None:
         try:
-            n_task_id = str(task_id) if task_id else None
-            self.mapping[step_name] = StepMap(step_id, n_task_id, managed)
+            self.mapping[step_name] = StepMap(step_id, task_id, managed)
         except Exception as e:
             msg = f"Could not add step {step_name} to mapping: {e}"
             logger.exception(msg)
@@ -78,8 +74,8 @@ class StepMapping:
         return task_id
 
     def get_ids(
-        self, step_names: t.List[str], managed: bool = True
-    ) -> t.Tuple[t.List[str], t.List[t.Union[str, None]]]:
+        self, step_names: t.List["_core_types.StepName"], managed: bool = True
+    ) -> t.Tuple[t.List["_core_types.StepName"], t.List[t.Union[str, None]]]:
         ids: t.List[t.Union[str, None]] = []
         names = []
         for name in step_names:

--- a/smartsim/_core/launcher/taskManager.py
+++ b/smartsim/_core/launcher/taskManager.py
@@ -33,6 +33,8 @@ from threading import RLock
 
 import psutil
 
+import smartsim._core.types as _core_types
+
 from ...error import LauncherError
 from ...log import ContextThread, get_logger
 from ..utils.helpers import check_dev_log_level
@@ -107,7 +109,7 @@ class TaskManager:
         env: t.Optional[t.Dict[str, str]] = None,
         out: int = PIPE,
         err: int = PIPE,
-    ) -> str:
+    ) -> _core_types.TaskID:
         """Start a task managed by the TaskManager
 
         This is an "unmanaged" task, meaning it is NOT managed
@@ -281,7 +283,7 @@ class Task:
         :type process: psutil.Process
         """
         self.process = process
-        self.pid = str(self.process.pid)
+        self.pid = _core_types.TaskID(str(self.process.pid))
 
     def check_status(self) -> t.Optional[int]:
         """Ping the job and return the returncode if finished

--- a/smartsim/_core/types.py
+++ b/smartsim/_core/types.py
@@ -1,9 +1,34 @@
 import typing as t
 
+if t.TYPE_CHECKING:
+    from smartsim.entity.entity import SmartSimEntity
+    from smartsim.entity.entityList import EntitySequence
+    from smartsim.settings import base as _settings_base
+    from smartsim.entity import types as _entity_types
+
 # New types
 StepName = t.NewType("StepName", str)
 StepID = t.NewType("StepID", str)
 TaskID = t.NewType("TaskID", str)
+
+
+# Protocols
+class _Stepable(t.Protocol):
+    @property
+    def name(self) -> "_entity_types.EntityName": ...
+    @property
+    def path(self) -> str: ...
+
+
+class RunSettingsStepable(_Stepable, t.Protocol):
+    @property
+    def run_settings(self) -> "_settings_base.RunSettings": ...
+
+
+class BatchSettingsStepable(_Stepable, t.Protocol):
+    @property
+    def batch_settings(self) -> t.Optional["_settings_base.BatchSettings"]: ...
+
 
 # Aliases
 JobIdType = t.Union[t.Optional[StepID], TaskID]

--- a/smartsim/_core/types.py
+++ b/smartsim/_core/types.py
@@ -1,4 +1,5 @@
 import typing as t
+import uuid
 
 if t.TYPE_CHECKING:
     from smartsim.entity.entity import SmartSimEntity
@@ -10,6 +11,7 @@ if t.TYPE_CHECKING:
 StepName = t.NewType("StepName", str)
 StepID = t.NewType("StepID", str)
 TaskID = t.NewType("TaskID", str)
+MonitoredJobID = t.NewType("MonitoredJobID", uuid.UUID)
 
 
 # Protocols

--- a/smartsim/_core/types.py
+++ b/smartsim/_core/types.py
@@ -1,0 +1,10 @@
+import typing as t
+
+# New types
+StepName = t.NewType("StepName", str)
+StepID = t.NewType("StepID", str)
+TaskID = t.NewType("TaskID", str)
+
+# Aliases
+JobIdType = t.Union[t.Optional[StepID], TaskID]
+TTelmonEntityTypeStr = t.Literal["model", "ensemble", "orchestrator"]

--- a/smartsim/_core/utils/serialize.py
+++ b/smartsim/_core/utils/serialize.py
@@ -36,6 +36,7 @@ import smartsim.log
 
 if t.TYPE_CHECKING:
     from smartsim._core.control.manifest import LaunchedManifest as _Manifest
+    from smartsim._core.types import StepID, TaskID
     from smartsim.database.orchestrator import Orchestrator
     from smartsim.entity import DBNode, Ensemble, Model
     from smartsim.entity.dbobject import DBModel, DBScript
@@ -43,7 +44,7 @@ if t.TYPE_CHECKING:
 
 
 TStepLaunchMetaData = t.Tuple[
-    t.Optional[str], t.Optional[str], t.Optional[bool], str, str, Path
+    t.Optional["StepID"], t.Optional["TaskID"], t.Optional[bool], str, str, Path
 ]
 
 MANIFEST_FILENAME: t.Final[str] = "manifest.json"
@@ -97,8 +98,8 @@ def save_launch_manifest(manifest: _Manifest[TStepLaunchMetaData]) -> None:
 
 def _dictify_model(
     model: Model,
-    step_id: t.Optional[str],
-    task_id: t.Optional[str],
+    step_id: t.Optional["StepID"],
+    task_id: t.Optional["TaskID"],
     managed: t.Optional[bool],
     out_file: str,
     err_file: str,

--- a/smartsim/_core/utils/telemetry/telemetry.py
+++ b/smartsim/_core/utils/telemetry/telemetry.py
@@ -248,7 +248,7 @@ class ManifestEventHandler(PatternMatchingEventHandler):
                         _dangerous_cast_entity_name_to_step_name(entity.name),
                         entity.step_id,
                         "",
-                        True
+                        True,
                     )
             self._tracked_runs[run.timestamp] = run
 

--- a/smartsim/entity/dbnode.py
+++ b/smartsim/entity/dbnode.py
@@ -96,6 +96,14 @@ class DBNode(SmartSimEntity):
     def hosts(self) -> t.List[str]:
         if not self._hosts:
             self._hosts = self._parse_db_hosts()
+            #                  ^^^^^^^^^^^^^^^^^
+            # XXX: Why on earth is the entity responsible for determining on
+            #      which hosts it is running. Especially since this parsing
+            #      behavior will not be preformed if a user sets the hosts attr
+            #      using the `set_hosts` method on either the `DBNode` or the
+            #      `Orchestrator`.  Since the `Job` (theoretically) correlates
+            #      to a "launched" entity, shouldn't it be the one responsible
+            #      for knowing what hosts it is _actually_ running on??
         return self._hosts
 
     def clear_hosts(self) -> None:

--- a/smartsim/entity/entity.py
+++ b/smartsim/entity/entity.py
@@ -26,6 +26,8 @@
 
 import typing as t
 
+from smartsim.entity import types as _types
+
 if t.TYPE_CHECKING:
     # pylint: disable-next=unused-import
     import smartsim.settings.base
@@ -108,7 +110,7 @@ class SmartSimEntity:
                              entity
         :type run_settings: dict
         """
-        self.name = name
+        self.name: t.Final = _types.EntityName(name)
         self.run_settings = run_settings
         self.path = path
 
@@ -123,4 +125,4 @@ class SmartSimEntity:
         self.path = path
 
     def __repr__(self) -> str:
-        return self.name
+        return str(self.name)

--- a/smartsim/entity/entityList.py
+++ b/smartsim/entity/entityList.py
@@ -27,6 +27,7 @@
 import typing as t
 
 from .entity import SmartSimEntity
+from .types import EntityName
 
 if t.TYPE_CHECKING:
     # pylint: disable-next=unused-import
@@ -42,8 +43,8 @@ class EntitySequence(t.Generic[_T_co]):
     """Abstract class for containers for SmartSimEntities"""
 
     def __init__(self, name: str, path: str, **kwargs: t.Any) -> None:
-        self.name: str = name
-        self.path: str = path
+        self.name: t.Final = EntityName(name)
+        self.path = path
 
         # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         # WARNING: This class cannot be made truly covariant until the

--- a/smartsim/entity/types.py
+++ b/smartsim/entity/types.py
@@ -1,0 +1,3 @@
+import typing as t
+
+EntityName = t.NewType("EntityName", str)

--- a/tests/on_wlm/test_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_base_settings_on_wlm.py
@@ -72,7 +72,7 @@ def test_model_stop_on_wlm(fileutils, test_dir, wlmutils):
     exp.start(M1, M2, block=False)
     time.sleep(2)
     exp.stop(M1, M2)
-    assert M1.name in exp._control._jobs.completed
-    assert M2.name in exp._control._jobs.completed
+    assert M1.name in exp._control._job_manager.completed
+    assert M2.name in exp._control._job_manager.completed
     statuses = exp.get_status(M1, M2)
     assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])

--- a/tests/on_wlm/test_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_base_settings_on_wlm.py
@@ -72,7 +72,7 @@ def test_model_stop_on_wlm(fileutils, test_dir, wlmutils):
     exp.start(M1, M2, block=False)
     time.sleep(2)
     exp.stop(M1, M2)
-    assert M1.name in exp._control._job_manager.completed
-    assert M2.name in exp._control._job_manager.completed
+    assert exp._control._entity_to_job_monitor_id[M1.name] in exp._control._job_manager.completed
+    assert exp._control._entity_to_job_monitor_id[M2.name] in exp._control._job_manager.completed
     statuses = exp.get_status(M1, M2)
     assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])

--- a/tests/on_wlm/test_simple_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_simple_base_settings_on_wlm.py
@@ -83,5 +83,5 @@ def test_simple_model_stop_on_wlm(fileutils, test_dir, wlmutils):
     exp.start(M, block=False)
     time.sleep(2)
     exp.stop(M)
-    assert M.name in exp._control._job_manager.completed
+    assert exp._control._entity_to_job_monitor_id[M.name] in exp._control._job_manager.completed
     assert exp.get_status(M)[0] == SmartSimStatus.STATUS_CANCELLED

--- a/tests/on_wlm/test_simple_base_settings_on_wlm.py
+++ b/tests/on_wlm/test_simple_base_settings_on_wlm.py
@@ -83,5 +83,5 @@ def test_simple_model_stop_on_wlm(fileutils, test_dir, wlmutils):
     exp.start(M, block=False)
     time.sleep(2)
     exp.stop(M)
-    assert M.name in exp._control._jobs.completed
+    assert M.name in exp._control._job_manager.completed
     assert exp.get_status(M)[0] == SmartSimStatus.STATUS_CANCELLED

--- a/tests/on_wlm/test_stop.py
+++ b/tests/on_wlm/test_stop.py
@@ -55,7 +55,7 @@ def test_stop_entity(fileutils, test_dir, wlmutils):
     exp.start(M1, block=False)
     time.sleep(5)
     exp.stop(M1)
-    assert M1.name in exp._control._jobs.completed
+    assert M1.name in exp._control._job_manager.completed
     assert exp.get_status(M1)[0] == SmartSimStatus.STATUS_CANCELLED
 
 
@@ -85,4 +85,4 @@ def test_stop_entity_list(fileutils, test_dir, wlmutils):
     exp.stop(ensemble)
     statuses = exp.get_status(ensemble)
     assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
-    assert all([m.name in exp._control._jobs.completed for m in ensemble])
+    assert all([m.name in exp._control._job_manager.completed for m in ensemble])

--- a/tests/on_wlm/test_stop.py
+++ b/tests/on_wlm/test_stop.py
@@ -55,7 +55,7 @@ def test_stop_entity(fileutils, test_dir, wlmutils):
     exp.start(M1, block=False)
     time.sleep(5)
     exp.stop(M1)
-    assert M1.name in exp._control._job_manager.completed
+    assert exp._control._entity_to_job_monitor_id[M1.name] in exp._control._job_manager.completed
     assert exp.get_status(M1)[0] == SmartSimStatus.STATUS_CANCELLED
 
 
@@ -85,4 +85,4 @@ def test_stop_entity_list(fileutils, test_dir, wlmutils):
     exp.stop(ensemble)
     statuses = exp.get_status(ensemble)
     assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
-    assert all([m.name in exp._control._job_manager.completed for m in ensemble])
+    assert all([exp._control._entity_to_job_monitor_id[m.name] in exp._control._job_manager.completed for m in ensemble])

--- a/tests/test_controller_errors.py
+++ b/tests/test_controller_errors.py
@@ -147,7 +147,7 @@ def test_duplicate_running_entity(test_dir, wlmutils, entity):
     step = MockStep("mock-step", test_dir, step_settings)
     test_launcher = wlmutils.get_test_launcher()
     controller = Controller(test_launcher)
-    controller._jobs.add_job(entity.name, job_id="1234", entity=entity)
+    controller._job_manager.add_job(entity.name, job_id="1234", entity=entity)
     with pytest.raises(SSUnsupportedError) as ex:
         controller._launch_step(step, entity=entity)
     assert ex.value.args[0] == "SmartSim entities cannot have duplicate names."
@@ -165,8 +165,8 @@ def test_restarting_entity(test_dir, wlmutils, entity):
     entity.path = test_dir
     test_launcher = wlmutils.get_test_launcher()
     controller = Controller(test_launcher)
-    controller._jobs.add_job(entity.name, job_id="1234", entity=entity)
-    controller._jobs.move_to_completed(controller._jobs.jobs.get(entity.name))
+    controller._job_manager.add_job(entity.name, job_id="1234", entity=entity)
+    controller._job_manager.move_to_completed(controller._job_manager.jobs.get(entity.name))
     controller._launch_step(step, entity=entity)
 
 
@@ -178,8 +178,8 @@ def test_restarting_orch(test_dir, wlmutils):
     orc.path = test_dir
     test_launcher = wlmutils.get_test_launcher()
     controller = Controller(test_launcher)
-    controller._jobs.add_job(orc.name, job_id="1234", entity=orc)
-    controller._jobs.move_to_completed(controller._jobs.db_jobs.get(orc.name))
+    controller._job_manager.add_job(orc.name, job_id="1234", entity=orc)
+    controller._job_manager.move_to_completed(controller._job_manager.db_jobs.get(orc.name))
     controller._launch_step(step, entity=orc)
 
 
@@ -196,8 +196,8 @@ def test_starting_entity(test_dir, wlmutils, entity, entity_2):
     step = MockStep("mock-step", test_dir, step_settings)
     test_launcher = wlmutils.get_test_launcher()
     controller = Controller(test_launcher)
-    controller._jobs.add_job(entity.name, job_id="1234", entity=entity)
-    controller._jobs.move_to_completed(controller._jobs.jobs.get(entity.name))
+    controller._job_manager.add_job(entity.name, job_id="1234", entity=entity)
+    controller._job_manager.move_to_completed(controller._job_manager.jobs.get(entity.name))
     with pytest.raises(SSUnsupportedError) as ex:
         controller._launch_step(step, entity=entity_2)
     assert ex.value.args[0] == "SmartSim entities cannot have duplicate names."

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -183,3 +183,43 @@ def test_signal_handler_calls_functions_in_reverse_order(mock_signal):
     helpers.SignalInterceptionStack.get(signal.NSIG).push(handler_2)
     mock_signal.signal_handlers[signal.NSIG](signal.NSIG, None)
     assert called_list == ["handler_2", "handler_1", "default"]
+
+
+@pytest.mark.parametrize(
+    "iterable, key, expected",
+    (
+        pytest.param("AABCCCCCDDBBACCEFFFFF", None, "ABCDEF", id="strs"),
+        pytest.param([2, 3, 2, 3, 1], None, (2, 3, 1), id="ints"),
+        pytest.param("BaAAAbbCbBcBBa", str.lower, "BaC", id="with key"),
+    ),
+)
+def test_unique_iter(iterable, key, expected):
+    assert tuple(expected) == tuple(helpers.unique(iterable, key))
+
+
+@pytest.mark.parametrize(
+    "fn, iterable, expected",
+    (
+        pytest.param(
+            lambda n: "odd" if n & 1 else "even",
+            range(10),
+            {"even": (0, 2, 4, 6, 8), "odd": (1, 3, 5, 7, 9)},
+            id="ints by even/odd",
+        ),
+        pytest.param(
+            lambda c: c,
+            "AABbcCddA",
+            {
+                "A": ("A", "A", "A"),
+                "B": ("B",),
+                "b": ("b",),
+                "C": ("C",),
+                "c": ("c",),
+                "d": ("d", "d"),
+            },
+            id="chars by occurrence",
+        ),
+    ),
+)
+def test_group_by_map(fn, iterable, expected):
+    assert expected == helpers.group_by_map(fn, iterable)

--- a/tests/test_interrupt.py
+++ b/tests/test_interrupt.py
@@ -74,9 +74,9 @@ def test_interrupt_blocked_jobs(test_dir):
         exp.start(model, ensemble, block=True, kill_on_interrupt=True)
 
     time.sleep(2)  # allow time for jobs to be stopped
-    active_jobs = exp._control._jobs.jobs
-    active_db_jobs = exp._control._jobs.db_jobs
-    completed_jobs = exp._control._jobs.completed
+    active_jobs = exp._control._job_manager.jobs
+    active_db_jobs = exp._control._job_manager.db_jobs
+    completed_jobs = exp._control._job_manager.completed
     assert len(active_jobs) + len(active_db_jobs) == 0
     assert len(completed_jobs) == num_jobs
 
@@ -119,8 +119,8 @@ def test_interrupt_multi_experiment_unblocked_jobs(test_dir):
 
     time.sleep(2)  # allow time for jobs to be stopped
     for i, experiment in enumerate(experiments):
-        active_jobs = experiment._control._jobs.jobs
-        active_db_jobs = experiment._control._jobs.db_jobs
-        completed_jobs = experiment._control._jobs.completed
+        active_jobs = experiment._control._job_manager.jobs
+        active_db_jobs = experiment._control._job_manager.db_jobs
+        completed_jobs = experiment._control._job_manager.completed
         assert len(active_jobs) + len(active_db_jobs) == 0
         assert len(completed_jobs) == jobs_per_experiment[i]

--- a/tests/test_multidb.py
+++ b/tests/test_multidb.py
@@ -483,7 +483,7 @@ def test_launch_cluster_orc_single_dbid(
     with make_entity_context(exp, orc), make_entity_context(exp, smartsim_model):
         exp.start(orc, block=True)
         exp.start(smartsim_model, block=True)
-        job_dict = exp._control._jobs.get_db_host_addresses()
+        job_dict = exp._control._job_manager.get_db_host_addresses()
         assert len(job_dict[orc.entities[0].db_identifier]) == 3
 
     check_not_failed(exp, orc, smartsim_model)

--- a/tests/test_reconnect_orchestrator.py
+++ b/tests/test_reconnect_orchestrator.py
@@ -58,7 +58,7 @@ def test_local_orchestrator(test_dir, wlmutils):
     assert [stat != SmartSimStatus.STATUS_FAILED for stat in statuses]
 
     # simulate user shutting down main thread
-    exp._control._jobs.actively_monitoring = False
+    exp._control._job_manager.actively_monitoring = False
     exp._control._launcher.task_manager.actively_monitoring = False
 
 

--- a/tests/test_telemetry_monitor.py
+++ b/tests/test_telemetry_monitor.py
@@ -1113,7 +1113,7 @@ def test_proxy_launch_cmd_decorator_errors_if_attempt_to_proxy_a_managed_step(
     mock_step, monkeypatch
 ):
     monkeypatch.setattr(cfg.Config, CFG_TM_ENABLED_ATTR, True)
-    mock_step.managed = True
+    type(mock_step).managed = property(lambda self: True)
     get_launch_cmd = proxyable_launch_cmd(lambda step: ["some", "cmd", "list"])
     with pytest.raises(UnproxyableStepError):
         get_launch_cmd(mock_step)


### PR DESCRIPTION
Prototype work to removes the responsibility of querying a job's status from the WLM from the job manager to the job itself. This allows for better decoupling for the controller and the JM.

## WARNING:
This work is strictly a prototype at this point in time and there is no guarantee that it will be incorporated into SmartSim. Expect this branch to be changed dramatically and rebased often. It is likely that not all of the tests will pass. Check out off of it at your own risk!