### PR TITLE
Avoid setting `task_id` on a managed step in telemetry monitor

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,7 @@ To be released at some future point in time
 
 Description
 
+- Fix telemetry monitor logging errrors for task history
 - Change default path for entities
 - Drop Python 3.8 support
 - Update watchdog dependency
@@ -41,6 +42,8 @@ Description
 
 Detailed Notes
 
+- Ensure the telemetry monitor does not track a task_id 
+  for a managed task. (SmartSim-PR557_)
 - The default path for an entity is now the path to the experiment / the
   entity name. create_database and create_ensemble now have path arguments.
   All path arguments are compatible with relative paths. Relative paths are
@@ -104,6 +107,7 @@ Detailed Notes
   handler. SmartSim will now attempt to kill any launched jobs before calling
   the previously registered signal handler. (SmartSim-PR535_)
 
+.. _SmartSim-PR557: https://github.com/CrayLabs/SmartSim/pull/557
 .. _SmartSim-PR533: https://github.com/CrayLabs/SmartSim/pull/533
 .. _SmartSim-PR544: https://github.com/CrayLabs/SmartSim/pull/544
 .. _SmartSim-PR540: https://github.com/CrayLabs/SmartSim/pull/540

--- a/smartsim/_core/utils/telemetry/telemetry.py
+++ b/smartsim/_core/utils/telemetry/telemetry.py
@@ -219,7 +219,7 @@ class ManifestEventHandler(PatternMatchingEventHandler):
                     # Tell the launcher it's managed so it doesn't attempt
                     # to look for a PID that may no longer exist
                     self._launcher.step_mapping.add(
-                        entity.name, entity.step_id, entity.task_id, True
+                        entity.name, entity.step_id, "", True
                     )
             self._tracked_runs[run.timestamp] = run
 

--- a/smartsim/_core/utils/telemetry/telemetry.py
+++ b/smartsim/_core/utils/telemetry/telemetry.py
@@ -212,7 +212,7 @@ class ManifestEventHandler(PatternMatchingEventHandler):
                     # status updates but does not try to start a new copy
                     self.job_manager.add_job(
                         entity.name,
-                        entity.task_id,
+                        entity.step_id,
                         entity,
                         False,
                     )


### PR DESCRIPTION
Ensures that a managed step-mapping doesn't include a `task_id`.

The telemetry monitor exhibits a defect where it logs errors from a task manager, even with only managed tasks being monitored for updates:

![image](https://github.com/CrayLabs/SmartSim/assets/3595025/84921e5b-144b-4fcd-8289-48d2504deaac)

This fix modifies the telemetry monitor to not set a `task_id` when adding items to the `step_mapping` collection. This avoids triggering lookups for unmanaged processes.

![image](https://github.com/CrayLabs/SmartSim/assets/3595025/dfc7cfad-a875-45b3-91d2-fa19407c9d0c)

