### PR TITLE
Fix failing and noisy WLM test

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -111,7 +111,7 @@ Detailed Notes
   directory creation. Ensure database are not left open on test suite failures.
   Update path to pickle file in
   ``tests/full_wlm/test_generic_orc_launch_batch.py::test_launch_cluster_orc_reconnect``
-  to conform with changes made in SmartSim-533_. (SmartSim-559_)
+  to conform with changes made in SmartSim-PR533_. (SmartSim-PR559_)
 - When calling ``Experiment.start`` SmartSim would register a signal handler
   that would capture an interrupt signal (^C) to kill any jobs launched through
   its ``JobManager``. This would replace the default (or user defined) signal

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -107,12 +107,18 @@ Detailed Notes
   undefined. (SmartSim-PR521_)
 - Remove previously deprecated behavior present in test suite on machines with
   Slurm and Open MPI. (SmartSim-PR520_)
+- Experiments in the WLM tests are given explicit paths to prevent unexpected
+  directory creation. Ensure database are not left open on test suite failures.
+  Update path to pickle file in
+  ``tests/full_wlm/test_generic_orc_launch_batch.py::test_launch_cluster_orc_reconnect``
+  to conform with changes made in SmartSim-533_. (SmartSim-559_)
 - When calling ``Experiment.start`` SmartSim would register a signal handler
   that would capture an interrupt signal (^C) to kill any jobs launched through
   its ``JobManager``. This would replace the default (or user defined) signal
   handler. SmartSim will now attempt to kill any launched jobs before calling
   the previously registered signal handler. (SmartSim-PR535_)
 
+.. _SmartSim-PR559: https://github.com/CrayLabs/SmartSim/pull/559
 .. _SmartSim-PR558: https://github.com/CrayLabs/SmartSim/pull/558
 .. _SmartSim-PR545: https://github.com/CrayLabs/SmartSim/pull/545
 .. _SmartSim-PR557: https://github.com/CrayLabs/SmartSim/pull/557

--- a/tests/full_wlm/test_generic_orc_launch_batch.py
+++ b/tests/full_wlm/test_generic_orc_launch_batch.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os.path as osp
+import pathlib
 import time
 
 import pytest
@@ -147,9 +148,12 @@ def test_launch_cluster_orc_batch_multi(test_dir, wlmutils):
 
 def test_launch_cluster_orc_reconnect(test_dir, wlmutils):
     """test reconnecting to clustered 3-node orchestrator"""
+    p_test_dir = pathlib.Path(test_dir)
     launcher = wlmutils.get_test_launcher()
     exp_name = "test-launch-cluster-orc-batch-reconect"
-    exp = Experiment(exp_name, launcher=launcher, exp_path=test_dir)
+    exp_1_dir = p_test_dir / exp_name
+    exp_1_dir.mkdir()
+    exp = Experiment(exp_name, launcher=launcher, exp_path=str(exp_1_dir))
 
     # batch = False to launch on existing allocation
     network_interface = wlmutils.get_test_interface()
@@ -164,26 +168,47 @@ def test_launch_cluster_orc_reconnect(test_dir, wlmutils):
     exp.start(orc, block=True)
 
     statuses = exp.get_status(orc)
-    # don't use assert so that orc we don't leave an orphan process
-    if SmartSimStatus.STATUS_FAILED in statuses:
+    try:
+        assert all(stat == SmartSimStatus.STATUS_RUNNING for stat in statuses)
+    except Exception:
         exp.stop(orc)
-        assert False
-
-    exp.stop(orc)
+        raise
 
     exp_name = "test-orc-cluster-orc-batch-reconnect-2nd"
-    exp_2 = Experiment(exp_name, launcher=launcher)
+    exp_2_dir = p_test_dir / exp_name
+    exp_2_dir.mkdir()
+    exp_2 = Experiment(exp_name, launcher=launcher, exp_path=str(exp_2_dir))
 
-    checkpoint = osp.join(test_dir, "smartsim_db.dat")
-    reloaded_orc = exp_2.reconnect_orchestrator(checkpoint)
+    try:
+        checkpoint = osp.join(orc.path, "smartsim_db.dat")
+        reloaded_orc = exp_2.reconnect_orchestrator(checkpoint)
 
-    # let statuses update once
-    time.sleep(5)
+        # let statuses update once
+        time.sleep(5)
 
-    statuses = exp_2.get_status(reloaded_orc)
-    for stat in statuses:
-        if stat == SmartSimStatus.STATUS_FAILED:
-            exp_2.stop(reloaded_orc)
-            assert False
+        statuses = exp_2.get_status(reloaded_orc)
+        assert all(stat == SmartSimStatus.STATUS_RUNNING for stat in statuses)
+    except Exception:
+        # Something went wrong! Let the experiment that started the DB
+        # clean up the DB
+        exp.stop(orc)
+        raise
 
-    exp_2.stop(reloaded_orc)
+    try:
+        # Test experiment 2 can stop the DB
+        exp_2.stop(reloaded_orc)
+        assert all(
+            stat == SmartSimStatus.STATUS_CANCELLED
+            for stat in exp_2.get_status(reloaded_orc)
+        )
+    except Exception:
+        # Something went wrong! Let the experiment that started the DB
+        # clean up the DB
+        exp.stop(orc)
+        raise
+    else:
+        # Ensure  it is the same DB that Experiment 1 was tracking
+        time.sleep(5)
+        assert not any(
+            stat == SmartSimStatus.STATUS_RUNNING for stat in exp.get_status(orc)
+        )

--- a/tests/on_wlm/test_het_job.py
+++ b/tests/on_wlm/test_het_job.py
@@ -34,10 +34,10 @@ if pytest.test_launcher != "slurm":
     pytestmark = pytest.mark.skip(reason="Test is only for Slurm WLM systems")
 
 
-def test_mpmd_errors(monkeypatch):
+def test_mpmd_errors(monkeypatch, test_dir):
     monkeypatch.setenv("SLURM_HET_SIZE", "1")
     exp_name = "test-het-job-errors"
-    exp = Experiment(exp_name, launcher="slurm")
+    exp = Experiment(exp_name, exp_path=test_dir, launcher="slurm")
     rs: SrunSettings = exp.create_run_settings("sleep", "1", run_command="srun")
     rs2: SrunSettings = exp.create_run_settings("sleep", "1", run_command="srun")
     with pytest.raises(ValueError):
@@ -49,11 +49,11 @@ def test_mpmd_errors(monkeypatch):
         rs.set_het_group(1)
 
 
-def test_set_het_groups(monkeypatch):
+def test_set_het_groups(monkeypatch, test_dir):
     """Test ability to set one or more het groups to run setting"""
     monkeypatch.setenv("SLURM_HET_SIZE", "4")
     exp_name = "test-set-het-group"
-    exp = Experiment(exp_name, launcher="slurm")
+    exp = Experiment(exp_name, exp_path=test_dir, launcher="slurm")
     rs: SrunSettings = exp.create_run_settings("sleep", "1", run_command="srun")
     rs.set_het_group([1])
     assert rs.run_args["het-group"] == "1"
@@ -63,11 +63,11 @@ def test_set_het_groups(monkeypatch):
         rs.set_het_group([4])
 
 
-def test_orch_single_cmd(monkeypatch, wlmutils):
+def test_orch_single_cmd(monkeypatch, wlmutils, test_dir):
     """Test that single cmd is rejected in a heterogeneous job"""
     monkeypatch.setenv("SLURM_HET_SIZE", "1")
     exp_name = "test-orch-single-cmd"
-    exp = Experiment(exp_name, launcher="slurm")
+    exp = Experiment(exp_name, exp_path=test_dir, launcher="slurm")
     orc = exp.create_database(
         wlmutils.get_test_port(),
         db_nodes=3,


### PR DESCRIPTION
Fixes:
- `tests/backends/test_onnx.py::test_sklearn_onnx`
  - Correctly set number of tasks when not using the local launcher
  - Makes sure the DB is not left running on test failure
- `tests/full_wlm/test_generic_orc_launch_batch.py::test_launch_cluster_orc_reconnect`
  - Look for pickle file under the orchestrator path rather than the test dir
  - Makes sure that DB is cleaned up correctly on test failure

Quiets:
- `tests/on_wlm/test_het_job.py`
  - All experiments under the test module are given an explict test path