### PR TITLE
Remove defensive regexp in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,5 @@ smartsim/_core/bin/*-cli
 # created upon install
 smartsim/_core/lib
 
-**/manifest/
-**/*.err
-**/*.out
-**/.smartsim/*
-
 # optional dev tools
 .pre-commit-config.yaml

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,7 @@ To be released at some future point in time
 
 Description
 
+- Remove defensive regexp in .gitignore
 - Upgrade ubuntu to 22.04
 - Remove helper function ``init_default``
 - Fix telemetry monitor logging errrors for task history
@@ -44,6 +45,8 @@ Description
 
 Detailed Notes
 
+- Remove defensive regexp in .gitignore and ensure tests write to test_output.
+  (SmartSim-PR560_)
 - After dropping support for Python 3.8, ubuntu needs to be upgraded.
   (SmartSim-PR558_)
 - Remove helper function ``init_default`` and replace with traditional type
@@ -113,6 +116,7 @@ Detailed Notes
   handler. SmartSim will now attempt to kill any launched jobs before calling
   the previously registered signal handler. (SmartSim-PR535_)
 
+.. _SmartSim-PR560: https://github.com/CrayLabs/SmartSim/pull/560
 .. _SmartSim-PR558: https://github.com/CrayLabs/SmartSim/pull/558
 .. _SmartSim-PR545: https://github.com/CrayLabs/SmartSim/pull/545
 .. _SmartSim-PR557: https://github.com/CrayLabs/SmartSim/pull/557

--- a/tests/on_wlm/test_het_job.py
+++ b/tests/on_wlm/test_het_job.py
@@ -63,11 +63,11 @@ def test_set_het_groups(monkeypatch):
         rs.set_het_group([4])
 
 
-def test_orch_single_cmd(monkeypatch, wlmutils):
+def test_orch_single_cmd(monkeypatch, wlmutils, test_dir):
     """Test that single cmd is rejected in a heterogeneous job"""
     monkeypatch.setenv("SLURM_HET_SIZE", "1")
     exp_name = "test-orch-single-cmd"
-    exp = Experiment(exp_name, launcher="slurm")
+    exp = Experiment(exp_name, launcher="slurm", exp_path=test_dir)
     orc = exp.create_database(
         wlmutils.get_test_port(),
         db_nodes=3,

--- a/tests/test_launch_errors.py
+++ b/tests/test_launch_errors.py
@@ -37,9 +37,9 @@ from smartsim.status import SmartSimStatus
 pytestmark = pytest.mark.group_a
 
 
-def test_unsupported_run_settings():
+def test_unsupported_run_settings(test_dir):
     exp_name = "test-unsupported-run-settings"
-    exp = Experiment(exp_name, launcher="slurm")
+    exp = Experiment(exp_name, launcher="slurm", exp_path=test_dir)
     bad_settings = JsrunSettings("echo", "hello")
     model = exp.create_model("bad_rs", bad_settings)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -116,8 +116,10 @@ def monkeypatch_exp_controller(monkeypatch):
     return _monkeypatch_exp_controller
 
 
-def test_model_with_batch_settings_makes_batch_step(monkeypatch_exp_controller):
-    exp = Experiment("experiment", launcher="slurm")
+def test_model_with_batch_settings_makes_batch_step(
+    monkeypatch_exp_controller, test_dir
+):
+    exp = Experiment("experiment", launcher="slurm", exp_path=test_dir)
     bs = SbatchSettings()
     rs = SrunSettings("python", exe_args="sleep.py")
     model = exp.create_model("test_model", run_settings=rs, batch_settings=bs)
@@ -132,9 +134,9 @@ def test_model_with_batch_settings_makes_batch_step(monkeypatch_exp_controller):
 
 
 def test_model_without_batch_settings_makes_run_step(
-    monkeypatch, monkeypatch_exp_controller
+    monkeypatch, monkeypatch_exp_controller, test_dir
 ):
-    exp = Experiment("experiment", launcher="slurm")
+    exp = Experiment("experiment", launcher="slurm", exp_path=test_dir)
     rs = SrunSettings("python", exe_args="sleep.py")
     model = exp.create_model("test_model", run_settings=rs)
 
@@ -150,8 +152,10 @@ def test_model_without_batch_settings_makes_run_step(
     assert isinstance(step, SrunStep)
 
 
-def test_models_batch_settings_are_ignored_in_ensemble(monkeypatch_exp_controller):
-    exp = Experiment("experiment", launcher="slurm")
+def test_models_batch_settings_are_ignored_in_ensemble(
+    monkeypatch_exp_controller, test_dir
+):
+    exp = Experiment("experiment", launcher="slurm", exp_path=test_dir)
     bs_1 = SbatchSettings(nodes=5)
     rs = SrunSettings("python", exe_args="sleep.py")
     model = exp.create_model("test_model", run_settings=rs, batch_settings=bs_1)


### PR DESCRIPTION
In this PR I removed the defensive regexp in `.gitignore` and added `test_dir` to the tests that were writing to the `cwd` instead of the `test_output` directory.