### PR TITLE
Use relative paths with specific loader config

### DIFF
--- a/smartsim/_core/control/previewrenderer.py
+++ b/smartsim/_core/control/previewrenderer.py
@@ -132,7 +132,9 @@ def render(
 
     _check_output_format(output_format)
 
-    loader = jinja2.PackageLoader("smartsim.templates")
+    loader = jinja2.PackageLoader(
+        "smartsim.templates.templates.preview", output_format.value
+    )
     env = jinja2.Environment(loader=loader, autoescape=True)
 
     env.filters["as_toggle"] = as_toggle
@@ -141,7 +143,7 @@ def render(
     env.filters["is_list"] = is_list
     env.globals["Verbosity"] = Verbosity
 
-    tpl_path = f"preview/{output_format.value}/base.template"
+    tpl_path = "base.template"
 
     tpl = env.get_template(tpl_path)
 

--- a/smartsim/templates/templates/preview/plain_text/base.template
+++ b/smartsim/templates/templates/preview/plain_text/base.template
@@ -1,5 +1,5 @@
 
-{% include "preview/plain_text/experiment.template" %}
+{% include "experiment.template" %}
 {%- if manifest.has_deployable or active_dbjobs %}
 
 === Entity Preview ===
@@ -8,7 +8,7 @@
 
   == Active Infrastructure ==
   {%- for name, db in active_dbjobs.items() %}
-      {% include "preview/plain_text/activeinfra.template" %}
+      {% include "activeinfra.template" %}
   {%- endfor %}
   {%- endif %}
   {%- if manifest.dbs %}
@@ -18,7 +18,7 @@
     {%- if db.is_active() %}
     WARNING: Cannot preview {{ db.name }}, because it is already started.
     {%- else %}
-        {% include "preview/plain_text/orchestrator.template" %}
+        {% include "orchestrator.template" %}
     {%- endif %}
     {%- endfor %}
   {%- endif %}
@@ -28,14 +28,14 @@
     {%- for model in manifest.models %}
 
     = Model Name: {{ model.name }} =
-    {%- include "preview/plain_text/model.template" %}
+    {%- include "model.template" %}
       {%- if model.run_settings.colocated_db_settings or manifest.dbs %}
         Client Configuration:
         {%- if model.run_settings.colocated_db_settings %}
-        {%- include "preview/plain_text/clientconfigcolo.template" %}
+        {%- include "clientconfigcolo.template" %}
         {%- endif %}
         {%- if manifest.dbs %}
-        {%- include "preview/plain_text/clientconfig.template" %}
+        {%- include "clientconfig.template" %}
         {%- endif %}
         {%- endif %}
       {%- endfor %}
@@ -45,7 +45,7 @@
 
   == Ensembles ==
     {%- for ensemble in manifest.ensembles %}
-    {%- include "preview/plain_text/ensemble.template" %}
+    {%- include "ensemble.template" %}
     {%- endfor %}
     {%- endif %}
 

--- a/smartsim/templates/templates/preview/plain_text/clientconfig.template
+++ b/smartsim/templates/templates/preview/plain_text/clientconfig.template
@@ -1,7 +1,7 @@
 
 {%- if verbosity_level == Verbosity.INFO %}
-{%- include "preview/plain_text/clientconfig_info.template" -%}
+{%- include "clientconfig_info.template" -%}
 {%- endif %}
 {%- if verbosity_level == Verbosity.DEBUG or verbosity_level == Verbosity.DEVELOPER %}
-{%- include "preview/plain_text/clientconfig_debug.template" -%}
+{%- include "clientconfig_debug.template" -%}
 {%- endif %}

--- a/smartsim/templates/templates/preview/plain_text/clientconfigcolo.template
+++ b/smartsim/templates/templates/preview/plain_text/clientconfigcolo.template
@@ -1,7 +1,7 @@
 
 {%- if verbosity_level == Verbosity.INFO %}
-{%- include "preview/plain_text/clientconfigcolo_info.template" %}
+{%- include "clientconfigcolo_info.template" %}
 {% endif %}
 {%- if verbosity_level == Verbosity.DEBUG or verbosity_level == Verbosity.DEVELOPER %}
-{%- include "preview/plain_text/clientconfigcolo_debug.template" %}
+{%- include "clientconfigcolo_debug.template" %}
 {%- endif %}

--- a/smartsim/templates/templates/preview/plain_text/ensemble.template
+++ b/smartsim/templates/templates/preview/plain_text/ensemble.template
@@ -1,7 +1,7 @@
 
 {%- if verbosity_level == Verbosity.INFO %}
-{%- include "preview/plain_text/ensemble_info.template" -%}
+{%- include "ensemble_info.template" -%}
 {%- endif %}
 {%- if verbosity_level == Verbosity.DEBUG or verbosity_level == Verbosity.DEVELOPER %}
-{%- include "preview/plain_text/ensemble_debug.template" -%}
+{%- include "ensemble_debug.template" -%}
 {%- endif %}

--- a/smartsim/templates/templates/preview/plain_text/ensemble_debug.template
+++ b/smartsim/templates/templates/preview/plain_text/ensemble_debug.template
@@ -31,14 +31,14 @@
     {%- for model in ensemble.entities %}
 
     - Model Name: {{ model.name }} -
-    {%- include 'preview/plain_text/model.template' %}
+    {%- include 'model.template' %}
         {%- if model.run_settings.colocated_db_settings or manifest.dbs %}
         Client Configuration:
             {%- if model.run_settings.colocated_db_settings %}
-            {%- include "preview/plain_text/clientconfigcolo.template" %}
+            {%- include "clientconfigcolo.template" %}
             {%- endif %}
             {%- if manifest.dbs %}
-            {%- include "preview/plain_text/clientconfig.template" %}
+            {%- include "clientconfig.template" %}
             {%- endif %}
     {%- endif %}
     {%- endfor %}
@@ -47,14 +47,14 @@
     {%- for model in ensemble.entities %}
 
     - Model Name: {{ model.name }} -
-        {%- include 'preview/plain_text/model_debug.template' %}
+        {%- include 'model_debug.template' %}
         {%- if model.run_settings.colocated_db_settings or manifest.dbs %}
         Client Configuration:
             {%- if model.run_settings.colocated_db_settings %}
-            {%- include "preview/plain_text/clientconfigcolo.template" %}
+            {%- include "clientconfigcolo.template" %}
             {%- endif %}
             {%- if manifest.dbs %}
-            {%- include "preview/plain_text/clientconfig.template" %}
+            {%- include "clientconfig.template" %}
             {%- endif %}
         {%- endif %}
 {%- endfor %}

--- a/smartsim/templates/templates/preview/plain_text/ensemble_info.template
+++ b/smartsim/templates/templates/preview/plain_text/ensemble_info.template
@@ -11,40 +11,40 @@
     {%- if ensemble.models | length > 2 %}
     {% set model = ensemble.models[0] %}
     - Model Name: {{ model.name }} -
-        {%- include 'preview/plain_text/model.template' %}
+        {%- include 'model.template' %}
         {%- if model.run_settings.colocated_db_settings or manifest.dbs %}
         Client Configuration:
             {%- if model.run_settings.colocated_db_settings %}
-            {%- include "preview/plain_text/clientconfigcolo.template" %}
+            {%- include "clientconfigcolo.template" %}
             {%- endif %}
             {%- if manifest.dbs %}
-            {%- include "preview/plain_text/clientconfig.template" %}
+            {%- include "clientconfig.template" %}
             {%- endif %}
             {%- endif %}
         ...
         {% set model = ensemble.models[(ensemble.models | length)-1] %}
     - Model Name: {{ model.name }} -
-        {%- include 'preview/plain_text/model.template' %}
+        {%- include 'model.template' %}
             {% if model.run_settings.colocated_db_settings or manifest.dbs %}
         Client Configuration:
             {%- if model.run_settings.colocated_db_settings %}
-            {%- include "preview/plain_text/clientconfigcolo.template" %}
+            {%- include "clientconfigcolo.template" %}
             {%- endif %}
             {%- if manifest.dbs %}
-            {%- include "preview/plain_text/clientconfig.template" %}
+            {%- include "clientconfig.template" %}
             {%- endif %}
             {%- endif %}
         {%- else %}
     {% for model in ensemble %}
     - Model Name: {{ model.name }} -
-        {%- include 'preview/plain_text/model.template' %}
+        {%- include 'model.template' %}
         {% if model.run_settings.colocated_db_settings or manifest.dbs %}
         Client Configuration:
               {%- if model.run_settings.colocated_db_settings %}
-                {%- include "preview/plain_text/clientconfigcolo.template" %}
+                {%- include "clientconfigcolo.template" %}
             {%- endif %}
             {%- if manifest.dbs %}
-            {%- include "preview/plain_text/clientconfig.template" %}
+            {%- include "clientconfig.template" %}
             {%- endif %}
             {%- endif %}
         {% endfor %}

--- a/smartsim/templates/templates/preview/plain_text/model.template
+++ b/smartsim/templates/templates/preview/plain_text/model.template
@@ -1,7 +1,7 @@
 
 {%- if verbosity_level == Verbosity.INFO %}
-{%- include "preview/plain_text/model_info.template" -%}
+{%- include "model_info.template" -%}
 {%- endif %}
 {%- if verbosity_level == Verbosity.DEBUG or verbosity_level == Verbosity.DEVELOPER %}
-{%- include "preview/plain_text/model_debug.template" -%}
+{%- include "model_debug.template" -%}
 {%- endif -%}

--- a/smartsim/templates/templates/preview/plain_text/orchestrator.template
+++ b/smartsim/templates/templates/preview/plain_text/orchestrator.template
@@ -1,7 +1,7 @@
 
 {%- if verbosity_level == Verbosity.INFO %}
-{%- include "preview/plain_text/orchestrator_info.template" -%}
+{%- include "orchestrator_info.template" -%}
 {%- endif %}
 {%- if verbosity_level == Verbosity.DEBUG or verbosity_level == Verbosity.DEVELOPER %}
-{%- include "preview/plain_text/orchestrator_debug.template" -%}
+{%- include "orchestrator_debug.template" -%}
 {%- endif %}


### PR DESCRIPTION
Avoid detailed paths in templates by configuring the template loader to use output format