### PR TITLE
Fix build error caused by use of deprecated pkg_resources

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,6 +9,18 @@ Jump to:
 
 ## SmartSim
 
+### Development branch
+
+To be released at some future point in time
+
+Description
+
+- Update packaging dependency
+
+Detailed Notes
+
+- Fix packaging failures due to deprecated `pkg_resources`. ([SmartSim-PR598](https://github.com/CrayLabs/SmartSim/pull/598))
+
 ### 0.7.0
 
 Released on 14 May, 2024

--- a/doc/installation_instructions/platform/olcf-summit.rst
+++ b/doc/installation_instructions/platform/olcf-summit.rst
@@ -6,10 +6,10 @@ Since SmartSim does not have a built PowerPC build, the build steps for an IBM
 system are slightly different than other systems.
 
 Luckily for us, a conda channel with all relevant packages is maintained as part
-of the `OpenCE <https://opence.mit.edu>`_ initiative.  Users can follow these
-instructions to get a working SmartSim build with PyTorch and TensorFlow for GPU
-on Summit.  Note that SmartSim and SmartRedis will be downloaded to the working
-directory from which these instructions are executed.
+of the `OpenCE <https://www.olcf.ornl.gov/wp-content/uploads/2020/09/open-ce.pdf>`_
+initiative.  Users can follow these instructions to get a working SmartSim build
+with PyTorch and TensorFlow for GPU on Summit.  Note that SmartSim and SmartRedis
+will be downloaded to the working directory from which these instructions are executed.
 
 Note that the available PyTorch version (1.10.2) does not match
 the one expected by RedisAI 1.2.7 (1.11): it is still compatible and should

--- a/doc/installation_instructions/platform/olcf-summit.rst
+++ b/doc/installation_instructions/platform/olcf-summit.rst
@@ -6,7 +6,7 @@ Since SmartSim does not have a built PowerPC build, the build steps for an IBM
 system are slightly different than other systems.
 
 Luckily for us, a conda channel with all relevant packages is maintained as part
-of the `OpenCE <https://www.olcf.ornl.gov/wp-content/uploads/2020/09/open-ce.pdf>`_
+of the `OpenCE <https://github.com/open-ce/open-ce>`_
 initiative.  Users can follow these instructions to get a working SmartSim build
 with PyTorch and TensorFlow for GPU on Summit.  Note that SmartSim and SmartRedis
 will be downloaded to the working directory from which these instructions are executed.

--- a/doc/tutorials/ml_training/surrogate/train_surrogate.ipynb
+++ b/doc/tutorials/ml_training/surrogate/train_surrogate.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "The problem can be solved using a finite difference scheme. To this end, a modified version of the code\n",
     "written by John Burkardt will be used. Its original version is licensed under LGPL, and so is this example.\n",
-    "The code was downloaded from [this page](https://people.sc.fsu.edu/~jburkardt/py_src/fd2d_heat_steady/fd2d_heat_steady.html),\n",
+    "The code was downloaded from [this page](https://github.com/johannesgerer/jburkardt-m/tree/master/fd2d_heat_steady),\n",
     "which explains how the problem is discretized and solved.\n",
     "\n",
     "In the modified version of the code which will be used, a random number (between 1 and 5) of heat sources is placed.\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@
 
 
 [build-system]
-requires = ["setuptools", "wheel", "cmake>=3.13"]
+requires = ["packaging>=24.0", "setuptools>=70.0", "wheel", "cmake>=3.13"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,10 +51,6 @@ classifiers =
 
 [options]
 packages = find:
-setup_requires =
-    packaging>=24.0
-    setuptools>=70.0
-    cmake>=3.13
 include_package_data = True
 python_requires = >=3.9,<3.12
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,8 @@ classifiers =
 [options]
 packages = find:
 setup_requires =
-    setuptools>=39.2
+    packaging>=24.0
+    setuptools>=70.0
     cmake>=3.13
 include_package_data = True
 python_requires = >=3.9,<3.12

--- a/setup.py
+++ b/setup.py
@@ -185,6 +185,7 @@ deps.append("smartredis>={}".format(versions.SMARTREDIS))
 
 extras_require = {
     "dev": [
+        "packaging>=24.0",
         "black==24.1a1",
         "isort>=5.6.4",
         "pylint>=2.10.0,<3",

--- a/setup.py
+++ b/setup.py
@@ -166,6 +166,7 @@ class BinaryDistribution(Distribution):
 
 # Define needed dependencies for the installation
 deps = [
+    "packaging>=24.0",
     "psutil>=5.7.2",
     "coloredlogs>=10.0",
     "tabulate>=0.8.9",
@@ -185,7 +186,6 @@ deps.append("smartredis>={}".format(versions.SMARTREDIS))
 
 extras_require = {
     "dev": [
-        "packaging>=24.0",
         "black==24.1a1",
         "isort>=5.6.4",
         "pylint>=2.10.0,<3",

--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -47,13 +47,10 @@ from typing import Iterable
 # https://setuptools.pypa.io/en/latest/pkg_resources.html
 
 # isort: off
-import pkg_resources
-from pkg_resources import packaging  # type: ignore
+from packaging.version import Version, InvalidVersion, parse
 
 # isort: on
 
-Version = packaging.version.Version
-InvalidVersion = packaging.version.InvalidVersion
 DbEngine = t.Literal["REDIS", "KEYDB"]
 
 
@@ -105,9 +102,7 @@ class Version_(str):
 
     @staticmethod
     def _convert_to_version(
-        vers: t.Union[
-            str, Iterable[packaging.version.Version], packaging.version.Version
-        ],
+        vers: t.Union[str, Iterable[Version], Version],
     ) -> t.Any:
         if isinstance(vers, Version):
             return vers
@@ -122,20 +117,20 @@ class Version_(str):
     def major(self) -> int:
         # Version(self).major doesn't work for all Python distributions
         # see https://github.com/lebedov/python-pdfbox/issues/28
-        return int(pkg_resources.parse_version(self).base_version.split(".")[0])
+        return int(parse(self).base_version.split(".", maxsplit=1)[0])
 
     @property
     def minor(self) -> int:
-        return int(pkg_resources.parse_version(self).base_version.split(".")[1])
+        return int(parse(self).base_version.split(".", maxsplit=2)[1])
 
     @property
     def micro(self) -> int:
-        return int(pkg_resources.parse_version(self).base_version.split(".")[2])
+        return int(parse(self).base_version.split(".", maxsplit=3)[2])
 
     @property
     def patch(self) -> str:
         # return micro with string modifier i.e. 1.2.3+cpu -> 3+cpu
-        return str(pkg_resources.parse_version(self)).split(".")[2]
+        return str(parse(self)).split(".")[2]
 
     def __gt__(self, cmp: t.Any) -> bool:
         try:

--- a/smartsim/_core/_install/buildenv.py
+++ b/smartsim/_core/_install/buildenv.py
@@ -35,21 +35,7 @@ import typing as t
 from pathlib import Path
 from typing import Iterable
 
-# NOTE: This will be imported by setup.py and hence no
-#       smartsim related items or non-standand library
-#       items should be imported here.
-
-# TODO: pkg_resources has been deprecated by PyPA. Currently we use it for its
-#       packaging implementation, as we cannot assume a user will have `packaging`
-#       prior to `pip install` time. We really only use pkg_resources for their
-#       vendored version of `packaging.version.Version` so we should probably try
-#       to remove
-# https://setuptools.pypa.io/en/latest/pkg_resources.html
-
-# isort: off
-from packaging.version import Version, InvalidVersion, parse
-
-# isort: on
+from packaging.version import InvalidVersion, Version, parse
 
 DbEngine = t.Literal["REDIS", "KEYDB"]
 

--- a/tests/install/test_buildenv.py
+++ b/tests/install/test_buildenv.py
@@ -25,10 +25,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+import packaging
 import pytest
 
-# from pkg_resources import packaging  # type: ignore
-import packaging
 from smartsim._core._install.buildenv import Version_
 
 # The tests in this file belong to the group_a group

--- a/tests/install/test_buildenv.py
+++ b/tests/install/test_buildenv.py
@@ -26,8 +26,8 @@
 
 
 import pytest
-from pkg_resources import packaging  # type: ignore
-
+# from pkg_resources import packaging  # type: ignore
+import packaging
 from smartsim._core._install.buildenv import Version_
 
 # The tests in this file belong to the group_a group
@@ -71,19 +71,32 @@ def test_version_equality_ne():
 
     assert v1 != v2
 
-
-def test_version_bad_input():
+    # def test_version_bad_input():
     """Test behavior when passing an invalid version string"""
-    v1 = Version_("abcdefg")
+    version = Version_("1")
+    assert version.major == 1
+    with pytest.raises((IndexError, packaging.version.InvalidVersion)) as ex:
+        version.minor
 
-    # todo: fix behavior to ensure versions are valid.
-    assert v1
+    version = Version_("2.")
+    with pytest.raises((IndexError, packaging.version.InvalidVersion)) as ex:
+        version.major
+
+    version = Version_("3.0.")
+    
+    with pytest.raises((IndexError, packaging.version.InvalidVersion)) as ex:
+        version.major
+
+    version = Version_("3.1.a")
+    assert version.major == 3
+    assert version.minor == 1
+    with pytest.raises((IndexError, packaging.version.InvalidVersion)) as ex:
+        version.patch
 
 
 def test_version_bad_parse_fail():
     """Test behavior when trying to parse with an invalid input string"""
-    v1 = Version_("abcdefg")
-
     # todo: ensure we can't take invalid input and have this IndexError occur.
     with pytest.raises((IndexError, packaging.version.InvalidVersion)) as ex:
-        _ = v1.minor
+        version = Version_("abcdefg")
+        version.minor

--- a/tests/install/test_buildenv.py
+++ b/tests/install/test_buildenv.py
@@ -26,6 +26,7 @@
 
 
 import pytest
+
 # from pkg_resources import packaging  # type: ignore
 import packaging
 from smartsim._core._install.buildenv import Version_
@@ -83,7 +84,7 @@ def test_version_equality_ne():
         version.major
 
     version = Version_("3.0.")
-    
+
     with pytest.raises((IndexError, packaging.version.InvalidVersion)) as ex:
         version.major
 
@@ -97,6 +98,6 @@ def test_version_equality_ne():
 def test_version_bad_parse_fail():
     """Test behavior when trying to parse with an invalid input string"""
     # todo: ensure we can't take invalid input and have this IndexError occur.
+    version = Version_("abcdefg")
     with pytest.raises((IndexError, packaging.version.InvalidVersion)) as ex:
-        version = Version_("abcdefg")
-        version.minor
+        version.major


### PR DESCRIPTION
Fixes a build error encountered after the latest update of `setuptools`.

### Additional Included Changes

- Fixed non-working links causing documentation build to fail validation