### PR TITLE
Fix util-tests outputs appearing in root directory

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -15,11 +15,13 @@ To be released at some future point in time
 
 Description
 
+- Fix tests outputs in incorrect directory
 - Improve support for building SmartSim without ML backends
 - Update packaging dependency
 
 Detailed Notes
 
+- Ensure ouputs from tests are written to temporary `tests/test_output` directory
 - Fix an error that would prevent ``smart build`` from moving a successfully
   compiled RedisAI shared object to the install location expected by SmartSim
   if no ML backend installations were found. Previously, this would effectively

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -15,7 +15,7 @@ To be released at some future point in time
 
 Description
 
-- Fix tests outputs in incorrect directory
+- Fix test outputs being created in incorrect directory
 - Improve support for building SmartSim without ML backends
 - Update packaging dependency
 


### PR DESCRIPTION
Fix unit tests that omit an experiment path and write to the root directory of the project.

## Secondary Changes

- Added typehints to enable successfully passing `mypy test_manifest.py`
- Refactored test using global variables in pytest parameterization to use a fixture
