### PR TITLE
Remove device attribute from schemas

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -15,6 +15,7 @@ Description
 
 - Added schemas and MessageHandler class for de/serialization of
   inference requests and response messages
+- Removed device from schemas, Messagehandler and tests
 
 
 ### Development branch

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -16,7 +16,7 @@ Description
 - Add ML worker manager, sample worker, and feature store
 - Added schemas and MessageHandler class for de/serialization of
   inference requests and response messages
-- Removed device from schemas, Messagehandler and tests
+- Removed device from schemas, MessageHandler and tests
 
 
 ### Development branch

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -64,7 +64,6 @@ def deserialize_message(
 
     request = MessageHandler.deserialize_request(data_blob)
     # return request
-    device = request.device
     model_key: t.Optional[str] = None
     model_bytes: t.Optional[bytes] = None
 
@@ -106,7 +105,6 @@ def deserialize_message(
         input_keys=input_keys,
         raw_model=model_bytes,
         batch_size=0,
-        device=device,
     )
     return inference_request
 

--- a/smartsim/_core/mli/infrastructure/worker/worker.py
+++ b/smartsim/_core/mli/infrastructure/worker/worker.py
@@ -50,7 +50,6 @@ class InferenceRequest:
         output_keys: t.Optional[t.List[str]] = None,
         raw_model: t.Optional[bytes] = None,
         batch_size: int = 0,
-        device: t.Optional[str] = None,
     ):
         """Initialize the object"""
         self.model_key = model_key
@@ -61,7 +60,6 @@ class InferenceRequest:
         self.input_meta = input_meta or []
         self.output_keys = output_keys or []
         self.batch_size = batch_size
-        self.device = device
 
 
 class InferenceReply:

--- a/smartsim/_core/mli/message_handler.py
+++ b/smartsim/_core/mli/message_handler.py
@@ -221,22 +221,6 @@ class MessageHandler:
             raise ValueError("Error building reply channel portion of request.") from e
 
     @staticmethod
-    def _assign_device(
-        request: request_capnp.Request, device: "request_capnp.Device"
-    ) -> None:
-        """
-        Assigns a device to the supplied request.
-
-        :param request: Request being built
-        :param device: Device to be assigned
-        :raises ValueError: if building fails
-        """
-        try:
-            request.device = device
-        except Exception as e:
-            raise ValueError("Error building device portion of request.") from e
-
-    @staticmethod
     def _assign_inputs(
         request: request_capnp.Request,
         inputs: t.Union[
@@ -342,7 +326,6 @@ class MessageHandler:
     def build_request(
         reply_channel: t.ByteString,
         model: t.Union[data_references_capnp.ModelKey, t.ByteString],
-        device: "request_capnp.Device",
         inputs: t.Union[
             t.List[data_references_capnp.TensorKey], t.List[tensor_capnp.Tensor]
         ],
@@ -359,7 +342,6 @@ class MessageHandler:
 
         :param reply_channel: Reply channel to be assigned to request
         :param model: Model to be assigned to request
-        :param device: Device to be assigned to request
         :param inputs: Inputs to be assigned to request
         :param outputs: Outputs to be assigned to request
         :param output_descriptors: Output descriptors to be assigned to request
@@ -368,7 +350,6 @@ class MessageHandler:
         request = request_capnp.Request.new_message()
         MessageHandler._assign_reply_channel(request, reply_channel)
         MessageHandler._assign_model(request, model)
-        MessageHandler._assign_device(request, device)
         MessageHandler._assign_inputs(request, inputs)
         MessageHandler._assign_outputs(request, outputs)
         MessageHandler._assign_output_descriptors(request, output_descriptors)

--- a/smartsim/_core/mli/mli_schemas/request/request.capnp
+++ b/smartsim/_core/mli/mli_schemas/request/request.capnp
@@ -30,12 +30,6 @@ using Tensors = import "../tensor/tensor.capnp";
 using RequestAttributes = import "request_attributes/request_attributes.capnp";
 using DataRef = import "../data/data_references.capnp";
 
-enum Device {
-  cpu @0;
-  gpu @1;
-  auto @2;
-}
-
 struct ChannelDescriptor {
   reply @0 :Data;
 }
@@ -46,16 +40,15 @@ struct Request {
     modelKey @1 :DataRef.ModelKey;
     modelData @2 :Data;
   }
-  device @3 :Device;
   input :union {
-    inputKeys @4 :List(DataRef.TensorKey);
-    inputData @5 :List(Tensors.Tensor);
+    inputKeys @3 :List(DataRef.TensorKey);
+    inputData @4 :List(Tensors.Tensor);
   }
-  output @6 :List(DataRef.TensorKey);
-  outputDescriptors @7 :List(Tensors.OutputDescriptor);
+  output @5 :List(DataRef.TensorKey);
+  outputDescriptors @6 :List(Tensors.OutputDescriptor);
   customAttributes :union {
-    torch @8 :RequestAttributes.TorchRequestAttributes;
-    tf @9 :RequestAttributes.TensorFlowRequestAttributes;
-    none @10 :Void;
+    torch @7 :RequestAttributes.TorchRequestAttributes;
+    tf @8 :RequestAttributes.TensorFlowRequestAttributes;
+    none @9 :Void;
   }
 }

--- a/smartsim/_core/mli/mli_schemas/request/request_capnp.pyi
+++ b/smartsim/_core/mli/mli_schemas/request/request_capnp.pyi
@@ -33,8 +33,6 @@ from .request_attributes.request_attributes_capnp import (
     TorchRequestAttributesReader,
 )
 
-Device = Literal["cpu", "gpu", "auto"]
-
 class ChannelDescriptor:
     reply: bytes
     @staticmethod
@@ -215,7 +213,6 @@ class Request:
         def write_packed(file: BufferedWriter) -> None: ...
     replyChannel: ChannelDescriptor | ChannelDescriptorBuilder | ChannelDescriptorReader
     model: Request.Model | Request.ModelBuilder | Request.ModelReader
-    device: Device
     input: Request.Input | Request.InputBuilder | Request.InputReader
     output: Sequence[TensorKey | TensorKeyBuilder | TensorKeyReader]
     outputDescriptors: Sequence[

--- a/tests/mli/test_integrated_torch_worker.py
+++ b/tests/mli/test_integrated_torch_worker.py
@@ -66,7 +66,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     model_bytes = persist_torch_model.read_bytes()
 #     input_tensor = torch.randn(2)
 
-#     expected_device = "cpu"
 #     expected_callback_channel = b"faux_channel_descriptor_bytes"
 #     callback_channel = mli.DragonCommChannel.find(expected_callback_channel)
 
@@ -77,7 +76,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     request = MessageHandler.build_request(
 #         reply_channel=callback_channel.descriptor,
 #         model=model_bytes,
-#         device=expected_device,
 #         inputs=[message_tensor_input],
 #         outputs=[],
 #         custom_attributes=None,
@@ -86,7 +84,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     msg_bytes = MessageHandler.serialize_request(request)
 
 #     inference_request = worker.deserialize(msg_bytes)
-#     assert inference_request.device == expected_device
 #     assert inference_request.callback._descriptor == expected_callback_channel
 
 
@@ -104,7 +101,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     # input_tensor = torch.randn(2)
 #     # feature_store[input_key] = input_tensor
 
-#     expected_device = "cpu"
 #     expected_callback_channel = b"faux_channel_descriptor_bytes"
 #     callback_channel = mli.DragonCommChannel.find(expected_callback_channel)
 
@@ -117,7 +113,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     request = MessageHandler.build_request(
 #         reply_channel=callback_channel.descriptor,
 #         model=message_model_key,
-#         device=expected_device,
 #         inputs=[message_tensor_input_key],
 #         outputs=[message_tensor_output_key],
 #         custom_attributes=None,
@@ -126,7 +121,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     msg_bytes = MessageHandler.serialize_request(request)
 
 #     inference_request = worker.deserialize(msg_bytes)
-#     assert inference_request.device == expected_device
 #     assert inference_request.callback._descriptor == expected_callback_channel
 
 
@@ -147,7 +141,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     # input_tensor = torch.randn(2)
 #     # feature_store[input_key] = input_tensor
 
-#     expected_device = "cpu"
 #     expected_callback_channel = b"faux_channel_descriptor_bytes"
 #     callback_channel = mli.DragonCommChannel.find(expected_callback_channel)
 
@@ -160,7 +153,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     request = MessageHandler.build_request(
 #         reply_channel=callback_channel.descriptor,
 #         model=model_bytes,
-#         device=expected_device,
 #         inputs=[message_tensor_input_key],
 #         # outputs=[message_tensor_output_key],
 #         outputs=[],
@@ -170,7 +162,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     msg_bytes = MessageHandler.serialize_request(request)
 
 #     inference_request = worker.deserialize(msg_bytes)
-#     assert inference_request.device == expected_device
 #     assert inference_request.callback._descriptor == expected_callback_channel
 
 
@@ -191,7 +182,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     input_tensor = torch.randn(2)
 #     # feature_store[input_key] = input_tensor
 
-#     expected_device = "cpu"
 #     expected_callback_channel = b"faux_channel_descriptor_bytes"
 #     callback_channel = mli.DragonCommChannel.find(expected_callback_channel)
 
@@ -207,7 +197,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     request = MessageHandler.build_request(
 #         reply_channel=callback_channel.descriptor,
 #         model=model_bytes,
-#         device=expected_device,
 #         inputs=[message_tensor_input],
 #         # outputs=[message_tensor_output_key],
 #         outputs=[message_tensor_output_key],
@@ -217,7 +206,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     msg_bytes = MessageHandler.serialize_request(request)
 
 #     inference_request = worker.deserialize(msg_bytes)
-#     assert inference_request.device == expected_device
 #     assert inference_request.callback._descriptor == expected_callback_channel
 
 
@@ -238,7 +226,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     input_tensor = torch.randn(2)
 #     # feature_store[input_key] = input_tensor
 
-#     expected_device = "cpu"
 #     expected_callback_channel = b"faux_channel_descriptor_bytes"
 #     callback_channel = mli.DragonCommChannel.find(expected_callback_channel)
 
@@ -254,7 +241,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     request = MessageHandler.build_request(
 #         reply_channel=callback_channel.descriptor,
 #         model=message_model_key,
-#         device=expected_device,
 #         inputs=[message_tensor_input],
 #         # outputs=[message_tensor_output_key],
 #         outputs=[],
@@ -264,7 +250,6 @@ def persist_torch_model(test_dir: str) -> pathlib.Path:
 #     msg_bytes = MessageHandler.serialize_request(request)
 
 #     inference_request = worker.deserialize(msg_bytes)
-#     assert inference_request.device == expected_device
 #     assert inference_request.callback._descriptor == expected_callback_channel
 
 

--- a/tests/mli/test_worker_manager.py
+++ b/tests/mli/test_worker_manager.py
@@ -122,7 +122,6 @@ def mock_messages(
         # working set size > 1 has side-effects
         # only incurs cost when working set size has been exceeded
 
-        expected_device: t.Literal["cpu", "gpu"] = "cpu"
         channel_key = comm_channel_root_dir / f"{iteration_number}/channel.txt"
         callback_channel = FileSystemCommChannel(pathlib.Path(channel_key))
 
@@ -144,7 +143,6 @@ def mock_messages(
         request = MessageHandler.build_request(
             reply_channel=callback_channel.descriptor,
             model=message_model_key,
-            device=expected_device,
             inputs=[message_tensor_input_key],
             outputs=[message_tensor_output_key],
             custom_attributes=None,

--- a/tests/test_message_handler/test_request.py
+++ b/tests/test_message_handler/test_request.py
@@ -92,7 +92,6 @@ if should_run_tf:
     tf_indirect_request = MessageHandler.build_request(
         b"reply",
         b"model",
-        "cpu",
         [input_key1, input_key2],
         [output_key1, output_key2],
         [output_descriptor1, output_descriptor2, output_descriptor3],
@@ -102,7 +101,6 @@ if should_run_tf:
     tf_direct_request = MessageHandler.build_request(
         b"reply",
         b"model",
-        "cpu",
         [tensor_3, tensor_4],
         [],
         [output_descriptor1, output_descriptor2],
@@ -113,7 +111,6 @@ if should_run_torch:
     torch_indirect_request = MessageHandler.build_request(
         b"reply",
         b"model",
-        "cpu",
         [input_key1, input_key2],
         [output_key1, output_key2],
         [output_descriptor1, output_descriptor2, output_descriptor3],
@@ -122,7 +119,6 @@ if should_run_torch:
     torch_direct_request = MessageHandler.build_request(
         b"reply",
         b"model",
-        "cpu",
         [tensor_1, tensor_2],
         [],
         [output_descriptor1, output_descriptor2],
@@ -132,12 +128,11 @@ if should_run_torch:
 
 @pytest.mark.skipif(not should_run_tf, reason="Test needs TF to run")
 @pytest.mark.parametrize(
-    "reply_channel, model, device, input, output, output_descriptors, custom_attributes",
+    "reply_channel, model, input, output, output_descriptors, custom_attributes",
     [
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1, input_key2],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -146,7 +141,6 @@ if should_run_torch:
         pytest.param(
             b"another reply channel",
             b"model data",
-            "gpu",
             [input_key1],
             [output_key2],
             [output_descriptor1],
@@ -155,7 +149,6 @@ if should_run_torch:
         pytest.param(
             b"another reply channel",
             b"model data",
-            "auto",
             [input_key1],
             [output_key2],
             [output_descriptor1],
@@ -164,7 +157,6 @@ if should_run_torch:
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             [output_key1],
             [output_descriptor1],
@@ -173,12 +165,11 @@ if should_run_torch:
     ],
 )
 def test_build_request_indirect_tf_successful(
-    reply_channel, model, device, input, output, output_descriptors, custom_attributes
+    reply_channel, model, input, output, output_descriptors, custom_attributes
 ):
     built_request = MessageHandler.build_request(
         reply_channel,
         model,
-        device,
         input,
         output,
         output_descriptors,
@@ -190,7 +181,6 @@ def test_build_request_indirect_tf_successful(
         assert built_request.model.modelKey.key == model.key
     else:
         assert built_request.model.modelData == model
-    assert built_request.device == device
     assert built_request.input.which() == "inputKeys"
     assert built_request.input.inputKeys[0].key == input[0].key
     assert len(built_request.input.inputKeys) == len(input)
@@ -212,12 +202,11 @@ def test_build_request_indirect_tf_successful(
 
 @pytest.mark.skipif(not should_run_torch, reason="Test needs Torch to run")
 @pytest.mark.parametrize(
-    "reply_channel, model, device, input, output, output_descriptors, custom_attributes",
+    "reply_channel, model, input, output, output_descriptors, custom_attributes",
     [
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1, input_key2],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -226,7 +215,6 @@ def test_build_request_indirect_tf_successful(
         pytest.param(
             b"another reply channel",
             b"model data",
-            "gpu",
             [input_key1],
             [output_key2],
             [output_descriptor1],
@@ -235,7 +223,6 @@ def test_build_request_indirect_tf_successful(
         pytest.param(
             b"another reply channel",
             b"model data",
-            "auto",
             [input_key1],
             [output_key2],
             [output_descriptor1],
@@ -244,7 +231,6 @@ def test_build_request_indirect_tf_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             [output_key1],
             [output_descriptor1],
@@ -253,12 +239,11 @@ def test_build_request_indirect_tf_successful(
     ],
 )
 def test_build_request_indirect_torch_successful(
-    reply_channel, model, device, input, output, output_descriptors, custom_attributes
+    reply_channel, model, input, output, output_descriptors, custom_attributes
 ):
     built_request = MessageHandler.build_request(
         reply_channel,
         model,
-        device,
         input,
         output,
         output_descriptors,
@@ -270,7 +255,6 @@ def test_build_request_indirect_torch_successful(
         assert built_request.model.modelKey.key == model.key
     else:
         assert built_request.model.modelData == model
-    assert built_request.device == device
     assert built_request.input.which() == "inputKeys"
     assert built_request.input.inputKeys[0].key == input[0].key
     assert len(built_request.input.inputKeys) == len(input)
@@ -292,12 +276,11 @@ def test_build_request_indirect_torch_successful(
 
 @pytest.mark.skipif(not should_run_torch, reason="Test needs Torch to run")
 @pytest.mark.parametrize(
-    "reply_channel, model, device, input, output, output_descriptors, custom_attributes",
+    "reply_channel, model, input, output, output_descriptors, custom_attributes",
     [
         pytest.param(
             [],
             model_key,
-            "cpu",
             [input_key1, input_key2],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -307,7 +290,6 @@ def test_build_request_indirect_torch_successful(
         pytest.param(
             b"reply channel",
             "bad model",
-            "gpu",
             [input_key1],
             [output_key2],
             [output_descriptor1],
@@ -317,17 +299,6 @@ def test_build_request_indirect_torch_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "bad device",
-            [input_key1],
-            [output_key2],
-            [output_descriptor1],
-            torch_attributes,
-            id="bad device",
-        ),
-        pytest.param(
-            b"reply channel",
-            model_key,
-            "cpu",
             ["input_key1", "input_key2"],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -337,7 +308,6 @@ def test_build_request_indirect_torch_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [model_key],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -347,7 +317,6 @@ def test_build_request_indirect_torch_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             ["output_key1", "output_key2"],
             [output_descriptor1],
@@ -357,7 +326,6 @@ def test_build_request_indirect_torch_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             [model_key],
             [output_descriptor1],
@@ -367,7 +335,6 @@ def test_build_request_indirect_torch_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -377,7 +344,6 @@ def test_build_request_indirect_torch_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -387,7 +353,6 @@ def test_build_request_indirect_torch_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             [output_key1, output_key2],
             "bad descriptors",
@@ -397,13 +362,12 @@ def test_build_request_indirect_torch_successful(
     ],
 )
 def test_build_request_indirect_torch_unsuccessful(
-    reply_channel, model, device, input, output, output_descriptors, custom_attributes
+    reply_channel, model, input, output, output_descriptors, custom_attributes
 ):
     with pytest.raises(ValueError):
         built_request = MessageHandler.build_request(
             reply_channel,
             model,
-            device,
             input,
             output,
             output_descriptors,
@@ -413,12 +377,11 @@ def test_build_request_indirect_torch_unsuccessful(
 
 @pytest.mark.skipif(not should_run_tf, reason="Test needs TF to run")
 @pytest.mark.parametrize(
-    "reply_channel, model, device, input, output, output_descriptors, custom_attributes",
+    "reply_channel, model, input, output, output_descriptors, custom_attributes",
     [
         pytest.param(
             [],
             model_key,
-            "cpu",
             [input_key1, input_key2],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -428,7 +391,6 @@ def test_build_request_indirect_torch_unsuccessful(
         pytest.param(
             b"reply channel",
             "bad model",
-            "gpu",
             [input_key1],
             [output_key2],
             [output_descriptor1],
@@ -438,17 +400,6 @@ def test_build_request_indirect_torch_unsuccessful(
         pytest.param(
             b"reply channel",
             model_key,
-            "bad device",
-            [input_key1],
-            [output_key2],
-            [output_descriptor1],
-            tf_attributes,
-            id="bad device",
-        ),
-        pytest.param(
-            b"reply channel",
-            model_key,
-            "cpu",
             ["input_key1", "input_key2"],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -458,7 +409,6 @@ def test_build_request_indirect_torch_unsuccessful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [model_key],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -468,7 +418,6 @@ def test_build_request_indirect_torch_unsuccessful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             ["output_key1", "output_key2"],
             [output_descriptor1],
@@ -478,7 +427,6 @@ def test_build_request_indirect_torch_unsuccessful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             [model_key],
             [output_descriptor1],
@@ -488,7 +436,6 @@ def test_build_request_indirect_torch_unsuccessful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -498,7 +445,6 @@ def test_build_request_indirect_torch_unsuccessful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             [output_key1, output_key2],
             [output_descriptor1],
@@ -508,7 +454,6 @@ def test_build_request_indirect_torch_unsuccessful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [input_key1],
             [output_key1, output_key2],
             "bad descriptors",
@@ -518,13 +463,12 @@ def test_build_request_indirect_torch_unsuccessful(
     ],
 )
 def test_build_request_indirect_tf_unsuccessful(
-    reply_channel, model, device, input, output, output_descriptors, custom_attributes
+    reply_channel, model, input, output, output_descriptors, custom_attributes
 ):
     with pytest.raises(ValueError):
         built_request = MessageHandler.build_request(
             reply_channel,
             model,
-            device,
             input,
             output,
             output_descriptors,
@@ -534,12 +478,11 @@ def test_build_request_indirect_tf_unsuccessful(
 
 @pytest.mark.skipif(not should_run_torch, reason="Test needs Torch to run")
 @pytest.mark.parametrize(
-    "reply_channel, model, device, input, output, output_descriptors, custom_attributes",
+    "reply_channel, model, input, output, output_descriptors, custom_attributes",
     [
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [tensor_1, tensor_2],
             [],
             [output_descriptor2],
@@ -548,7 +491,6 @@ def test_build_request_indirect_tf_unsuccessful(
         pytest.param(
             b"another reply channel",
             b"model data",
-            "gpu",
             [tensor_1],
             [],
             [output_descriptor3],
@@ -557,7 +499,6 @@ def test_build_request_indirect_tf_unsuccessful(
         pytest.param(
             b"another reply channel",
             b"model data",
-            "auto",
             [tensor_2],
             [],
             [output_descriptor1],
@@ -566,7 +507,6 @@ def test_build_request_indirect_tf_unsuccessful(
         pytest.param(
             b"another reply channel",
             b"model data",
-            "auto",
             [tensor_1],
             [],
             [output_descriptor1],
@@ -575,12 +515,11 @@ def test_build_request_indirect_tf_unsuccessful(
     ],
 )
 def test_build_request_direct_torch_successful(
-    reply_channel, model, device, input, output, output_descriptors, custom_attributes
+    reply_channel, model, input, output, output_descriptors, custom_attributes
 ):
     built_request = MessageHandler.build_request(
         reply_channel,
         model,
-        device,
         input,
         output,
         output_descriptors,
@@ -592,7 +531,6 @@ def test_build_request_direct_torch_successful(
         assert built_request.model.modelKey.key == model.key
     else:
         assert built_request.model.modelData == model
-    assert built_request.device == device
     assert built_request.input.which() == "inputData"
     assert built_request.input.inputData[0].blob == input[0].blob
     assert len(built_request.input.inputData) == len(input)
@@ -614,12 +552,11 @@ def test_build_request_direct_torch_successful(
 
 @pytest.mark.skipif(not should_run_tf, reason="Test needs TF to run")
 @pytest.mark.parametrize(
-    "reply_channel, model, device, input, output, output_descriptors, custom_attributes",
+    "reply_channel, model, input, output, output_descriptors, custom_attributes",
     [
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [tensor_3, tensor_4],
             [],
             [output_descriptor2],
@@ -628,7 +565,6 @@ def test_build_request_direct_torch_successful(
         pytest.param(
             b"another reply channel",
             b"model data",
-            "gpu",
             [tensor_4],
             [],
             [output_descriptor3],
@@ -637,7 +573,6 @@ def test_build_request_direct_torch_successful(
         pytest.param(
             b"another reply channel",
             b"model data",
-            "auto",
             [tensor_4],
             [],
             [output_descriptor1],
@@ -646,7 +581,6 @@ def test_build_request_direct_torch_successful(
         pytest.param(
             b"another reply channel",
             b"model data",
-            "auto",
             [tensor_3],
             [],
             [output_descriptor1],
@@ -655,12 +589,11 @@ def test_build_request_direct_torch_successful(
     ],
 )
 def test_build_request_direct_tf_successful(
-    reply_channel, model, device, input, output, output_descriptors, custom_attributes
+    reply_channel, model, input, output, output_descriptors, custom_attributes
 ):
     built_request = MessageHandler.build_request(
         reply_channel,
         model,
-        device,
         input,
         output,
         output_descriptors,
@@ -672,7 +605,6 @@ def test_build_request_direct_tf_successful(
         assert built_request.model.modelKey.key == model.key
     else:
         assert built_request.model.modelData == model
-    assert built_request.device == device
     assert built_request.input.which() == "inputData"
     assert built_request.input.inputData[0].blob == input[0].blob
     assert len(built_request.input.inputData) == len(input)
@@ -694,12 +626,11 @@ def test_build_request_direct_tf_successful(
 
 @pytest.mark.skipif(not should_run_torch, reason="Test needs Torch to run")
 @pytest.mark.parametrize(
-    "reply_channel, model, device, input, output, output_descriptors, custom_attributes",
+    "reply_channel, model, input, output, output_descriptors, custom_attributes",
     [
         pytest.param(
             [],
             model_key,
-            "cpu",
             [tensor_1, tensor_2],
             [],
             [output_descriptor2],
@@ -709,7 +640,6 @@ def test_build_request_direct_tf_successful(
         pytest.param(
             b"reply channel",
             "bad model",
-            "gpu",
             [tensor_1],
             [],
             [output_descriptor2],
@@ -719,17 +649,6 @@ def test_build_request_direct_tf_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "bad device",
-            [tensor_2],
-            [],
-            [output_descriptor2],
-            torch_attributes,
-            id="bad device",
-        ),
-        pytest.param(
-            b"reply channel",
-            model_key,
-            "cpu",
             ["input_key1", "input_key2"],
             [],
             [output_descriptor2],
@@ -739,7 +658,6 @@ def test_build_request_direct_tf_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [],
             ["output_key1", "output_key2"],
             [output_descriptor2],
@@ -749,7 +667,6 @@ def test_build_request_direct_tf_successful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [tensor_1],
             [],
             [output_descriptor2],
@@ -759,7 +676,6 @@ def test_build_request_direct_tf_successful(
         pytest.param(
             b"reply_channel",
             model_key,
-            "cpu",
             [tensor_1, tensor_2],
             [],
             ["output_descriptor2"],
@@ -769,13 +685,12 @@ def test_build_request_direct_tf_successful(
     ],
 )
 def test_build_torch_request_direct_unsuccessful(
-    reply_channel, model, device, input, output, output_descriptors, custom_attributes
+    reply_channel, model, input, output, output_descriptors, custom_attributes
 ):
     with pytest.raises(ValueError):
         built_request = MessageHandler.build_request(
             reply_channel,
             model,
-            device,
             input,
             output,
             output_descriptors,
@@ -785,12 +700,11 @@ def test_build_torch_request_direct_unsuccessful(
 
 @pytest.mark.skipif(not should_run_tf, reason="Test needs TF to run")
 @pytest.mark.parametrize(
-    "reply_channel, model, device, input, output, output_descriptors, custom_attributes",
+    "reply_channel, model, input, output, output_descriptors, custom_attributes",
     [
         pytest.param(
             [],
             model_key,
-            "cpu",
             [tensor_3, tensor_4],
             [],
             [output_descriptor2],
@@ -800,7 +714,6 @@ def test_build_torch_request_direct_unsuccessful(
         pytest.param(
             b"reply channel",
             "bad model",
-            "gpu",
             [tensor_4],
             [],
             [output_descriptor2],
@@ -810,17 +723,6 @@ def test_build_torch_request_direct_unsuccessful(
         pytest.param(
             b"reply channel",
             model_key,
-            "bad device",
-            [tensor_3],
-            [],
-            [output_descriptor2],
-            tf_attributes,
-            id="bad device",
-        ),
-        pytest.param(
-            b"reply channel",
-            model_key,
-            "cpu",
             ["input_key1", "input_key2"],
             [],
             [output_descriptor2],
@@ -830,7 +732,6 @@ def test_build_torch_request_direct_unsuccessful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [],
             ["output_key1", "output_key2"],
             [output_descriptor2],
@@ -840,7 +741,6 @@ def test_build_torch_request_direct_unsuccessful(
         pytest.param(
             b"reply channel",
             model_key,
-            "cpu",
             [tensor_4],
             [],
             [output_descriptor2],
@@ -850,7 +750,6 @@ def test_build_torch_request_direct_unsuccessful(
         pytest.param(
             b"reply_channel",
             model_key,
-            "cpu",
             [tensor_3, tensor_4],
             [],
             ["output_descriptor2"],
@@ -860,13 +759,12 @@ def test_build_torch_request_direct_unsuccessful(
     ],
 )
 def test_build_tf_request_direct_unsuccessful(
-    reply_channel, model, device, input, output, output_descriptors, custom_attributes
+    reply_channel, model, input, output, output_descriptors, custom_attributes
 ):
     with pytest.raises(ValueError):
         built_request = MessageHandler.build_request(
             reply_channel,
             model,
-            device,
             input,
             output,
             output_descriptors,


### PR DESCRIPTION
This PR removes `device` from the schemas, MessageHandler, and tests.