### PR TITLE
Replace stage result types

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -18,7 +18,6 @@ Description
   inference requests and response messages
 - Removed device from schemas, MessageHandler and tests
 
-
 ### Development branch
 
 To be released at some future point in time

--- a/smartsim/_core/mli/infrastructure/worker/worker.py
+++ b/smartsim/_core/mli/infrastructure/worker/worker.py
@@ -81,6 +81,7 @@ class InferenceReply:
 @dataclasses.dataclass
 class TensorResult:
     """A result from a tensor operation in the pipeline"""
+
     tensor: t.Any
     shape: t.List[int]
     order: str
@@ -93,16 +94,17 @@ _T = t.TypeVar("_T")
 @dataclasses.dataclass
 class StageResult(t.Generic[_T]):
     """Generic base class for results from a stage in the pipeline"""
+
     result: _T
 
 
-LoadModelResult: t.TypeAlias = StageResult[t.Any]
-TransformInputResult: t.TypeAlias = StageResult[t.Any]
-ExecuteResult: t.TypeAlias = StageResult[t.Any]
-FetchInputResult: t.TypeAlias = StageResult[t.Any]
-TransformOutputResult: t.TypeAlias = StageResult[t.List[TensorResult]]
-CreateInputBatchResult: t.TypeAlias = StageResult[t.Any]
-FetchModelResult: t.TypeAlias = StageResult[bytes]
+LoadModelResult = StageResult[t.Any]
+TransformInputResult = StageResult[t.Any]
+ExecuteResult = StageResult[t.Any]
+FetchInputResult = StageResult[t.Any]
+TransformOutputResult = StageResult[t.List[TensorResult]]
+CreateInputBatchResult = StageResult[t.Any]
+FetchModelResult = StageResult[bytes]
 
 
 class MachineLearningWorkerCore:

--- a/tests/mli/test_core_machine_learning_worker.py
+++ b/tests/mli/test_core_machine_learning_worker.py
@@ -34,6 +34,7 @@ import smartsim.error as sse
 from smartsim._core.mli.infrastructure.worker.worker import (
     InferenceRequest,
     MachineLearningWorkerCore,
+    TensorResult,
     TransformInputResult,
     TransformOutputResult,
 )
@@ -313,7 +314,7 @@ def test_place_outputs() -> None:
         feature_store[k] = v
 
     request = InferenceRequest(output_keys=keys)
-    transform_result = TransformOutputResult(data, [1], "c", "float32")
+    transform_result = TransformOutputResult([TensorResult(data, [1], "c", "float32")])
 
     worker.place_output(request, transform_result, feature_store)
 

--- a/tests/mli/test_core_machine_learning_worker.py
+++ b/tests/mli/test_core_machine_learning_worker.py
@@ -311,7 +311,9 @@ def test_place_outputs() -> None:
     data = [b"abcdef", b"ghijkl", b"mnopqr"]
 
     request = InferenceRequest(output_keys=keys)
-    mock_result = [TensorResult(tensor_data, [1], "c", "float32") for tensor_data in data]
+    mock_result = [
+        TensorResult(tensor_data, [1], "c", "float32") for tensor_data in data
+    ]
     transform_result = TransformOutputResult(mock_result)
 
     worker.place_output(request, transform_result, feature_store)

--- a/tests/mli/test_core_machine_learning_worker.py
+++ b/tests/mli/test_core_machine_learning_worker.py
@@ -95,8 +95,8 @@ def test_fetch_model_disk(persist_torch_model: pathlib.Path) -> None:
     request = InferenceRequest(model_key=key)
 
     fetch_result = worker.fetch_model(request, feature_store)
-    assert fetch_result.model_bytes
-    assert fetch_result.model_bytes == persist_torch_model.read_bytes()
+    assert fetch_result.result
+    assert fetch_result.result == persist_torch_model.read_bytes()
 
 
 def test_fetch_model_disk_missing() -> None:
@@ -131,8 +131,8 @@ def test_fetch_model_feature_store(persist_torch_model: pathlib.Path) -> None:
 
     request = InferenceRequest(model_key=key)
     fetch_result = worker.fetch_model(request, feature_store)
-    assert fetch_result.model_bytes
-    assert fetch_result.model_bytes == persist_torch_model.read_bytes()
+    assert fetch_result.result
+    assert fetch_result.result == persist_torch_model.read_bytes()
 
 
 def test_fetch_model_feature_store_missing() -> None:
@@ -166,8 +166,8 @@ def test_fetch_model_memory(persist_torch_model: pathlib.Path) -> None:
     request = InferenceRequest(model_key=key)
 
     fetch_result = worker.fetch_model(request, feature_store)
-    assert fetch_result.model_bytes
-    assert fetch_result.model_bytes == persist_torch_model.read_bytes()
+    assert fetch_result.result
+    assert fetch_result.result == persist_torch_model.read_bytes()
 
 
 @pytest.mark.skipif(not torch_available, reason="Torch backend is not installed")
@@ -183,7 +183,7 @@ def test_fetch_input_disk(persist_torch_tensor: pathlib.Path) -> None:
     feature_store[tensor_name] = persist_torch_tensor.read_bytes()
 
     fetch_result = worker.fetch_inputs(request, feature_store)
-    assert fetch_result.inputs is not None
+    assert fetch_result.result is not None
 
 
 def test_fetch_input_disk_missing() -> None:
@@ -218,8 +218,8 @@ def test_fetch_input_feature_store(persist_torch_tensor: pathlib.Path) -> None:
     feature_store[tensor_name] = persist_torch_tensor.read_bytes()
 
     fetch_result = worker.fetch_inputs(request, feature_store)
-    assert fetch_result.inputs
-    assert list(fetch_result.inputs)[0][:10] == persist_torch_tensor.read_bytes()[:10]
+    assert fetch_result.result
+    assert list(fetch_result.result)[0][:10] == persist_torch_tensor.read_bytes()[:10]
 
 
 @pytest.mark.skipif(not torch_available, reason="Torch backend is not installed")
@@ -247,7 +247,7 @@ def test_fetch_multi_input_feature_store(persist_torch_tensor: pathlib.Path) -> 
 
     fetch_result = worker.fetch_inputs(request, feature_store)
 
-    raw_bytes = list(fetch_result.inputs)
+    raw_bytes = list(fetch_result.result)
     assert raw_bytes
     assert raw_bytes[0][:10] == persist_torch_tensor.read_bytes()[:10]
     assert raw_bytes[1][:10] == body2[:10]
@@ -282,7 +282,7 @@ def test_fetch_input_memory(persist_torch_tensor: pathlib.Path) -> None:
     request = InferenceRequest(input_keys=[model_name])
 
     fetch_result = worker.fetch_inputs(request, feature_store)
-    assert fetch_result.inputs is not None
+    assert fetch_result.result is not None
 
 
 def test_batch_requests() -> None:

--- a/tests/mli/test_core_machine_learning_worker.py
+++ b/tests/mli/test_core_machine_learning_worker.py
@@ -314,7 +314,8 @@ def test_place_outputs() -> None:
         feature_store[k] = v
 
     request = InferenceRequest(output_keys=keys)
-    transform_result = TransformOutputResult([TensorResult(data, [1], "c", "float32")])
+    mock_result = [TensorResult(tensor_data, [1], "c", "float32") for tensor_data in data]
+    transform_result = TransformOutputResult(mock_result)
 
     worker.place_output(request, transform_result, feature_store)
 

--- a/tests/mli/test_core_machine_learning_worker.py
+++ b/tests/mli/test_core_machine_learning_worker.py
@@ -310,9 +310,6 @@ def test_place_outputs() -> None:
     keys = [key_name + "1", key_name + "2", key_name + "3"]
     data = [b"abcdef", b"ghijkl", b"mnopqr"]
 
-    for k, v in zip(keys, data):
-        feature_store[k] = v
-
     request = InferenceRequest(output_keys=keys)
     mock_result = [TensorResult(tensor_data, [1], "c", "float32") for tensor_data in data]
     transform_result = TransformOutputResult(mock_result)


### PR DESCRIPTION
Stages now return a uniform, generic type for stage outputs. This will avoid minor variations in field names and reduces overall waste/repetitive code.