### PR TITLE
Remove broken redis documentation links

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -19,6 +19,7 @@ Description
 - Fix test outputs being created in incorrect directory
 - Improve support for building SmartSim without ML backends
 - Update packaging dependency
+- Remove broken oss.redis.com URI blocking documentation generation
 
 Detailed Notes
 

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -189,8 +189,6 @@ class Orchestrator(EntityList[DBNode]):
 
         Extra configurations for RedisAI
 
-        See https://oss.redis.com/redisai/configuration/
-
         :param path: path to location of ``Orchestrator`` directory
         :param port: TCP/IP port
         :param interface: network interface(s)


### PR DESCRIPTION
This PR will remove a broken link to oss.redis.com that is breaking the documentation build