### PR TITLE
Add FeatureStore descriptor to tensor & model keys

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install SmartSim (with ML backends)
         run: |
           python -m pip install git+https://github.com/CrayLabs/SmartRedis.git@develop#egg=smartredis
-          python -m pip install .[dev,ml]
+          python -m pip install .[dev,mypy,ml]
 
       - name: Install ML Runtimes with Smart (with pt, tf, and onnx support)
         if: (contains( matrix.os, 'ubuntu' ) || contains( matrix.os, 'macos-12')) && ( matrix.subset != 'dragon' )
@@ -129,7 +129,6 @@ jobs:
 
       - name: Run mypy
         run: |
-          python -m pip install .[mypy]
           make check-mypy
 
       - name: Run Pylint

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install SmartSim (with ML backends)
         run: |
           python -m pip install git+https://github.com/CrayLabs/SmartRedis.git@develop#egg=smartredis
-          python -m pip install .[dev,mypy,ml]
+          python -m pip install .[dev,ml]
 
       - name: Install ML Runtimes with Smart (with pt, tf, and onnx support)
         if: (contains( matrix.os, 'ubuntu' ) || contains( matrix.os, 'macos-12')) && ( matrix.subset != 'dragon' )
@@ -129,6 +129,7 @@ jobs:
 
       - name: Run mypy
         run: |
+          python -m pip install .[mypy]
           make check-mypy
 
       - name: Run Pylint

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@ Jump to:
 
 Description
 
+- Enable dynamic feature store selection
 - Fix dragon package installation bug
 - Adjust schemas for better performance
 - Add TorchWorker first implementation and mock inference app example

--- a/ex/high_throughput_inference/mli_driver.py
+++ b/ex/high_throughput_inference/mli_driver.py
@@ -1,5 +1,4 @@
-
-
+import argparse
 import os
 import base64
 import cloudpickle
@@ -26,11 +25,23 @@ exp = Experiment("MLI_proto", launcher="dragon", exp_path=exp_path)
 
 torch_worker_str = base64.b64encode(cloudpickle.dumps(TorchWorker)).decode("ascii")
 
-worker_manager_rs = exp.create_run_settings(sys.executable, [worker_manager_script_name, "--device", device, "--worker_class", torch_worker_str])
+worker_manager_rs = exp.create_run_settings(
+    sys.executable,
+    [
+        worker_manager_script_name,
+        "--device",
+        device,
+        "--worker_class",
+        torch_worker_str,
+    ],
+)
 worker_manager = exp.create_model("worker_manager", run_settings=worker_manager_rs)
 worker_manager.attach_generator_files(to_copy=[worker_manager_script_name])
 
-app_rs = exp.create_run_settings(sys.executable, exe_args = [app_script_name, "--device", device])
+app_rs = exp.create_run_settings(
+    sys.executable,
+    exe_args=[app_script_name, "--device", device],
+)
 app = exp.create_model("app", run_settings=app_rs)
 app.attach_generator_files(to_copy=[app_script_name], to_symlink=[model_name])
 

--- a/ex/high_throughput_inference/mock_app.py
+++ b/ex/high_throughput_inference/mock_app.py
@@ -44,16 +44,21 @@ import torch
 import numbers
 
 from collections import OrderedDict
+from smartsim._core.mli.infrastructure.storage.dragonfeaturestore import (
+    DragonFeatureStore,
+)
 from smartsim._core.mli.message_handler import MessageHandler
 from smartsim.log import get_logger
 
 logger = get_logger("App")
+
 
 class ProtoClient:
     def __init__(self, timing_on: bool):
         connect_to_infrastructure()
         ddict_str = os.environ["SS_DRG_DDICT"]
         self._ddict = DDict.attach(ddict_str)
+        self._backbone_descriptor = DragonFeatureStore(self._ddict).descriptor
         to_worker_fli_str = None
         while to_worker_fli_str is None:
             try:
@@ -88,17 +93,23 @@ class ProtoClient:
     def end_timings(self):
         if self._timing_on:
             self._add_label_to_timings("total_time")
-            self._timings["total_time"].append(self._format_number(time.perf_counter()-self._start))
+            self._timings["total_time"].append(
+                self._format_number(time.perf_counter() - self._start)
+            )
 
     def measure_time(self, label: str):
         if self._timing_on:
             self._add_label_to_timings(label)
-            self._timings[label].append(self._format_number(time.perf_counter()-self._interm))
+            self._timings[label].append(
+                self._format_number(time.perf_counter() - self._interm)
+            )
             self._interm = time.perf_counter()
 
     def print_timings(self, to_file: bool = False):
         print(" ".join(self._timings.keys()))
-        value_array = numpy.array([value for  value in self._timings.values()], dtype=float)
+        value_array = numpy.array(
+            [value for value in self._timings.values()], dtype=float
+        )
         value_array = numpy.transpose(value_array)
         for i in range(value_array.shape[0]):
             print(" ".join(self._format_number(value) for value in value_array[i]))
@@ -106,21 +117,21 @@ class ProtoClient:
             numpy.save("timings.npy", value_array)
             numpy.savetxt("timings.txt", value_array)
 
-
     def run_model(self, model: bytes | str, batch: torch.Tensor):
         tensors = [batch.numpy()]
         self.start_timings(batch.shape[0])
         built_tensor_desc = MessageHandler.build_tensor_descriptor(
-            "c", "float32", list(batch.shape))
+            "c", "float32", list(batch.shape)
+        )
         self.measure_time("build_tensor_descriptor")
         built_model = None
         if isinstance(model, str):
-            model_arg = MessageHandler.build_model_key(model)  # todo: this needs FSD
+            model_arg = MessageHandler.build_model_key(model, self._backbone_descriptor)
         else:
             model_arg = MessageHandler.build_model(model, "resnet-50", "1.0")
         request = MessageHandler.build_request(
             reply_channel=self._from_worker_ch_serialized,
-            model= model_arg,
+            model=model_arg,
             inputs=[built_tensor_desc],
             outputs=[],
             output_descriptors=[],
@@ -129,10 +140,12 @@ class ProtoClient:
         self.measure_time("build_request")
         request_bytes = MessageHandler.serialize_request(request)
         self.measure_time("serialize_request")
-        with self._to_worker_fli.sendh(timeout=None, stream_channel=self._to_worker_ch) as to_sendh:
+        with self._to_worker_fli.sendh(
+            timeout=None, stream_channel=self._to_worker_ch
+        ) as to_sendh:
             to_sendh.send_bytes(request_bytes)
             for t in tensors:
-                to_sendh.send_bytes(t.tobytes()) #TODO NOT FAST ENOUGH!!!
+                to_sendh.send_bytes(t.tobytes())  # TODO NOT FAST ENOUGH!!!
                 # to_sendh.send_bytes(bytes(t.data))
         logger.info(f"Message size: {len(request_bytes)} bytes")
 
@@ -159,7 +172,7 @@ class ProtoClient:
         self._ddict[key] = model
 
 
-class ResNetWrapper():
+class ResNetWrapper:
     def __init__(self, name: str, model: str):
         self._model = torch.jit.load(model)
         self._name = name
@@ -168,7 +181,7 @@ class ResNetWrapper():
         torch.jit.save(scripted, buffer)
         self._serialized_model = buffer.getvalue()
 
-    def get_batch(self, batch_size: int=32):
+    def get_batch(self, batch_size: int = 32):
         return torch.randn((batch_size, 3, 224, 224), dtype=torch.float32)
 
     @property
@@ -178,6 +191,7 @@ class ResNetWrapper():
     @property
     def name(self):
         return self._name
+
 
 if __name__ == "__main__":
 
@@ -194,7 +208,7 @@ if __name__ == "__main__":
 
     for batch_size in [1, 2, 4, 8, 16, 32, 64, 128]:
         logger.info(f"Batch size: {batch_size}")
-        for iteration_number in range(total_iterations + int(batch_size==1)):
+        for iteration_number in range(total_iterations + int(batch_size == 1)):
             logger.info(f"Iteration: {iteration_number}")
             client.run_model(resnet.name, resnet.get_batch(batch_size))
 

--- a/ex/high_throughput_inference/mock_app.py
+++ b/ex/high_throughput_inference/mock_app.py
@@ -56,7 +56,7 @@ logger = get_logger("App")
 class ProtoClient:
     def __init__(self, timing_on: bool):
         connect_to_infrastructure()
-        ddict_str = os.environ["SS_DRG_DDICT"]
+        ddict_str = os.environ["SS_INFRA_BACKBONE"]
         self._ddict = DDict.attach(ddict_str)
         self._backbone_descriptor = DragonFeatureStore(self._ddict).descriptor
         to_worker_fli_str = None

--- a/ex/high_throughput_inference/mock_app.py
+++ b/ex/high_throughput_inference/mock_app.py
@@ -115,7 +115,7 @@ class ProtoClient:
         self.measure_time("build_tensor_descriptor")
         built_model = None
         if isinstance(model, str):
-            model_arg = MessageHandler.build_model_key(model)
+            model_arg = MessageHandler.build_model_key(model)  # todo: this needs FSD
         else:
             model_arg = MessageHandler.build_model(model, "resnet-50", "1.0")
         request = MessageHandler.build_request(

--- a/ex/high_throughput_inference/standalone_workermanager.py
+++ b/ex/high_throughput_inference/standalone_workermanager.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     connect_to_infrastructure()
-    ddict_str = os.environ["SS_DRG_DDICT"]
+    ddict_str = os.environ["SS_INFRA_BACKBONE"]
     ddict = DDict.attach(ddict_str)
 
     to_worker_channel = Channel.make_process_local()

--- a/ex/high_throughput_inference/standalone_workermanager.py
+++ b/ex/high_throughput_inference/standalone_workermanager.py
@@ -80,7 +80,8 @@ if __name__ == "__main__":
     worker_type_name = base64.b64decode(args.worker_class.encode("ascii"))
     torch_worker = cloudpickle.loads(worker_type_name)()
 
-    os.environ["SS_QUEUE"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
+    descriptor = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
+    os.environ["SS_REQUEST_QUEUE"] = descriptor
 
     config_loader = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,

--- a/ex/high_throughput_inference/standalone_workermanager.py
+++ b/ex/high_throughput_inference/standalone_workermanager.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     worker_type_name = base64.b64decode(args.worker_class.encode("ascii"))
     torch_worker = cloudpickle.loads(worker_type_name)()
 
-    os.environ["SSQueue"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
+    os.environ["SS_QUEUE"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
 
     config_loader = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,

--- a/smartsim/_core/_cli/scripts/dragon_install.py
+++ b/smartsim/_core/_cli/scripts/dragon_install.py
@@ -2,10 +2,10 @@ import os
 import pathlib
 import sys
 import typing as t
+from urllib.request import urlretrieve
 
 from github import Github
 from github.GitReleaseAsset import GitReleaseAsset
-from urllib.request import urlretrieve
 
 from smartsim._core._cli.utils import pip
 from smartsim._core._install.builder import WebTGZ
@@ -169,11 +169,25 @@ def retrieve_asset(working_dir: pathlib.Path, asset: GitReleaseAsset) -> pathlib
     # grab a copy of the complete asset
     asset_path = download_dir / str(asset.name)
     download_url = asset.browser_download_url
+    if "0.91" not in asset.name:
+        if "3.9" in python_version():
+            logger.debug("I want to snake the original w/3.9 rpm")
+            # download_url = "https://arti.hpc.amslabs.hpecorp.net/ui/native/dragon-rpm-master-local/dev/master/sle15_sp3_pe/x86_64/dragon-0.91-py3.11.5-1d600977c.rpm"
+            ...  # temp no-op
+        elif "3.10" in python_version():
+            logger.debug("snaking original w/3.10 rpm")
+            download_url = "https://drive.usercontent.google.com/download?id=1dyScGNomzoPO8-bC8i6zaIbOOhsL83Sp&export=download&authuser=0&confirm=t&uuid=6068afeb-14fd-4303-90a5-498b316d3cce&at=APZUnTWTIf9Tl7Yt8tcdKyodnydV:1722641072921"
+        elif "3.11" in python_version():
+            logger.debug("snaking original w/3.11rpm")
+            download_url = "https://drive.usercontent.google.com/download?id=1vhUXLIu06-RPA_N3wWmi42avnawzizZZ&export=download&authuser=0&confirm=t&uuid=04c920cb-2e66-4762-8e0f-8ad57e0cbbdf&at=APZUnTUKtCv_BgYOkWAaHqoPpGLd:1722640947383"
+    else:
+        logger.debug(f"the name was: {asset.name}")
+
     try:
         urlretrieve(download_url, str(asset_path))
         logger.debug(f"Retrieved asset {asset.name} to {download_url}")
     except Exception:
-        logger.warning(f"Unable to download asset from: {download_url}")
+        logger.exception(f"Unable to download asset from: {download_url}")
 
     # extract the asset
     archive = WebTGZ(download_url)

--- a/smartsim/_core/_cli/scripts/dragon_install.py
+++ b/smartsim/_core/_cli/scripts/dragon_install.py
@@ -163,27 +163,13 @@ def retrieve_asset(working_dir: pathlib.Path, asset: GitReleaseAsset) -> pathlib
     # if we've previously downloaded the release and still have
     # wheels laying around, use that cached version instead
     if download_dir.exists() or list(download_dir.rglob("*.whl")):
-        # return download_dir
-        shutil.rmtree(str(download_dir))
+        return download_dir
 
     download_dir.mkdir(parents=True, exist_ok=True)
 
     # grab a copy of the complete asset
     asset_path = download_dir / str(asset.name)
     download_url = asset.browser_download_url
-    if "0.91" not in asset.name:
-        if "3.9" in python_version():
-            logger.debug("I want to snake the original w/3.9 rpm")
-            # download_url = "https://arti.hpc.amslabs.hpecorp.net/ui/native/dragon-rpm-master-local/dev/master/sle15_sp3_pe/x86_64/dragon-0.91-py3.11.5-1d600977c.rpm"
-            ...  # temp no-op
-        elif "3.10" in python_version():
-            logger.debug("snaking original w/3.10 rpm")
-            download_url = "https://drive.usercontent.google.com/download?id=1dyScGNomzoPO8-bC8i6zaIbOOhsL83Sp&export=download&authuser=0&confirm=t&uuid=6068afeb-14fd-4303-90a5-498b316d3cce&at=APZUnTWTIf9Tl7Yt8tcdKyodnydV:1722641072921"
-        elif "3.11" in python_version():
-            logger.debug("snaking original w/3.11rpm")
-            download_url = "https://drive.usercontent.google.com/download?id=1vhUXLIu06-RPA_N3wWmi42avnawzizZZ&export=download&authuser=0&confirm=t&uuid=04c920cb-2e66-4762-8e0f-8ad57e0cbbdf&at=APZUnTUKtCv_BgYOkWAaHqoPpGLd:1722640947383"
-    else:
-        logger.debug(f"the name was: {asset.name}")
 
     try:
         urlretrieve(download_url, str(asset_path))

--- a/smartsim/_core/_cli/scripts/dragon_install.py
+++ b/smartsim/_core/_cli/scripts/dragon_install.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import shutil
 import sys
 import typing as t
 from urllib.request import urlretrieve
@@ -161,8 +162,9 @@ def retrieve_asset(working_dir: pathlib.Path, asset: GitReleaseAsset) -> pathlib
 
     # if we've previously downloaded the release and still have
     # wheels laying around, use that cached version instead
-    if download_dir.exists() and list(download_dir.rglob("*.whl")):
-        return download_dir
+    if download_dir.exists() or list(download_dir.rglob("*.whl")):
+        # return download_dir
+        shutil.rmtree(str(download_dir))
 
     download_dir.mkdir(parents=True, exist_ok=True)
 
@@ -185,7 +187,7 @@ def retrieve_asset(working_dir: pathlib.Path, asset: GitReleaseAsset) -> pathlib
 
     try:
         urlretrieve(download_url, str(asset_path))
-        logger.debug(f"Retrieved asset {asset.name} to {download_url}")
+        logger.debug(f"Retrieved asset {asset.name} from {download_url}")
     except Exception:
         logger.exception(f"Unable to download asset from: {download_url}")
 

--- a/smartsim/_core/launcher/dragon/dragonBackend.py
+++ b/smartsim/_core/launcher/dragon/dragonBackend.py
@@ -521,7 +521,7 @@ class DragonBackend:
                         env={
                             **request.current_env,
                             **request.env,
-                            "SS_DRG_DDICT": self.infra_ddict,
+                            "SS_INFRA_BACKBONE": self.infra_ddict,
                         },
                         stdout=dragon_process.Popen.PIPE,
                         stderr=dragon_process.Popen.PIPE,

--- a/smartsim/_core/launcher/dragon/dragonBackend.py
+++ b/smartsim/_core/launcher/dragon/dragonBackend.py
@@ -457,7 +457,6 @@ class DragonBackend:
         if isinstance(request, DragonRunRequest):
             run_request: DragonRunRequest = request
 
-            affinity = dragon_policy.Policy.Affinity.DEFAULT
             cpu_affinity: t.List[int] = []
             gpu_affinity: t.List[int] = []
 
@@ -465,25 +464,20 @@ class DragonBackend:
             if run_request.policy is not None:
                 # Affinities are not mutually exclusive. If specified, both are used
                 if run_request.policy.cpu_affinity:
-                    affinity = dragon_policy.Policy.Affinity.SPECIFIC
                     cpu_affinity = run_request.policy.cpu_affinity
 
                 if run_request.policy.gpu_affinity:
-                    affinity = dragon_policy.Policy.Affinity.SPECIFIC
                     gpu_affinity = run_request.policy.gpu_affinity
             logger.debug(
-                f"Affinity strategy: {affinity}, "
                 f"CPU affinity mask: {cpu_affinity}, "
                 f"GPU affinity mask: {gpu_affinity}"
             )
-            if affinity != dragon_policy.Policy.Affinity.DEFAULT:
-                return dragon_policy.Policy(
-                    placement=dragon_policy.Policy.Placement.HOST_NAME,
-                    host_name=node_name,
-                    affinity=affinity,
-                    cpu_affinity=cpu_affinity,
-                    gpu_affinity=gpu_affinity,
-                )
+            return dragon_policy.Policy(
+                placement=dragon_policy.Policy.Placement.HOST_NAME,
+                host_name=node_name,
+                cpu_affinity=cpu_affinity,
+                gpu_affinity=gpu_affinity,
+            )
 
         return dragon_policy.Policy(
             placement=dragon_policy.Policy.Placement.HOST_NAME,

--- a/smartsim/_core/mli/comm/channel/channel.py
+++ b/smartsim/_core/mli/comm/channel/channel.py
@@ -42,11 +42,13 @@ class CommChannelBase(ABC):
     @abstractmethod
     def send(self, value: bytes) -> None:
         """Send a message through the underlying communication channel
+
         :param value: The value to send"""
 
     @abstractmethod
     def recv(self) -> t.List[bytes]:
         """Receieve a message through the underlying communication channel
+
         :returns: the received message"""
 
     @property

--- a/smartsim/_core/mli/comm/channel/dragonchannel.py
+++ b/smartsim/_core/mli/comm/channel/dragonchannel.py
@@ -56,6 +56,7 @@ class DragonCommChannel(cch.CommChannelBase):
 
     def recv(self) -> t.List[bytes]:
         """Receieve a message through the underlying communication channel
+
         :returns: the received message"""
         with self._channel.recvh(timeout=None) as recvh:
             message_bytes: bytes = recvh.recv_bytes(timeout=None)
@@ -67,6 +68,7 @@ class DragonCommChannel(cch.CommChannelBase):
         descriptor: str,
     ) -> "DragonCommChannel":
         """A factory method that creates an instance from a descriptor string
+
         :param descriptor: The descriptor that uniquely identifies the resource
         :returns: An attached DragonCommChannel"""
         try:

--- a/smartsim/_core/mli/comm/channel/dragonchannel.py
+++ b/smartsim/_core/mli/comm/channel/dragonchannel.py
@@ -24,6 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import base64
 import sys
 import typing as t
 
@@ -59,3 +60,14 @@ class DragonCommChannel(cch.CommChannelBase):
         with self._channel.recvh(timeout=None) as recvh:
             message_bytes: bytes = recvh.recv_bytes(timeout=None)
             return [message_bytes]
+
+    @classmethod
+    def from_descriptor(
+        cls,
+        descriptor: str,
+    ) -> "DragonCommChannel":
+        try:
+            return DragonCommChannel(base64.b64decode(descriptor))
+        except:
+            print(f"failed to create dragon comm channel: {descriptor}")
+            raise

--- a/smartsim/_core/mli/comm/channel/dragonchannel.py
+++ b/smartsim/_core/mli/comm/channel/dragonchannel.py
@@ -66,6 +66,9 @@ class DragonCommChannel(cch.CommChannelBase):
         cls,
         descriptor: str,
     ) -> "DragonCommChannel":
+        """A factory method that creates an instance from a descriptor string
+        :param descriptor: The descriptor that uniquely identifies the resource
+        :returns: An attached DragonCommChannel"""
         try:
             return DragonCommChannel(base64.b64decode(descriptor))
         except:

--- a/smartsim/_core/mli/comm/channel/dragonchannel.py
+++ b/smartsim/_core/mli/comm/channel/dragonchannel.py
@@ -69,5 +69,5 @@ class DragonCommChannel(cch.CommChannelBase):
         try:
             return DragonCommChannel(base64.b64decode(descriptor))
         except:
-            print(f"failed to create dragon comm channel: {descriptor}")
+            logger.error(f"Failed to create dragon comm channel: {descriptor}")
             raise

--- a/smartsim/_core/mli/comm/channel/dragonfli.py
+++ b/smartsim/_core/mli/comm/channel/dragonfli.py
@@ -76,6 +76,8 @@ class DragonFLIChannel(cch.CommChannelBase):
         cls,
         descriptor: str,
     ) -> "DragonFLIChannel":
+        """A factory method that creates an instance from a descriptor string
+        :param descriptor: The descriptor that uniquely identifies the resource"""
         try:
             return DragonFLIChannel(
                 fli_desc=base64.b64decode(descriptor),

--- a/smartsim/_core/mli/comm/channel/dragonfli.py
+++ b/smartsim/_core/mli/comm/channel/dragonfli.py
@@ -44,6 +44,7 @@ class DragonFLIChannel(cch.CommChannelBase):
 
     def __init__(self, fli_desc: bytes, sender_supplied: bool = True) -> None:
         """Initialize the DragonFLIChannel instance
+
         :param fli_desc: the descriptor of the FLI channel to attach
         :param sender_supplied: flag indicating if the FLI uses sender-supplied streams
         """
@@ -56,12 +57,14 @@ class DragonFLIChannel(cch.CommChannelBase):
 
     def send(self, value: bytes) -> None:
         """Send a message through the underlying communication channel
+
         :param value: The value to send"""
         with self._fli.sendh(timeout=None, stream_channel=self._channel) as sendh:
             sendh.send_bytes(value)
 
     def recv(self) -> t.List[bytes]:
         """Receieve a message through the underlying communication channel
+
         :returns: the received message"""
         messages = []
         eot = False
@@ -80,6 +83,7 @@ class DragonFLIChannel(cch.CommChannelBase):
         descriptor: str,
     ) -> "DragonFLIChannel":
         """A factory method that creates an instance from a descriptor string
+
         :param descriptor: The descriptor that uniquely identifies the resource
         :returns: An attached DragonFLIChannel"""
         try:

--- a/smartsim/_core/mli/comm/channel/dragonfli.py
+++ b/smartsim/_core/mli/comm/channel/dragonfli.py
@@ -77,7 +77,8 @@ class DragonFLIChannel(cch.CommChannelBase):
         descriptor: str,
     ) -> "DragonFLIChannel":
         """A factory method that creates an instance from a descriptor string
-        :param descriptor: The descriptor that uniquely identifies the resource"""
+        :param descriptor: The descriptor that uniquely identifies the resource
+        :returns: An attached DragonFLIChannel"""
         try:
             return DragonFLIChannel(
                 fli_desc=base64.b64decode(descriptor),

--- a/smartsim/_core/mli/comm/channel/dragonfli.py
+++ b/smartsim/_core/mli/comm/channel/dragonfli.py
@@ -43,7 +43,10 @@ class DragonFLIChannel(cch.CommChannelBase):
     """Passes messages by writing to a Dragon FLI Channel"""
 
     def __init__(self, fli_desc: bytes, sender_supplied: bool = True) -> None:
-        """Initialize the DragonFLIChannel instance"""
+        """Initialize the DragonFLIChannel instance
+        :param fli_desc: the descriptor of the FLI channel to attach
+        :param sender_supplied: flag indicating if the FLI uses sender-supplied streams
+        """
         super().__init__(fli_desc)
         # todo: do we need memory pool information to construct the channel correctly?
         self._fli: "fli" = fli.FLInterface.attach(fli_desc)

--- a/smartsim/_core/mli/comm/channel/dragonfli.py
+++ b/smartsim/_core/mli/comm/channel/dragonfli.py
@@ -30,7 +30,7 @@ import dragon.channels as dch
 
 # isort: on
 
-import sys
+import base64
 import typing as t
 
 import smartsim._core.mli.comm.channel.channel as cch
@@ -70,3 +70,13 @@ class DragonFLIChannel(cch.CommChannelBase):
                 except fli.FLIEOT as exc:
                     eot = True
         return messages
+
+    @classmethod
+    def from_descriptor(
+        cls,
+        descriptor: str,
+    ) -> "DragonFLIChannel":
+        return DragonFLIChannel(
+            fli_desc=base64.b64decode(descriptor),
+            sender_supplied=True,
+        )

--- a/smartsim/_core/mli/comm/channel/dragonfli.py
+++ b/smartsim/_core/mli/comm/channel/dragonfli.py
@@ -76,7 +76,11 @@ class DragonFLIChannel(cch.CommChannelBase):
         cls,
         descriptor: str,
     ) -> "DragonFLIChannel":
-        return DragonFLIChannel(
-            fli_desc=base64.b64decode(descriptor),
-            sender_supplied=True,
-        )
+        try:
+            return DragonFLIChannel(
+                fli_desc=base64.b64decode(descriptor),
+                sender_supplied=True,
+            )
+        except:
+            logger.error(f"Error while creating DragonFLIChannel: {descriptor}")
+            raise

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -146,7 +146,7 @@ class WorkerManager(Service):
         fs_missing = fs_desired - fs_actual
 
         if self._featurestore_factory is None:
-            logger.warning("No feature store factory configured")
+            logger.error("No feature store factory configured")
             return False
 
         # create the feature stores we need to service request
@@ -215,7 +215,7 @@ class WorkerManager(Service):
         logger.debug("executing worker manager pipeline")
 
         if self._task_queue is None:
-            logger.warning("No queue to check for tasks")
+            logger.error("No queue to check for tasks")
             return
 
         timings = []  # timing

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -103,7 +103,7 @@ class WorkerManager(Service):
         :param as_service: Specifies run-once or run-until-complete behavior of service
         :param cooldown: Number of seconds to wait before shutting down after
         shutdown criteria are met
-        :param comm_channel_type: The type of communication channel used for callbacks
+        :param device: The type of hardware the workers must be executed on
         """
         super().__init__(as_service, cooldown)
 

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -122,7 +122,8 @@ class WorkerManager(Service):
         self._fs_factory = config_loader._featurestore_factory
         """A factory method to create a desired feature store client type"""
         self._backbone: t.Optional[FeatureStore] = config_loader.get_backbone()
-        """The backbone feature store"""
+        """A standalone, system-created feature store used to share internal
+        information among MLI components"""
 
     def _check_feature_stores(self, request: InferenceRequest) -> bool:
         """Ensures that all feature stores required by the request are available

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -92,10 +92,8 @@ class WorkerManager(Service):
         self,
         config_loader: EnvironmentConfigLoader,
         worker: MachineLearningWorkerBase,
-        # fs_factory: t.Callable[[str], FeatureStore],
         as_service: bool = False,
         cooldown: int = 0,
-        # comm_channel_type: t.Type[CommChannelBase] = DragonCommChannel,
         device: t.Literal["cpu", "gpu"] = "cpu",
     ) -> None:
         """Initialize the WorkerManager

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -98,6 +98,7 @@ class WorkerManager(Service):
         device: t.Literal["cpu", "gpu"] = "cpu",
     ) -> None:
         """Initialize the WorkerManager
+
         :param config_loader: Environment config loader that loads the task queue and
         feature store
         :param workers: A worker to manage
@@ -128,6 +129,7 @@ class WorkerManager(Service):
 
     def _check_feature_stores(self, request: InferenceRequest) -> bool:
         """Ensures that all feature stores required by the request are available
+
         :param request: The request to validate
         :returns: False if feature store validation fails for the request, True otherwise
         """
@@ -158,6 +160,7 @@ class WorkerManager(Service):
 
     def _check_model(self, request: InferenceRequest) -> bool:
         """Ensure that a model is available for the request
+
         :param request: The request to validate
         :returns: False if model validation fails for the request, True otherwise
         """
@@ -169,6 +172,7 @@ class WorkerManager(Service):
 
     def _check_inputs(self, request: InferenceRequest) -> bool:
         """Ensure that inputs are available for the request
+
         :param request: The request to validate
         :returns: False if input validation fails for the request, True otherwise
         """
@@ -180,6 +184,7 @@ class WorkerManager(Service):
 
     def _check_callback(self, request: InferenceRequest) -> bool:
         """Ensure that a callback channel is available for the request
+
         :param request: The request to validate
         :returns: False if callback validation fails for the request, True otherwise
         """
@@ -190,7 +195,8 @@ class WorkerManager(Service):
         return False
 
     def _validate_request(self, request: InferenceRequest) -> bool:
-        """Ensure the request can be processed.
+        """Ensure the request can be processed
+
         :param request: The request to validate
         :return: False if the request fails any validation checks, True otherwise"""
         checks = [
@@ -204,6 +210,7 @@ class WorkerManager(Service):
 
     def _on_iteration(self) -> None:
         """Executes calls to the machine learning worker implementation to complete
+
         the inference pipeline"""
         logger.debug("executing worker manager pipeline")
 

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -45,11 +45,7 @@ from ...mli_schemas.response.response_capnp import ResponseBuilder
 
 if t.TYPE_CHECKING:
     from dragon.fli import FLInterface
-
-    # from smartsim._core.mli.mli_schemas.model.model_capnp import Model
     from smartsim._core.mli.mli_schemas.response.response_capnp import Status
-
-    # from smartsim._core.mli.mli_schemas.tensor.tensor_capnp import TensorDescriptor
 
 logger = get_logger(__name__)
 

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -45,6 +45,7 @@ from ...mli_schemas.response.response_capnp import ResponseBuilder
 
 if t.TYPE_CHECKING:
     from dragon.fli import FLInterface
+
     from smartsim._core.mli.mli_schemas.response.response_capnp import Status
 
 logger = get_logger(__name__)

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -128,7 +128,9 @@ class WorkerManager(Service):
 
     def _check_feature_stores(self, request: InferenceRequest) -> bool:
         """Ensures that all feature stores required by the request are available
-        :param request: The request to validate"""
+        :param request: The request to validate
+        :returns: False if feature store validation fails for the request, True otherwise
+        """
         # collect all feature stores required by the request
         fs_model: t.Set[str] = set()
         if request.model_key:
@@ -147,7 +149,7 @@ class WorkerManager(Service):
 
         # create the feature stores we need to service request
         if fs_missing:
-            logger.info(f"Missing feature store(s): {fs_missing}")
+            logger.debug(f"Adding feature store(s): {fs_missing}")
             for descriptor in fs_missing:
                 feature_store = self._fs_factory(descriptor)
                 self._feature_stores[descriptor] = feature_store
@@ -156,7 +158,9 @@ class WorkerManager(Service):
 
     def _check_model(self, request: InferenceRequest) -> bool:
         """Ensure that a model is available for the request
-        :param request: The request to validate"""
+        :param request: The request to validate
+        :returns: False if model validation fails for the request, True otherwise
+        """
         if request.model_key or request.raw_model:
             return True
 
@@ -165,7 +169,9 @@ class WorkerManager(Service):
 
     def _check_inputs(self, request: InferenceRequest) -> bool:
         """Ensure that inputs are available for the request
-        :param request: The request to validate"""
+        :param request: The request to validate
+        :returns: False if input validation fails for the request, True otherwise
+        """
         if request.input_keys or request.raw_inputs:
             return True
 
@@ -174,7 +180,9 @@ class WorkerManager(Service):
 
     def _check_callback(self, request: InferenceRequest) -> bool:
         """Ensure that a callback channel is available for the request
-        :param request: The request to validate"""
+        :param request: The request to validate
+        :returns: False if callback validation fails for the request, True otherwise
+        """
         if request.callback is not None:
             return True
 
@@ -184,7 +192,7 @@ class WorkerManager(Service):
     def _validate_request(self, request: InferenceRequest) -> bool:
         """Ensure the request can be processed.
         :param request: The request to validate
-        :return: True if the request is valid, False otherwise"""
+        :return: False if the request fails any validation checks, True otherwise"""
         checks = [
             self._check_feature_stores(request),
             self._check_model(request),

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -121,7 +121,7 @@ class WorkerManager(Service):
         """Dictionary of previously loaded models"""
         self._feature_stores: t.Dict[str, FeatureStore] = {}
         """A collection of attached feature stores"""
-        self._fs_factory = config_loader._featurestore_factory
+        self._featurestore_factory = config_loader._featurestore_factory
         """A factory method to create a desired feature store client type"""
         self._backbone: t.Optional[FeatureStore] = config_loader.get_backbone()
         """A standalone, system-created feature store used to share internal
@@ -145,7 +145,7 @@ class WorkerManager(Service):
         fs_actual = {item.descriptor for item in self._feature_stores.values()}
         fs_missing = fs_desired - fs_actual
 
-        if self._fs_factory is None:
+        if self._featurestore_factory is None:
             logger.warning("No feature store factory configured")
             return False
 
@@ -153,7 +153,7 @@ class WorkerManager(Service):
         if fs_missing:
             logger.debug(f"Adding feature store(s): {fs_missing}")
             for descriptor in fs_missing:
-                feature_store = self._fs_factory(descriptor)
+                feature_store = self._featurestore_factory(descriptor)
                 self._feature_stores[descriptor] = feature_store
 
         return True
@@ -261,11 +261,6 @@ class WorkerManager(Service):
                     "Could not find model key or model.",
                 )
                 return
-
-            # if request.model_key.descriptor not in self._feature_stores:
-            #     self._fs_factory(request.model_key.descriptor)
-            # todo: decide if we should load here or in _check_feature_stores.
-            # todo: should i raise error here?
 
             if request.model_key.key in self._cached_models:
                 timings.append(time.perf_counter() - interm)  # timing

--- a/smartsim/_core/mli/infrastructure/control/workermanager.py
+++ b/smartsim/_core/mli/infrastructure/control/workermanager.py
@@ -235,7 +235,11 @@ class WorkerManager(Service):
             request.raw_inputs = tensor_bytes_list
 
         if not self._validate_request(request):
-            return
+            exception_handler(
+                ValueError("Error validating the request"),
+                request.callback,
+                "Error validating the request.",
+            )
 
         timings.append(time.perf_counter() - interm)  # timing
         interm = time.perf_counter()  # timing

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -83,12 +83,7 @@ class EnvironmentConfigLoader:
             logger.warning("No queue factory is configured")
             return None
 
-        if descriptor is not None:
-            # , sender_supplied: bool = True
-            # self.queue = DragonFLIChannel(
-            #     fli_desc=base64.b64decode(descriptor),
-            #     sender_supplied=sender_supplied,
-            # )
+        if descriptor is not None and descriptor:
             self.queue = self._queue_factory(descriptor)
             self._queue_descriptor = descriptor
         return self.queue

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -49,7 +49,7 @@ class EnvironmentConfigLoader:
         self._queue_descriptor: t.Optional[str] = os.getenv("SSQueue", None)
         self.feature_stores: t.Optional[t.Dict[str, FeatureStore]] = None
         self.queue: t.Optional[DragonFLIChannel] = None
-        self._prefix = "SSFeatureStore"
+        self._feature_store_prefix = "SSFeatureStore"
 
     def _load_feature_store(self, env_var: str) -> FeatureStore:
         """Load a feature store from a descriptor
@@ -74,7 +74,7 @@ class EnvironmentConfigLoader:
         """Loads multiple Feature Stores by scanning environment for variables
         prefixed with `SSFeatureStore`"""
         if not self.feature_stores:
-            env_vars = [var for var in os.environ if var.startswith(self._prefix)]
+            env_vars = [var for var in os.environ if var.startswith(self._feature_store_prefix)]
             stores = [self._load_feature_store(var) for var in env_vars]
             self.feature_stores = {fs.descriptor: fs for fs in stores}
         return self.feature_stores

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -90,8 +90,8 @@ class EnvironmentConfigLoader:
         """Attach to a queue-like communication channel using the descriptor
         found in an environment variable.
 
-        :returns: The attached queue specified via SS_QUEUE"""
-        descriptor = os.getenv("SS_QUEUE", "")
+        :returns: The attached queue specified via `SS_REQUEST_QUEUE`"""
+        descriptor = os.getenv("SS_REQUEST_QUEUE", "")
 
         if not descriptor:
             logger.warning("No queue descriptor is configured")

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -90,8 +90,8 @@ class EnvironmentConfigLoader:
         """Attach to a queue-like communication channel using the descriptor
         found in an environment variable.
 
-        :returns: The attached queue specified via SSQueue"""
-        descriptor = os.getenv("SSQueue", "")
+        :returns: The attached queue specified via SS_QUEUE"""
+        descriptor = os.getenv("SS_QUEUE", "")
 
         if not descriptor:
             logger.warning("No queue descriptor is configured")

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -65,7 +65,8 @@ class EnvironmentConfigLoader:
 
     def get_backbone(self) -> t.Optional[FeatureStore]:
         """Create the backbone feature store using the descriptor found in
-        an environment variable"""
+        an environment variable. The backbone is a standalone, system-created
+        feature store used to share internal information among MLI components"""
         descriptor = self._backbone_descriptor or os.getenv("SS_DRG_DDICT", None)
         if self._featurestore_factory is None:
             logger.warning("No feature store factory is configured")

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -77,6 +77,7 @@ class EnvironmentConfigLoader:
 
         if not descriptor:
             logger.warning("No backbone descriptor is configured")
+            return None
 
         if self._featurestore_factory is None:
             logger.warning("No feature store factory is configured")
@@ -94,6 +95,7 @@ class EnvironmentConfigLoader:
 
         if not descriptor:
             logger.warning("No queue descriptor is configured")
+            return None
 
         if self._queue_factory is None:
             logger.warning("No queue factory is configured")

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -72,8 +72,8 @@ class EnvironmentConfigLoader:
         an environment variable. The backbone is a standalone, system-created
         feature store used to share internal information among MLI components
 
-        :returns: The attached feature store via SS_DRG_DDICT"""
-        descriptor = os.getenv("SS_DRG_DDICT", "")
+        :returns: The attached feature store via SS_INFRA_BACKBONE"""
+        descriptor = os.getenv("SS_INFRA_BACKBONE", "")
 
         if not descriptor:
             logger.warning("No backbone descriptor is configured")

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -64,7 +64,7 @@ class EnvironmentConfigLoader:
         for inference requests"""
 
     def get_backbone(self) -> t.Optional[FeatureStore]:
-        """Create the backbone feature store using the descriptor found in
+        """Attach to the backbone feature store using the descriptor found in
         an environment variable. The backbone is a standalone, system-created
         feature store used to share internal information among MLI components"""
         descriptor = self._backbone_descriptor or os.getenv("SS_DRG_DDICT", None)

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -46,6 +46,15 @@ class EnvironmentConfigLoader:
         callback_factory: t.Callable[[bytes], CommChannelBase],
         queue_factory: t.Callable[[str], CommChannelBase],
     ) -> None:
+        """Initialize the config loader instance with the factories necessary for
+        creating additional objects.
+
+        :param featurestore_factory: A factory method that produces a feature store
+        given a descriptor
+        :param callback_factory: A factory method that produces a callback
+        channel given a descriptor
+        :param featurestore_factory: A factory method that produces a queue
+        channel given a descriptor"""
         self._queue_descriptor: t.Optional[str] = os.getenv("SSQueue", None)
         """The descriptor used to attach to the incoming event queue"""
         self.queue: t.Optional[CommChannelBase] = None
@@ -66,7 +75,8 @@ class EnvironmentConfigLoader:
     def get_backbone(self) -> t.Optional[FeatureStore]:
         """Attach to the backbone feature store using the descriptor found in
         an environment variable. The backbone is a standalone, system-created
-        feature store used to share internal information among MLI components"""
+        feature store used to share internal information among MLI components
+        :returns: The attached feature store via SS_DRG_DDICT"""
         descriptor = self._backbone_descriptor or os.getenv("SS_DRG_DDICT", None)
         if self._featurestore_factory is None:
             logger.warning("No feature store factory is configured")
@@ -78,7 +88,9 @@ class EnvironmentConfigLoader:
         return self.backbone
 
     def get_queue(self) -> t.Optional[CommChannelBase]:
-        """Returns the Queue previously set in SSQueue"""
+        """Attach to a queue-like communication channel using the descriptor
+        found in an environment variable.
+        :returns: The attached queue specified via SSQueue"""
         descriptor = self._queue_descriptor or os.getenv("SSQueue", None)
         if self._queue_factory is None:
             logger.warning("No queue factory is configured")

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -41,9 +41,9 @@ class EnvironmentConfigLoader:
 
     def __init__(
         self,
-        featurestore_factory: t.Optional[t.Callable[[str], FeatureStore]] = None,
-        callback_factory: t.Optional[t.Callable[[bytes], CommChannelBase]] = None,
-        queue_factory: t.Optional[t.Callable[[str], CommChannelBase]] = None,
+        featurestore_factory: t.Callable[[str], FeatureStore],
+        callback_factory: t.Callable[[bytes], CommChannelBase],
+        queue_factory: t.Callable[[str], CommChannelBase],
     ) -> None:
         """Initialize the config loader instance with the factories necessary for
         creating additional objects.

--- a/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
@@ -89,5 +89,5 @@ class DragonFeatureStore(FeatureStore):
         try:
             return DragonFeatureStore(dragon_ddict.DDict.attach(descriptor))
         except:
-            print(f"error creating dragon feature store: {descriptor}")
+            logger.error(f"Error creating dragon feature store: {descriptor}")
             raise

--- a/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
@@ -83,9 +83,10 @@ class DragonFeatureStore(FeatureStore):
     def from_descriptor(
         cls,
         descriptor: str,
-        # b64encoded: bool = False,
     ) -> "DragonFeatureStore":
-
+        """A factory method that creates an instance from a descriptor string
+        :param descriptor: The descriptor that uniquely identifies the resource
+        :returns: An attached DragonFeatureStore"""
         try:
             return DragonFeatureStore(dragon_ddict.DDict.attach(descriptor))
         except:

--- a/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
@@ -59,7 +59,8 @@ class DragonFeatureStore(FeatureStore):
         try:
             value: t.Union[str, bytes] = self._storage[key]
             return value
-        except KeyError as ex:
+        except KeyError:
+            logger.warning(f"An unknown key was requested: {key}")
             raise
         except Exception as ex:
             # note: explicitly avoid round-trip to check for key existence

--- a/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
@@ -69,3 +69,10 @@ class DragonFeatureStore(FeatureStore):
         Return `True` if the key is found, `False` otherwise
         :param key: Unique key of an item to retrieve from the feature store"""
         return key in self._storage
+
+    @property
+    def descriptor(self) -> str:
+        """Return a unique identifier enabling a client to connect to
+        the feature store
+        :returns: A descriptor encoded as a string"""
+        return str(self._storage.serialize())

--- a/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
@@ -26,13 +26,15 @@
 
 import typing as t
 
-import smartsim.error as sse
+# pylint: disable=import-error
+# isort: off
+import dragon.data.ddict.ddict as dragon_ddict
+
+# isort: on
+
 from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStore
+from smartsim.error import SmartSimError
 from smartsim.log import get_logger
-
-if t.TYPE_CHECKING:
-    from dragon.data.ddict.ddict import DDict
-
 
 logger = get_logger(__name__)
 
@@ -40,7 +42,7 @@ logger = get_logger(__name__)
 class DragonFeatureStore(FeatureStore):
     """A feature store backed by a dragon distributed dictionary"""
 
-    def __init__(self, storage: "DDict") -> None:
+    def __init__(self, storage: "dragon_ddict.DDict") -> None:
         """Initialize the DragonFeatureStore instance"""
         self._storage = storage
 
@@ -54,7 +56,7 @@ class DragonFeatureStore(FeatureStore):
             raise ex
         except Exception as ex:
             # note: explicitly avoid round-trip to check for key existence
-            raise sse.SmartSimError(
+            raise SmartSimError(
                 f"Could not get value for existing key {key}, error:\n{ex}"
             ) from ex
 
@@ -76,3 +78,25 @@ class DragonFeatureStore(FeatureStore):
         the feature store
         :returns: A descriptor encoded as a string"""
         return str(self._storage.serialize())
+
+    @classmethod
+    def from_descriptor(
+        cls,
+        descriptor: str,
+        # b64encoded: bool = False,
+    ) -> "DragonFeatureStore":
+        # import dragon.data.ddict.ddict as dragon_ddict  # pylint: disable=import-outside-toplevel
+
+        # # if b64encoded:
+        # #     descriptor = base64.b64decode(descriptor).encode("utf-8")
+        # # ddict = DDict.attach(descriptor)
+        # # ddict.attach(descriptor)
+
+        # storage = dragon_ddict.DDict()
+        # storage.attach(descriptor)
+        # return DragonFeatureStore(storage)
+
+        if descriptor is None:
+            print("foo")
+            return None
+        return DragonFeatureStore({"tmp": "here"})

--- a/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
@@ -85,18 +85,9 @@ class DragonFeatureStore(FeatureStore):
         descriptor: str,
         # b64encoded: bool = False,
     ) -> "DragonFeatureStore":
-        # import dragon.data.ddict.ddict as dragon_ddict  # pylint: disable=import-outside-toplevel
 
-        # # if b64encoded:
-        # #     descriptor = base64.b64decode(descriptor).encode("utf-8")
-        # # ddict = DDict.attach(descriptor)
-        # # ddict.attach(descriptor)
-
-        # storage = dragon_ddict.DDict()
-        # storage.attach(descriptor)
-        # return DragonFeatureStore(storage)
-
-        if descriptor is None:
-            print("foo")
-            return None
-        return DragonFeatureStore({"tmp": "here"})
+        try:
+            return DragonFeatureStore(dragon_ddict.DDict.attach(descriptor))
+        except:
+            print(f"error creating dragon feature store: {descriptor}")
+            raise

--- a/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/dragonfeaturestore.py
@@ -48,6 +48,7 @@ class DragonFeatureStore(FeatureStore):
 
     def __getitem__(self, key: str) -> t.Union[str, bytes]:
         """Retrieve an item using key
+
         :param key: Unique key of an item to retrieve from the feature store"""
         try:
             value: t.Union[str, bytes] = self._storage[key]
@@ -62,20 +63,22 @@ class DragonFeatureStore(FeatureStore):
 
     def __setitem__(self, key: str, value: t.Union[str, bytes]) -> None:
         """Assign a value using key
+
         :param key: Unique key of an item to set in the feature store
         :param value: Value to persist in the feature store"""
         self._storage[key] = value
 
     def __contains__(self, key: str) -> bool:
         """Membership operator to test for a key existing within the feature store.
-        Return `True` if the key is found, `False` otherwise
-        :param key: Unique key of an item to retrieve from the feature store"""
+
+        :param key: Unique key of an item to retrieve from the feature store
+        :returns: `True` if the key is found, `False` otherwise"""
         return key in self._storage
 
     @property
     def descriptor(self) -> str:
-        """Return a unique identifier enabling a client to connect to
-        the feature store
+        """A unique identifier enabling a client to connect to the feature store
+
         :returns: A descriptor encoded as a string"""
         return str(self._storage.serialize())
 
@@ -85,6 +88,7 @@ class DragonFeatureStore(FeatureStore):
         descriptor: str,
     ) -> "DragonFeatureStore":
         """A factory method that creates an instance from a descriptor string
+
         :param descriptor: The descriptor that uniquely identifies the resource
         :returns: An attached DragonFeatureStore"""
         try:

--- a/smartsim/_core/mli/infrastructure/storage/featurestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/featurestore.py
@@ -50,23 +50,26 @@ class FeatureStore(ABC):
     @abstractmethod
     def __getitem__(self, key: str) -> t.Union[str, bytes]:
         """Retrieve an item using key
+
         :param key: Unique key of an item to retrieve from the feature store"""
 
     @abstractmethod
     def __setitem__(self, key: str, value: t.Union[str, bytes]) -> None:
         """Assign a value using key
+
         :param key: Unique key of an item to set in the feature store
         :param value: Value to persist in the feature store"""
 
     @abstractmethod
     def __contains__(self, key: str) -> bool:
         """Membership operator to test for a key existing within the feature store.
-        Return `True` if the key is found, `False` otherwise
-        :param key: Unique key of an item to retrieve from the feature store"""
+
+        :param key: Unique key of an item to retrieve from the feature store
+        :returns: `True` if the key is found, `False` otherwise"""
 
     @property
     @abstractmethod
     def descriptor(self) -> str:
-        """Return a unique identifier enabling a client to connect to
-        the feature store
+        """Unique identifier enabling a client to connect to the feature store
+
         :returns: A descriptor encoded as a string"""

--- a/smartsim/_core/mli/infrastructure/storage/featurestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/featurestore.py
@@ -28,6 +28,16 @@ import typing as t
 from abc import ABC, abstractmethod
 
 
+class FeatureStoreKey:
+    """A key-value pair enabling retrieval of an item in a feature store"""
+
+    def __init__(self, key: str, descriptor: str) -> None:
+        self.key = key
+        """The unique key of an item in the feature store"""
+        self.descriptor = descriptor
+        """The unique identifier of the feature store containing the key"""
+
+
 class FeatureStore(ABC):
     """Abstract base class providing the common interface for retrieving
     values from a feature store implementation"""
@@ -48,3 +58,10 @@ class FeatureStore(ABC):
         """Membership operator to test for a key existing within the feature store.
         Return `True` if the key is found, `False` otherwise
         :param key: Unique key of an item to retrieve from the feature store"""
+
+    @property
+    @abstractmethod
+    def descriptor(self) -> str:
+        """Return a unique identifier enabling a client to connect to
+        the feature store
+        :returns: A descriptor encoded as a string"""

--- a/smartsim/_core/mli/infrastructure/storage/featurestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/featurestore.py
@@ -29,6 +29,10 @@ from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, Field
 
+from smartsim.log import get_logger
+
+logger = get_logger(__name__)
+
 
 class FeatureStoreKey(BaseModel):
     """A key,descriptor pair enabling retrieval of an item from a feature store"""

--- a/smartsim/_core/mli/infrastructure/storage/featurestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/featurestore.py
@@ -27,15 +27,16 @@
 import typing as t
 from abc import ABC, abstractmethod
 
+from pydantic import BaseModel, Field
 
-class FeatureStoreKey:
-    """A key-value pair enabling retrieval of an item in a feature store"""
 
-    def __init__(self, key: str, descriptor: str) -> None:
-        self.key = key
-        """The unique key of an item in the feature store"""
-        self.descriptor = descriptor
-        """The unique identifier of the feature store containing the key"""
+class FeatureStoreKey(BaseModel):
+    """A key,descriptor pair enabling retrieval of an item from a feature store"""
+
+    key: str = Field(min_length=1)
+    """The unique key of an item in a feature store"""
+    descriptor: str = Field(min_length=1)
+    """The unique identifier of the feature store containing the key"""
 
 
 class FeatureStore(ABC):

--- a/smartsim/_core/mli/infrastructure/worker/worker.py
+++ b/smartsim/_core/mli/infrastructure/worker/worker.py
@@ -159,7 +159,7 @@ class MachineLearningWorkerCore:
     @staticmethod
     def deserialize_message(
         data_blob: bytes,
-        channel_type: t.Type[CommChannelBase],
+        callback_factory: t.Callable[[bytes], CommChannelBase],
     ) -> InferenceRequest:
         """Deserialize a message from a byte stream into an InferenceRequest
         :param data_blob: The byte stream to deserialize
@@ -179,7 +179,7 @@ class MachineLearningWorkerCore:
             model_bytes = request.model.data
 
         callback_key = request.replyChannel.descriptor
-        comm_channel = channel_type(callback_key)
+        comm_channel = callback_factory(callback_key)
         input_keys: t.Optional[t.List[FeatureStoreKey]] = None
         input_bytes: t.Optional[t.List[bytes]] = None
         output_keys: t.Optional[t.List[FeatureStoreKey]] = None

--- a/smartsim/_core/mli/infrastructure/worker/worker.py
+++ b/smartsim/_core/mli/infrastructure/worker/worker.py
@@ -163,7 +163,8 @@ class MachineLearningWorkerCore:
     ) -> InferenceRequest:
         """Deserialize a message from a byte stream into an InferenceRequest
         :param data_blob: The byte stream to deserialize
-        :param channel_type: Type to be used for callback communications
+        :param callback_factory: A factory method that can create an instance
+        of the desired concrete comm channel type
         :returns: The raw input message deserialized into an InferenceRequest
         """
         request = MessageHandler.deserialize_request(data_blob)

--- a/smartsim/_core/mli/infrastructure/worker/worker.py
+++ b/smartsim/_core/mli/infrastructure/worker/worker.py
@@ -162,14 +162,18 @@ class MachineLearningWorkerCore:
         channel_type: t.Type[CommChannelBase],
     ) -> InferenceRequest:
         """Deserialize a message from a byte stream into an InferenceRequest
-        :param data_blob: The byte stream to deserialize"""
+        :param data_blob: The byte stream to deserialize
+        :param channel_type: Type to be used for callback communications
+        :returns: The raw input message deserialized into an InferenceRequest
+        """
         request = MessageHandler.deserialize_request(data_blob)
         model_key: t.Optional[FeatureStoreKey] = None
         model_bytes: t.Optional[Model] = None
 
         if request.model.which() == "key":
             model_key = FeatureStoreKey(
-                request.model.key.key, request.model.key.featureStoreDescriptor
+                key=request.model.key.key,
+                descriptor=request.model.key.featureStoreDescriptor,
             )
         elif request.model.which() == "data":
             model_bytes = request.model.data
@@ -183,7 +187,7 @@ class MachineLearningWorkerCore:
 
         if request.input.which() == "keys":
             input_keys = [
-                FeatureStoreKey(value.key, value.featureStoreDescriptor)
+                FeatureStoreKey(key=value.key, descriptor=value.featureStoreDescriptor)
                 for value in request.input.keys
             ]
         elif request.input.which() == "descriptors":
@@ -191,7 +195,7 @@ class MachineLearningWorkerCore:
 
         if request.output:
             output_keys = [
-                FeatureStoreKey(value.key, value.featureStoreDescriptor)
+                FeatureStoreKey(key=value.key, descriptor=value.featureStoreDescriptor)
                 for value in request.output
             ]
 

--- a/smartsim/_core/mli/message_handler.py
+++ b/smartsim/_core/mli/message_handler.py
@@ -99,6 +99,8 @@ class MessageHandler:
         Builds a new TensorKey message with the provided key.
 
         :param key: String to set the TensorKey
+        :param feature_store_descriptor: A descriptor identifying the feature store
+        containing the key
         :raises ValueError: if building fails
         """
         try:
@@ -136,6 +138,8 @@ class MessageHandler:
         Builds a new ModelKey message with the provided key.
 
         :param key: String to set the ModelKey
+        :param feature_store_descriptor: A descriptor identifying the feature store
+        containing the key
         :raises ValueError: if building fails
         """
         try:
@@ -222,8 +226,10 @@ class MessageHandler:
             elif class_name == "ModelKey":
                 request.model.key = model  # type: ignore
             else:
-                raise ValueError("""Invalid custom attribute class name.
-                        Expected 'Model' or 'ModelKey'.""")
+                raise ValueError(
+                    """Invalid custom attribute class name.
+                        Expected 'Model' or 'ModelKey'."""
+                )
         except Exception as e:
             raise ValueError("Error building model portion of request.") from e
 
@@ -267,8 +273,10 @@ class MessageHandler:
                 elif input_class_name == "TensorKey":
                     request.input.keys = inputs  # type: ignore
                 else:
-                    raise ValueError("""Invalid input class name. Expected
-                        'TensorDescriptor' or 'TensorKey'.""")
+                    raise ValueError(
+                        """Invalid input class name. Expected
+                        'TensorDescriptor' or 'TensorKey'."""
+                    )
         except Exception as e:
             raise ValueError("Error building inputs portion of request.") from e
 
@@ -337,9 +345,11 @@ class MessageHandler:
                 elif custom_attribute_class_name == "TensorFlowRequestAttributes":
                     request.customAttributes.tf = custom_attrs  # type: ignore
                 else:
-                    raise ValueError("""Invalid custom attribute class name.
+                    raise ValueError(
+                        """Invalid custom attribute class name.
                         Expected 'TensorFlowRequestAttributes' or
-                        'TorchRequestAttributes'.""")
+                        'TorchRequestAttributes'."""
+                    )
         except Exception as e:
             raise ValueError(
                 "Error building custom attributes portion of request."
@@ -459,8 +469,10 @@ class MessageHandler:
                 elif result_class_name == "TensorKey":
                     response.result.keys = result  # type: ignore
                 else:
-                    raise ValueError("""Invalid custom attribute class name.
-                        Expected 'TensorDescriptor' or 'TensorKey'.""")
+                    raise ValueError(
+                        """Invalid custom attribute class name.
+                        Expected 'TensorDescriptor' or 'TensorKey'."""
+                    )
         except Exception as e:
             raise ValueError("Error assigning result to response.") from e
 
@@ -492,9 +504,11 @@ class MessageHandler:
                 elif custom_attribute_class_name == "TensorFlowResponseAttributes":
                     response.customAttributes.tf = custom_attrs  # type: ignore
                 else:
-                    raise ValueError("""Invalid custom attribute class name.
+                    raise ValueError(
+                        """Invalid custom attribute class name.
                         Expected 'TensorFlowResponseAttributes' or
-                        'TorchResponseAttributes'.""")
+                        'TorchResponseAttributes'."""
+                    )
         except Exception as e:
             raise ValueError("Error assigning custom attributes to response.") from e
 

--- a/smartsim/_core/mli/message_handler.py
+++ b/smartsim/_core/mli/message_handler.py
@@ -226,10 +226,8 @@ class MessageHandler:
             elif class_name == "ModelKey":
                 request.model.key = model  # type: ignore
             else:
-                raise ValueError(
-                    """Invalid custom attribute class name.
-                        Expected 'Model' or 'ModelKey'."""
-                )
+                raise ValueError("""Invalid custom attribute class name.
+                        Expected 'Model' or 'ModelKey'.""")
         except Exception as e:
             raise ValueError("Error building model portion of request.") from e
 
@@ -273,10 +271,8 @@ class MessageHandler:
                 elif input_class_name == "TensorKey":
                     request.input.keys = inputs  # type: ignore
                 else:
-                    raise ValueError(
-                        """Invalid input class name. Expected
-                        'TensorDescriptor' or 'TensorKey'."""
-                    )
+                    raise ValueError("""Invalid input class name. Expected
+                        'TensorDescriptor' or 'TensorKey'.""")
         except Exception as e:
             raise ValueError("Error building inputs portion of request.") from e
 
@@ -345,11 +341,9 @@ class MessageHandler:
                 elif custom_attribute_class_name == "TensorFlowRequestAttributes":
                     request.customAttributes.tf = custom_attrs  # type: ignore
                 else:
-                    raise ValueError(
-                        """Invalid custom attribute class name.
+                    raise ValueError("""Invalid custom attribute class name.
                         Expected 'TensorFlowRequestAttributes' or
-                        'TorchRequestAttributes'."""
-                    )
+                        'TorchRequestAttributes'.""")
         except Exception as e:
             raise ValueError(
                 "Error building custom attributes portion of request."
@@ -469,10 +463,8 @@ class MessageHandler:
                 elif result_class_name == "TensorKey":
                     response.result.keys = result  # type: ignore
                 else:
-                    raise ValueError(
-                        """Invalid custom attribute class name.
-                        Expected 'TensorDescriptor' or 'TensorKey'."""
-                    )
+                    raise ValueError("""Invalid custom attribute class name.
+                        Expected 'TensorDescriptor' or 'TensorKey'.""")
         except Exception as e:
             raise ValueError("Error assigning result to response.") from e
 
@@ -504,11 +496,9 @@ class MessageHandler:
                 elif custom_attribute_class_name == "TensorFlowResponseAttributes":
                     response.customAttributes.tf = custom_attrs  # type: ignore
                 else:
-                    raise ValueError(
-                        """Invalid custom attribute class name.
+                    raise ValueError("""Invalid custom attribute class name.
                         Expected 'TensorFlowResponseAttributes' or
-                        'TorchResponseAttributes'."""
-                    )
+                        'TorchResponseAttributes'.""")
         except Exception as e:
             raise ValueError("Error assigning custom attributes to response.") from e
 

--- a/smartsim/_core/mli/message_handler.py
+++ b/smartsim/_core/mli/message_handler.py
@@ -439,6 +439,7 @@ class MessageHandler:
         result: t.Union[
             t.List[tensor_capnp.TensorDescriptor],
             t.List[data_references_capnp.TensorKey],
+            None,
         ],
     ) -> None:
         """
@@ -504,7 +505,7 @@ class MessageHandler:
         result: t.Union[
             t.List[tensor_capnp.TensorDescriptor],
             t.List[data_references_capnp.TensorKey],
-            None
+            None,
         ],
         custom_attributes: t.Union[
             response_attributes_capnp.TorchResponseAttributes,

--- a/smartsim/_core/mli/message_handler.py
+++ b/smartsim/_core/mli/message_handler.py
@@ -92,7 +92,9 @@ class MessageHandler:
         return description
 
     @staticmethod
-    def build_tensor_key(key: str) -> data_references_capnp.TensorKey:
+    def build_tensor_key(
+        key: str, feature_store_descriptor: str
+    ) -> data_references_capnp.TensorKey:
         """
         Builds a new TensorKey message with the provided key.
 
@@ -102,6 +104,7 @@ class MessageHandler:
         try:
             tensor_key = data_references_capnp.TensorKey.new_message()
             tensor_key.key = key
+            tensor_key.featureStoreDescriptor = feature_store_descriptor
         except Exception as e:
             raise ValueError("Error building tensor key.") from e
         return tensor_key
@@ -126,7 +129,9 @@ class MessageHandler:
         return model
 
     @staticmethod
-    def build_model_key(key: str) -> data_references_capnp.ModelKey:
+    def build_model_key(
+        key: str, feature_store_descriptor: str
+    ) -> data_references_capnp.ModelKey:
         """
         Builds a new ModelKey message with the provided key.
 
@@ -136,6 +141,7 @@ class MessageHandler:
         try:
             model_key = data_references_capnp.ModelKey.new_message()
             model_key.key = key
+            model_key.featureStoreDescriptor = feature_store_descriptor
         except Exception as e:
             raise ValueError("Error building model key.") from e
         return model_key
@@ -498,6 +504,7 @@ class MessageHandler:
         result: t.Union[
             t.List[tensor_capnp.TensorDescriptor],
             t.List[data_references_capnp.TensorKey],
+            None
         ],
         custom_attributes: t.Union[
             response_attributes_capnp.TorchResponseAttributes,

--- a/smartsim/_core/mli/mli_schemas/data/data_references.capnp
+++ b/smartsim/_core/mli/mli_schemas/data/data_references.capnp
@@ -28,8 +28,10 @@
 
 struct ModelKey {
   key @0 :Text;
+  featureStoreDescriptor @1 :Text;
 }
 
 struct TensorKey {
   key @0 :Text;
+  featureStoreDescriptor @1 :Text;
 }

--- a/smartsim/_core/mli/mli_schemas/data/data_references_capnp.pyi
+++ b/smartsim/_core/mli/mli_schemas/data/data_references_capnp.pyi
@@ -36,6 +36,7 @@ from typing import Iterator
 
 class ModelKey:
     key: str
+    featureStoreDescriptor: str
     @staticmethod
     @contextmanager
     def from_bytes(
@@ -71,6 +72,7 @@ class ModelKeyBuilder(ModelKey):
 
 class TensorKey:
     key: str
+    featureStoreDescriptor: str
     @staticmethod
     @contextmanager
     def from_bytes(

--- a/tests/dragon/featurestore.py
+++ b/tests/dragon/featurestore.py
@@ -130,10 +130,10 @@ class FileSystemFeatureStore(FeatureStore):
     def from_descriptor(
         cls,
         descriptor: str,
-        # b64encoded: bool = False,
     ) -> "FileSystemFeatureStore":
-        # if b64encoded:
-        #     descriptor = base64.b64decode(descriptor).encode("utf-8")
+        """A factory method that creates an instance from a descriptor string
+        :param descriptor: The descriptor that uniquely identifies the resource
+        :returns: An attached FileSystemFeatureStore"""
         try:
             path = pathlib.Path(descriptor)
             path.mkdir(parents=True, exist_ok=True)

--- a/tests/dragon/featurestore.py
+++ b/tests/dragon/featurestore.py
@@ -115,7 +115,24 @@ class FileSystemFeatureStore(FeatureStore):
         """Return a unique identifier enabling a client to connect to
         the feature store
         :returns: A descriptor encoded as a string"""
-        return "in-memory-fs"
+        if not self._storage_dir:
+            raise ValueError("No storage path configured")
+        return self._storage_dir.as_posix()
+
+    @classmethod
+    def from_descriptor(
+        cls,
+        descriptor: str,
+        # b64encoded: bool = False,
+    ) -> "FileSystemFeatureStore":
+        # if b64encoded:
+        #     descriptor = base64.b64decode(descriptor).encode("utf-8")
+        path = pathlib.Path(descriptor)
+        if not path.is_dir():
+            raise ValueError("FileSystemFeatureStore requires a directory path")
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+        return FileSystemFeatureStore(path)
 
 
 class DragonDict:

--- a/tests/dragon/featurestore.py
+++ b/tests/dragon/featurestore.py
@@ -57,6 +57,13 @@ class MemoryFeatureStore(FeatureStore):
         :param key: Unique key of an item to retrieve from the feature store"""
         return key in self._storage
 
+    @property
+    def descriptor(self) -> str:
+        """Return a unique identifier enabling a client to connect to
+        the feature store
+        :returns: A descriptor encoded as a string"""
+        return "file-system-fs"
+
 
 class FileSystemFeatureStore(FeatureStore):
     """Alternative feature store implementation for testing. Stores all
@@ -102,6 +109,13 @@ class FileSystemFeatureStore(FeatureStore):
             value.parent.mkdir(parents=True, exist_ok=True)
 
         return value
+
+    @property
+    def descriptor(self) -> str:
+        """Return a unique identifier enabling a client to connect to
+        the feature store
+        :returns: A descriptor encoded as a string"""
+        return "in-memory-fs"
 
 
 class DragonDict:

--- a/tests/dragon/featurestore.py
+++ b/tests/dragon/featurestore.py
@@ -43,6 +43,7 @@ class MemoryFeatureStore(FeatureStore):
 
     def __getitem__(self, key: str) -> bytes:
         """Retrieve an item using key
+
         :param key: Unique key of an item to retrieve from the feature store"""
         if key not in self._storage:
             raise sse.SmartSimError(f"{key} not found in feature store")
@@ -50,20 +51,22 @@ class MemoryFeatureStore(FeatureStore):
 
     def __setitem__(self, key: str, value: bytes) -> None:
         """Membership operator to test for a key existing within the feature store.
-        Return `True` if the key is found, `False` otherwise
-        :param key: Unique key of an item to retrieve from the feature store"""
+
+        :param key: Unique key of an item to retrieve from the feature store
+        :returns: `True` if the key is found, `False` otherwise"""
         self._storage[key] = value
 
     def __contains__(self, key: str) -> bool:
         """Membership operator to test for a key existing within the feature store.
-        Return `True` if the key is found, `False` otherwise
-        :param key: Unique key of an item to retrieve from the feature store"""
+
+        :param key: Unique key of an item to retrieve from the feature store
+        :returns: `True` if the key is found, `False` otherwise"""
         return key in self._storage
 
     @property
     def descriptor(self) -> str:
-        """Return a unique identifier enabling a client to connect to
-        the feature store
+        """Unique identifier enabling a client to connect to the feature store
+
         :returns: A descriptor encoded as a string"""
         return "file-system-fs"
 
@@ -76,6 +79,7 @@ class FileSystemFeatureStore(FeatureStore):
         self, storage_dir: t.Optional[t.Union[pathlib.Path, str]] = None
     ) -> None:
         """Initialize the FileSystemFeatureStore instance
+
         :param storage_dir: (optional) root directory to store all data relative to"""
         if isinstance(storage_dir, str):
             storage_dir = pathlib.Path(storage_dir)
@@ -83,6 +87,7 @@ class FileSystemFeatureStore(FeatureStore):
 
     def __getitem__(self, key: str) -> bytes:
         """Retrieve an item using key
+
         :param key: Unique key of an item to retrieve from the feature store"""
         path = self._key_path(key)
         if not path.exists():
@@ -91,6 +96,7 @@ class FileSystemFeatureStore(FeatureStore):
 
     def __setitem__(self, key: str, value: bytes) -> None:
         """Assign a value using key
+
         :param key: Unique key of an item to set in the feature store
         :param value: Value to persist in the feature store"""
         path = self._key_path(key, create=True)
@@ -98,14 +104,16 @@ class FileSystemFeatureStore(FeatureStore):
 
     def __contains__(self, key: str) -> bool:
         """Membership operator to test for a key existing within the feature store.
-        Return `True` if the key is found, `False` otherwise
-        :param key: Unique key of an item to retrieve from the feature store"""
+
+        :param key: Unique key of an item to retrieve from the feature store
+        :returns: `True` if the key is found, `False` otherwise"""
         path = self._key_path(key)
         return path.exists()
 
     def _key_path(self, key: str, create: bool = False) -> pathlib.Path:
         """Given a key, return a path that is optionally combined with a base
         directory used by the FileSystemFeatureStore.
+
         :param key: Unique key of an item to retrieve from the feature store"""
         value = pathlib.Path(key)
 
@@ -119,8 +127,8 @@ class FileSystemFeatureStore(FeatureStore):
 
     @property
     def descriptor(self) -> str:
-        """Return a unique identifier enabling a client to connect to
-        the feature store
+        """Unique identifier enabling a client to connect to the feature store
+
         :returns: A descriptor encoded as a string"""
         if not self._storage_dir:
             raise ValueError("No storage path configured")
@@ -132,6 +140,7 @@ class FileSystemFeatureStore(FeatureStore):
         descriptor: str,
     ) -> "FileSystemFeatureStore":
         """A factory method that creates an instance from a descriptor string
+
         :param descriptor: The descriptor that uniquely identifies the resource
         :returns: An attached FileSystemFeatureStore"""
         try:

--- a/tests/dragon/test_environment_loader.py
+++ b/tests/dragon/test_environment_loader.py
@@ -24,11 +24,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import pathlib
-
 import pytest
 
-from tests.mli.channel import FileSystemCommChannel
 
 dragon = pytest.importorskip("dragon")
 
@@ -42,7 +39,8 @@ from smartsim._core.mli.infrastructure.storage.dragonfeaturestore import (
     DragonFeatureStore,
 )
 
-from .featurestore import FileSystemFeatureStore
+from smartsim._core.mli.comm.channel.dragonchannel import DragonCommChannel
+
 
 # The tests in this file belong to the dragon group
 pytestmark = pytest.mark.dragon
@@ -63,8 +61,8 @@ def test_environment_loader_attach_FLI(content: bytes, monkeypatch: pytest.Monke
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
-        callback_factory=FileSystemCommChannel.from_descriptor,
-        queue_factory=FileSystemCommChannel.from_descriptor,
+        callback_factory=DragonCommChannel.from_descriptor,
+        queue_factory=DragonCommChannel.from_descriptor,
     )
     config_queue = config.get_queue()
 
@@ -84,8 +82,8 @@ def test_environment_loader_serialize_FLI(monkeypatch: pytest.MonkeyPatch):
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
-        callback_factory=FileSystemCommChannel.from_descriptor,
-        queue_factory=FileSystemCommChannel.from_descriptor,
+        callback_factory=DragonCommChannel.from_descriptor,
+        queue_factory=DragonCommChannel.from_descriptor,
     )
     config_queue = config.get_queue()
     assert config_queue._fli.serialize() == queue.serialize()
@@ -96,8 +94,8 @@ def test_environment_loader_FLI_fails(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("SSQueue", "randomstring")
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
-        callback_factory=FileSystemCommChannel.from_descriptor,
-        queue_factory=FileSystemCommChannel.from_descriptor,
+        callback_factory=DragonCommChannel.from_descriptor,
+        queue_factory=DragonCommChannel.from_descriptor,
     )
 
     with pytest.raises(DragonFLIError):
@@ -109,13 +107,13 @@ def test_environment_loader_backbone_load_fs(
 ):
     """Verify the file system feature store is loaded correctly by
     the EnvironmentConfigLoader to demonstrate fs_factory correctness"""
-    fs = FileSystemFeatureStore(pathlib.Path(test_dir))
+    fs = DragonFeatureStore(DDict())
     monkeypatch.setenv("SS_DRG_DDICT", fs.descriptor)
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
-        callback_factory=FileSystemCommChannel.from_descriptor,
-        queue_factory=FileSystemCommChannel.from_descriptor,
+        callback_factory=DragonCommChannel.from_descriptor,
+        queue_factory=DragonCommChannel.from_descriptor,
     )
 
     backbone = config.get_backbone()
@@ -132,8 +130,8 @@ def test_environment_loader_backbone_load_dfs(
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
-        callback_factory=FileSystemCommChannel.from_descriptor,
-        queue_factory=FileSystemCommChannel.from_descriptor,
+        callback_factory=DragonCommChannel.from_descriptor,
+        queue_factory=DragonCommChannel.from_descriptor,
     )
 
     backbone = config.get_backbone()
@@ -145,8 +143,8 @@ def test_environment_variables_not_set():
     variables are not set"""
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
-        callback_factory=FileSystemCommChannel.from_descriptor,
-        queue_factory=FileSystemCommChannel.from_descriptor,
+        callback_factory=DragonCommChannel.from_descriptor,
+        queue_factory=DragonCommChannel.from_descriptor,
     )
     assert config.get_backbone() == None
     assert config.get_queue() == None

--- a/tests/dragon/test_environment_loader.py
+++ b/tests/dragon/test_environment_loader.py
@@ -112,6 +112,8 @@ def test_environment_loader_backbone_load_dfs(monkeypatch: pytest.MonkeyPatch):
         queue_factory=None,
     )
 
+    print(f"calling config.get_backbone: `{feature_store.descriptor}`")
+
     backbone = config.get_backbone()
     assert backbone is not None
 

--- a/tests/dragon/test_environment_loader.py
+++ b/tests/dragon/test_environment_loader.py
@@ -101,10 +101,10 @@ def test_environment_loader_flifails(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_environment_loader_backbone_load_dfs(monkeypatch: pytest.MonkeyPatch):
-    """Verify the dragon feature store is loaded correctly by
-    the EnvironmentConfigLoader to demonstrate fs_factory correctness"""
+    """Verify the dragon feature store is loaded correctly by the
+    EnvironmentConfigLoader to demonstrate featurestore_factory correctness"""
     feature_store = DragonFeatureStore(DDict())
-    monkeypatch.setenv("SS_DRG_DDICT", feature_store.descriptor)
+    monkeypatch.setenv("SS_INFRA_BACKBONE", feature_store.descriptor)
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,

--- a/tests/dragon/test_environment_loader.py
+++ b/tests/dragon/test_environment_loader.py
@@ -55,7 +55,7 @@ def test_environment_loader_attach_fli(content: bytes, monkeypatch: pytest.Monke
     """A descriptor can be stored, loaded, and reattached"""
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SSQueue", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv("SS_QUEUE", du.B64.bytes_to_str(queue.serialize()))
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
@@ -76,7 +76,7 @@ def test_environment_loader_serialize_fli(monkeypatch: pytest.MonkeyPatch):
     queue are the same"""
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SSQueue", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv("SS_QUEUE", du.B64.bytes_to_str(queue.serialize()))
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
@@ -89,7 +89,7 @@ def test_environment_loader_serialize_fli(monkeypatch: pytest.MonkeyPatch):
 
 def test_environment_loader_flifails(monkeypatch: pytest.MonkeyPatch):
     """An incorrect serialized descriptor will fails to attach"""
-    monkeypatch.setenv("SSQueue", "randomstring")
+    monkeypatch.setenv("SS_QUEUE", "randomstring")
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
         callback_factory=None,

--- a/tests/dragon/test_environment_loader.py
+++ b/tests/dragon/test_environment_loader.py
@@ -27,8 +27,12 @@
 import base64
 import os
 import pickle
+import typing as t
 
 import pytest
+
+from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStore
+from smartsim.error.errors import SmartSimError
 
 dragon = pytest.importorskip("dragon")
 
@@ -42,7 +46,7 @@ from smartsim._core.mli.infrastructure.storage.dragonfeaturestore import (
     DragonFeatureStore,
 )
 
-from .utils.featurestore import MemoryFeatureStore
+from .featurestore import FileSystemFeatureStore, MemoryFeatureStore
 
 # The tests in this file belong to the dragon group
 pytestmark = pytest.mark.dragon
@@ -93,59 +97,70 @@ def test_environment_loader_FLI_fails(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "expected_keys, expected_values",
+    "feature_stores",
     [
-        pytest.param(["key1", "key2", "key3"], ["value1", "value2", "value3"]),
-        pytest.param(["another key"], ["another value"]),
+        pytest.param([], id="No feature stores"),
+        pytest.param([MemoryFeatureStore()], id="Single feature store"),
+        pytest.param(
+            [MemoryFeatureStore(), FileSystemFeatureStore()],
+            id="Multiple feature stores",
+        ),
     ],
 )
-def test_environment_loader_memory_featurestore(
-    expected_keys, expected_values, monkeypatch
+def test_environment_loader_featurestores(
+    feature_stores: t.List[FeatureStore], monkeypatch: pytest.MonkeyPatch
 ):
-    """MemoryFeatureStores can be correctly serialized and deserialized"""
-    feature_store = MemoryFeatureStore()
-    key_value_pairs = zip(expected_keys, expected_values)
-    for k, v in key_value_pairs:
-        feature_store[k] = v
-    monkeypatch.setenv(
-        "SSFeatureStore", base64.b64encode(pickle.dumps(feature_store)).decode("utf-8")
-    )
-    config = EnvironmentConfigLoader()
-    config_feature_store = config.get_feature_store()
+    """FeatureStore can be correctly identified, serialized and deserialized"""
+    with monkeypatch.context() as m:
+        for fs in feature_stores:
+            value = base64.b64encode(pickle.dumps(fs)).decode("utf-8")
+            key = f"SSFeatureStore.{fs.descriptor}"
+            m.setenv(key, value)
 
-    for k, _ in key_value_pairs:
-        assert config_feature_store[k] == feature_store[k]
+        config = EnvironmentConfigLoader()
+        actual_feature_stores = config.get_feature_stores()
+
+        for fs in feature_stores:
+            # Confirm that the descriptors were used as keys in the loaded feature stores
+            assert fs.descriptor in actual_feature_stores
+
+            # Confirm that the value loaded from env var is a FeatureStore
+            # and it is consistent w/the key identifying it
+            loaded_fs = actual_feature_stores[fs.descriptor]
+            assert loaded_fs.descriptor == fs.descriptor
 
 
 @pytest.mark.parametrize(
-    "expected_keys, expected_values",
+    "value_to_use,error_filter",
     [
-        pytest.param(["key1", "key2", "key3"], ["value1", "value2", "value3"]),
-        pytest.param(["another key"], ["another value"]),
+        pytest.param("", "empty", id="Empty value"),
+        pytest.param("abcd", "invalid", id="Incorrectly serialized value"),
     ],
 )
-def test_environment_loader_dragon_featurestore(
-    expected_keys, expected_values, monkeypatch
+def test_environment_loader_featurestores_errors(
+    value_to_use: str, error_filter: str, monkeypatch: pytest.MonkeyPatch
 ):
-    """DragonFeatureStores can be correctly serialized and deserialized"""
-    storage = DDict()
-    feature_store = DragonFeatureStore(storage)
-    key_value_pairs = zip(expected_keys, expected_values)
-    for k, v in key_value_pairs:
-        feature_store[k] = v
-    monkeypatch.setenv(
-        "SSFeatureStore", base64.b64encode(pickle.dumps(feature_store)).decode("utf-8")
-    )
-    config = EnvironmentConfigLoader()
-    config_feature_store = config.get_feature_store()
+    """Verify that the environment loader reports an error when a feature store
+    env var is populated with something that cannot be loaded properly"""
 
-    for k, _ in key_value_pairs:
-        assert config_feature_store[k] == feature_store[k]
+    fs = FileSystemFeatureStore()  # just use for descriptor...
+    key = f"SSFeatureStore.{fs.descriptor}"
+
+    with monkeypatch.context() as m, pytest.raises(SmartSimError) as ex:
+        m.setenv(key, value_to_use)  # <----- simulate incorrect value in env var
+
+        config = EnvironmentConfigLoader()
+        config.get_feature_stores()  # <---- kick off validation
+
+    # confirm the specific key is reported in error message
+    assert key in ex.value.args[0]
+    # ensure the failure occurred during loading
+    assert error_filter in ex.value.args[0].lower()
 
 
 def test_environment_variables_not_set():
     """EnvironmentConfigLoader getters return None when environment
     variables are not set"""
     config = EnvironmentConfigLoader()
-    assert config.get_feature_store() == None
+    assert config.get_feature_stores() == {}
     assert config.get_queue() == None

--- a/tests/dragon/test_environment_loader.py
+++ b/tests/dragon/test_environment_loader.py
@@ -55,7 +55,7 @@ def test_environment_loader_attach_fli(content: bytes, monkeypatch: pytest.Monke
     """A descriptor can be stored, loaded, and reattached"""
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SS_QUEUE", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv("SS_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize()))
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
@@ -76,7 +76,7 @@ def test_environment_loader_serialize_fli(monkeypatch: pytest.MonkeyPatch):
     queue are the same"""
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SS_QUEUE", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv("SS_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize()))
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
@@ -89,7 +89,7 @@ def test_environment_loader_serialize_fli(monkeypatch: pytest.MonkeyPatch):
 
 def test_environment_loader_flifails(monkeypatch: pytest.MonkeyPatch):
     """An incorrect serialized descriptor will fails to attach"""
-    monkeypatch.setenv("SS_QUEUE", "randomstring")
+    monkeypatch.setenv("SS_REQUEST_QUEUE", "randomstring")
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
         callback_factory=None,

--- a/tests/dragon/test_error_handling.py
+++ b/tests/dragon/test_error_handling.py
@@ -28,7 +28,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel
 
 dragon = pytest.importorskip("dragon")
 
@@ -37,6 +36,7 @@ from dragon.channels import Channel
 from dragon.data.ddict.ddict import DDict
 from dragon.fli import FLInterface
 
+from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel
 from smartsim._core.mli.infrastructure.control.workermanager import (
     WorkerManager,
     exception_handler,

--- a/tests/dragon/test_error_handling.py
+++ b/tests/dragon/test_error_handling.py
@@ -28,7 +28,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 dragon = pytest.importorskip("dragon")
 
 import dragon.utils as du

--- a/tests/dragon/test_error_handling.py
+++ b/tests/dragon/test_error_handling.py
@@ -84,7 +84,7 @@ def setup_worker_manager_model_bytes(test_dir, monkeypatch: pytest.MonkeyPatch):
         comm_channel_type=FileSystemCommChannel,
     )
 
-    tensor_key = MessageHandler.build_tensor_key("key")
+    tensor_key = MessageHandler.build_tensor_key("key", feature_store.descriptor)
     model = MessageHandler.build_model(b"model", "model name", "v 0.0.1")
     request = MessageHandler.build_request(
         test_dir, model, [tensor_key], [tensor_key], [], None
@@ -116,8 +116,8 @@ def setup_worker_manager_model_key(test_dir, monkeypatch: pytest.MonkeyPatch):
         comm_channel_type=FileSystemCommChannel,
     )
 
-    tensor_key = MessageHandler.build_tensor_key("key")
-    model_key = MessageHandler.build_model_key("model key")
+    tensor_key = MessageHandler.build_tensor_key("key", feature_store.descriptor)
+    model_key = MessageHandler.build_model_key("model key", feature_store.descriptor)
     request = MessageHandler.build_request(
         test_dir, model_key, [tensor_key], [tensor_key], [], None
     )

--- a/tests/dragon/test_error_handling.py
+++ b/tests/dragon/test_error_handling.py
@@ -24,11 +24,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import base64
-import pickle
 from unittest.mock import MagicMock
 
 import pytest
+
+from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel
 
 dragon = pytest.importorskip("dragon")
 
@@ -45,6 +45,7 @@ from smartsim._core.mli.infrastructure.environmentloader import EnvironmentConfi
 from smartsim._core.mli.infrastructure.storage.dragonfeaturestore import (
     DragonFeatureStore,
 )
+from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStore
 from smartsim._core.mli.infrastructure.worker.worker import (
     ExecuteResult,
     FetchInputResult,
@@ -64,30 +65,51 @@ pytestmark = pytest.mark.dragon
 
 
 @pytest.fixture
-def setup_worker_manager_model_bytes(test_dir, monkeypatch: pytest.MonkeyPatch):
+def backbone_descriptor() -> str:
+    # create a shared backbone featurestore
+    feature_store = DragonFeatureStore(DDict())
+    return feature_store.descriptor
+
+
+@pytest.fixture
+def app_feature_store() -> FeatureStore:
+    # create a standalone feature store to mimic a user application putting
+    # data into an application-owned resource (app should not access backbone)
+    app_fs = DragonFeatureStore(DDict())
+    return app_fs
+
+
+@pytest.fixture
+def setup_worker_manager_model_bytes(
+    test_dir,
+    monkeypatch: pytest.MonkeyPatch,
+    backbone_descriptor: str,
+    app_feature_store: FeatureStore,
+):
     integrated_worker = IntegratedTorchWorker()
 
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
     monkeypatch.setenv("SSQueue", du.B64.bytes_to_str(queue.serialize()))
-    storage = DDict()
-    feature_store = DragonFeatureStore(storage)
-    monkeypatch.setenv(
-        "SSFeatureStore", base64.b64encode(pickle.dumps(feature_store)).decode("utf-8")
-    )
+    # Put backbone descriptor into env var for the `EnvironmentConfigLoader`
+    monkeypatch.setenv("SS_DRG_DDICT", backbone_descriptor)
 
     worker_manager = WorkerManager(
-        EnvironmentConfigLoader(),
+        EnvironmentConfigLoader(
+            featurestore_factory=DragonFeatureStore.from_descriptor,
+            callback_factory=FileSystemCommChannel.from_descriptor,
+            queue_factory=DragonFLIChannel.from_descriptor,
+        ),
         integrated_worker,
         as_service=False,
         cooldown=3,
-        comm_channel_type=FileSystemCommChannel,
     )
 
-    tensor_key = MessageHandler.build_tensor_key("key", feature_store.descriptor)
+    tensor_key = MessageHandler.build_tensor_key("key", app_feature_store.descriptor)
+    output_key = MessageHandler.build_tensor_key("key", f"{test_dir}/out")
     model = MessageHandler.build_model(b"model", "model name", "v 0.0.1")
     request = MessageHandler.build_request(
-        test_dir, model, [tensor_key], [tensor_key], [], None
+        test_dir, model, [tensor_key], [output_key], [], None
     )
     ser_request = MessageHandler.serialize_request(request)
     worker_manager._task_queue.send(ser_request)
@@ -96,30 +118,38 @@ def setup_worker_manager_model_bytes(test_dir, monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
-def setup_worker_manager_model_key(test_dir, monkeypatch: pytest.MonkeyPatch):
+def setup_worker_manager_model_key(
+    test_dir: str,
+    monkeypatch: pytest.MonkeyPatch,
+    backbone_descriptor: str,
+    app_feature_store: FeatureStore,
+):
     integrated_worker = IntegratedTorchWorker()
 
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
     monkeypatch.setenv("SSQueue", du.B64.bytes_to_str(queue.serialize()))
-    storage = DDict()
-    feature_store = DragonFeatureStore(storage)
-    monkeypatch.setenv(
-        "SSFeatureStore", base64.b64encode(pickle.dumps(feature_store)).decode("utf-8")
-    )
+    # Put backbone descriptor into env var for the `EnvironmentConfigLoader`
+    monkeypatch.setenv("SS_DRG_DDICT", backbone_descriptor)
 
     worker_manager = WorkerManager(
-        EnvironmentConfigLoader(),
+        EnvironmentConfigLoader(
+            featurestore_factory=DragonFeatureStore.from_descriptor,
+            callback_factory=FileSystemCommChannel.from_descriptor,
+            queue_factory=DragonFLIChannel.from_descriptor,
+        ),
         integrated_worker,
         as_service=False,
         cooldown=3,
-        comm_channel_type=FileSystemCommChannel,
     )
 
-    tensor_key = MessageHandler.build_tensor_key("key", feature_store.descriptor)
-    model_key = MessageHandler.build_model_key("model key", feature_store.descriptor)
+    tensor_key = MessageHandler.build_tensor_key("key", app_feature_store.descriptor)
+    output_key = MessageHandler.build_tensor_key("key", f"{test_dir}/out")
+    model_key = MessageHandler.build_model_key(
+        "model key", app_feature_store.descriptor
+    )
     request = MessageHandler.build_request(
-        test_dir, model_key, [tensor_key], [tensor_key], [], None
+        test_dir, model_key, [tensor_key], [output_key], [], None
     )
     ser_request = MessageHandler.serialize_request(request)
     worker_manager._task_queue.send(ser_request)
@@ -162,7 +192,11 @@ def mock_pipeline_stage(monkeypatch: pytest.MonkeyPatch, integrated_worker, stag
         pytest.param(
             "fetch_model", "Failed while fetching the model.", id="fetch model"
         ),
-        pytest.param("load_model", "Failed while loading the model.", id="load model"),
+        pytest.param(
+            "load_model",
+            "Failed while loading model from feature store.",
+            id="load model",
+        ),
         pytest.param(
             "fetch_inputs", "Failed while fetching the inputs.", id="fetch inputs"
         ),

--- a/tests/dragon/test_error_handling.py
+++ b/tests/dragon/test_error_handling.py
@@ -91,7 +91,7 @@ def setup_worker_manager_model_bytes(
     queue = FLInterface(main_ch=chan)
     monkeypatch.setenv("SSQueue", du.B64.bytes_to_str(queue.serialize()))
     # Put backbone descriptor into env var for the `EnvironmentConfigLoader`
-    monkeypatch.setenv("SS_DRG_DDICT", backbone_descriptor)
+    monkeypatch.setenv("SS_INFRA_BACKBONE", backbone_descriptor)
 
     worker_manager = WorkerManager(
         EnvironmentConfigLoader(
@@ -129,7 +129,7 @@ def setup_worker_manager_model_key(
     queue = FLInterface(main_ch=chan)
     monkeypatch.setenv("SSQueue", du.B64.bytes_to_str(queue.serialize()))
     # Put backbone descriptor into env var for the `EnvironmentConfigLoader`
-    monkeypatch.setenv("SS_DRG_DDICT", backbone_descriptor)
+    monkeypatch.setenv("SS_INFRA_BACKBONE", backbone_descriptor)
 
     worker_manager = WorkerManager(
         EnvironmentConfigLoader(

--- a/tests/dragon/test_error_handling.py
+++ b/tests/dragon/test_error_handling.py
@@ -106,7 +106,7 @@ def setup_worker_manager_model_bytes(
     )
 
     tensor_key = MessageHandler.build_tensor_key("key", app_feature_store.descriptor)
-    output_key = MessageHandler.build_tensor_key("key", f"{test_dir}/out")
+    output_key = MessageHandler.build_tensor_key("key", app_feature_store.descriptor)
     model = MessageHandler.build_model(b"model", "model name", "v 0.0.1")
     request = MessageHandler.build_request(
         test_dir, model, [tensor_key], [output_key], [], None
@@ -144,7 +144,7 @@ def setup_worker_manager_model_key(
     )
 
     tensor_key = MessageHandler.build_tensor_key("key", app_feature_store.descriptor)
-    output_key = MessageHandler.build_tensor_key("key", f"{test_dir}/out")
+    output_key = MessageHandler.build_tensor_key("key", app_feature_store.descriptor)
     model_key = MessageHandler.build_model_key(
         "model key", app_feature_store.descriptor
     )

--- a/tests/dragon/test_error_handling.py
+++ b/tests/dragon/test_error_handling.py
@@ -89,7 +89,7 @@ def setup_worker_manager_model_bytes(
 
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SS_QUEUE", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv("SS_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize()))
     # Put backbone descriptor into env var for the `EnvironmentConfigLoader`
     monkeypatch.setenv("SS_INFRA_BACKBONE", backbone_descriptor)
 
@@ -127,7 +127,7 @@ def setup_worker_manager_model_key(
 
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SS_QUEUE", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv("SS_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize()))
     # Put backbone descriptor into env var for the `EnvironmentConfigLoader`
     monkeypatch.setenv("SS_INFRA_BACKBONE", backbone_descriptor)
 

--- a/tests/dragon/test_error_handling.py
+++ b/tests/dragon/test_error_handling.py
@@ -89,7 +89,7 @@ def setup_worker_manager_model_bytes(
 
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SSQueue", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv("SS_QUEUE", du.B64.bytes_to_str(queue.serialize()))
     # Put backbone descriptor into env var for the `EnvironmentConfigLoader`
     monkeypatch.setenv("SS_INFRA_BACKBONE", backbone_descriptor)
 
@@ -127,7 +127,7 @@ def setup_worker_manager_model_key(
 
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SSQueue", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv("SS_QUEUE", du.B64.bytes_to_str(queue.serialize()))
     # Put backbone descriptor into env var for the `EnvironmentConfigLoader`
     monkeypatch.setenv("SS_INFRA_BACKBONE", backbone_descriptor)
 

--- a/tests/dragon/test_reply_building.py
+++ b/tests/dragon/test_reply_building.py
@@ -30,10 +30,7 @@ import pytest
 
 dragon = pytest.importorskip("dragon")
 
-from smartsim._core.mli.infrastructure.control.workermanager import (
-    build_failure_reply,
-    build_reply,
-)
+from smartsim._core.mli.infrastructure.control.workermanager import build_failure_reply
 from smartsim._core.mli.infrastructure.worker.worker import InferenceReply
 
 if t.TYPE_CHECKING:
@@ -61,31 +58,5 @@ def test_build_failure_reply_fails():
     "Ensures ValueError is raised if a Status Enum is not used"
     with pytest.raises(ValueError) as ex:
         response = build_failure_reply("not a status enum", "message")
-
-    assert "Error assigning status to response" in ex.value.args[0]
-
-
-@pytest.mark.parametrize(
-    "status, message",
-    [
-        pytest.param("complete", "Success", id="complete"),
-    ],
-)
-def test_build_reply(status: "Status", message: str):
-    "Ensures replies can be built successfully"
-    reply = InferenceReply()
-    reply.status_enum = status
-    reply.message = message
-    response = build_reply(reply)
-    assert response.status == status
-    assert response.message == message
-
-
-def test_build_reply_fails():
-    "Ensures ValueError is raised if a Status Enum is not used"
-    with pytest.raises(ValueError) as ex:
-        reply = InferenceReply()
-        reply.status_enum = "not a status enum"
-        response = build_reply(reply)
 
     assert "Error assigning status to response" in ex.value.args[0]

--- a/tests/dragon/test_worker_manager.py
+++ b/tests/dragon/test_worker_manager.py
@@ -39,8 +39,6 @@ import base64
 import os
 
 import dragon.channels as dch
-from .utils.channel import FileSystemCommChannel
-from .featurestore import FileSystemFeatureStore
 from dragon import fli
 
 from smartsim._core.mli.comm.channel.channel import CommChannelBase
@@ -56,6 +54,9 @@ from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStore
 from smartsim._core.mli.infrastructure.worker.torch_worker import TorchWorker
 from smartsim._core.mli.message_handler import MessageHandler
 from smartsim.log import get_logger
+
+from .featurestore import FileSystemFeatureStore
+from .utils.channel import FileSystemCommChannel
 
 logger = get_logger(__name__)
 # The tests in this file belong to the dragon group

--- a/tests/dragon/test_worker_manager.py
+++ b/tests/dragon/test_worker_manager.py
@@ -39,9 +39,9 @@ import base64
 import os
 
 import dragon.channels as dch
-from channel import FileSystemCommChannel
+from .utils.channel import FileSystemCommChannel
+from .featurestore import FileSystemFeatureStore
 from dragon import fli
-from featurestore import FileSystemFeatureStore
 
 from smartsim._core.mli.comm.channel.channel import CommChannelBase
 from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel

--- a/tests/dragon/utils/channel.py
+++ b/tests/dragon/utils/channel.py
@@ -39,6 +39,7 @@ class FileSystemCommChannel(CommChannelBase):
 
     def __init__(self, key: t.Union[bytes, pathlib.Path]) -> None:
         """Initialize the FileSystemCommChannel instance
+
         :param key: a path to the root directory of the feature store"""
         self._lock = threading.RLock()
 
@@ -56,6 +57,7 @@ class FileSystemCommChannel(CommChannelBase):
 
     def send(self, value: bytes) -> None:
         """Send a message throuh the underlying communication channel
+
         :param value: The value to send"""
         logger.debug(
             f"Channel {self.descriptor.decode('utf-8')} sending message to {self._file_path}"
@@ -65,6 +67,7 @@ class FileSystemCommChannel(CommChannelBase):
 
     def recv(self) -> bytes:
         """Receieve a message through the underlying communication channel
+
         :returns: the received message"""
         with self._lock:
             if self._file_path.exists():
@@ -78,6 +81,7 @@ class FileSystemCommChannel(CommChannelBase):
         descriptor: t.Union[str, bytes],
     ) -> "FileSystemCommChannel":
         """A factory method that creates an instance from a descriptor string
+
         :param descriptor: The descriptor that uniquely identifies the resource
         :returns: An attached FileSystemCommChannel"""
         try:

--- a/tests/dragon/utils/channel.py
+++ b/tests/dragon/utils/channel.py
@@ -76,6 +76,9 @@ class FileSystemCommChannel(CommChannelBase):
         cls,
         descriptor: t.Union[str, bytes],
     ) -> "FileSystemCommChannel":
+        """A factory method that creates an instance from a descriptor string
+        :param descriptor: The descriptor that uniquely identifies the resource
+        :returns: An attached FileSystemCommChannel"""
         try:
             if isinstance(descriptor, str):
                 path = pathlib.Path(descriptor)

--- a/tests/dragon/utils/channel.py
+++ b/tests/dragon/utils/channel.py
@@ -62,3 +62,14 @@ class FileSystemCommChannel(CommChannelBase):
         """Receieve a message through the underlying communication channel
         :returns: the received message"""
         ...
+
+    @classmethod
+    def from_descriptor(
+        cls,
+        descriptor: t.Union[str, bytes],
+    ) -> "FileSystemCommChannel":
+        if isinstance(descriptor, str):
+            path = pathlib.Path(descriptor)
+        else:
+            path = pathlib.Path(descriptor.decode("utf-8"))
+        return FileSystemCommChannel(path)

--- a/tests/dragon/utils/channel.py
+++ b/tests/dragon/utils/channel.py
@@ -38,7 +38,8 @@ class FileSystemCommChannel(CommChannelBase):
     """Passes messages by writing to a file"""
 
     def __init__(self, key: t.Union[bytes, pathlib.Path]) -> None:
-        """Initialize the FileSystemCommChannel instance"""
+        """Initialize the FileSystemCommChannel instance
+        :param key: a path to the root directory of the feature store"""
         self._lock = threading.RLock()
 
         if not isinstance(key, bytes):

--- a/tests/dragon/utils/worker.py
+++ b/tests/dragon/utils/worker.py
@@ -47,7 +47,7 @@ class IntegratedTorchWorker(mliw.MachineLearningWorkerBase):
 
     @staticmethod
     def load_model(
-        request: mliw.InferenceRequest, fetch_result: mliw.FetchModelResult
+        request: mliw.InferenceRequest, fetch_result: mliw.FetchModelResult, device: str
     ) -> mliw.LoadModelResult:
         model_bytes = fetch_result.model_bytes or request.raw_model
         if not model_bytes:
@@ -61,6 +61,7 @@ class IntegratedTorchWorker(mliw.MachineLearningWorkerBase):
     def transform_input(
         request: mliw.InferenceRequest,
         fetch_result: mliw.FetchInputResult,
+        device: str,
     ) -> mliw.TransformInputResult:
         # extra metadata for assembly can be found in request.input_meta
         raw_inputs = request.raw_inputs or fetch_result.inputs
@@ -93,6 +94,7 @@ class IntegratedTorchWorker(mliw.MachineLearningWorkerBase):
     def transform_output(
         request: mliw.InferenceRequest,
         execute_result: mliw.ExecuteResult,
+        result_device: str,
     ) -> mliw.TransformOutputResult:
         # transformed = [item.clone() for item in execute_result.predictions]
         # return OutputTransformResult(transformed)

--- a/tests/dragon/utils/worker.py
+++ b/tests/dragon/utils/worker.py
@@ -96,35 +96,9 @@ class IntegratedTorchWorker(mliw.MachineLearningWorkerBase):
         execute_result: mliw.ExecuteResult,
         result_device: str,
     ) -> mliw.TransformOutputResult:
-        # transformed = [item.clone() for item in execute_result.predictions]
-        # return OutputTransformResult(transformed)
-
-        # transformed = [item.bytes() for item in execute_result.predictions]
-
-        # OutputTransformResult.transformed SHOULD be a list of
-        # capnproto Tensors Or tensor descriptors accompanying bytes
-
         # send the original tensors...
         execute_result.predictions = [t.detach() for t in execute_result.predictions]
         # todo: solve sending all tensor metadata that coincisdes with each prediction
         return mliw.TransformOutputResult(
             execute_result.predictions, [1], "c", "float32"
         )
-        # return OutputTransformResult(transformed)
-
-    # @staticmethod
-    # def serialize_reply(
-    #     request: InferenceRequest, results: OutputTransformResult
-    # ) -> t.Any:
-    #     # results = IntegratedTorchWorker._prepare_outputs(results.outputs)
-    #     # return results
-    #     return None
-    #     # response = MessageHandler.build_response(
-    #     #     status=200,  # todo: are we satisfied with 0/1 (success, fail)
-    #     #     # todo: if not detailed messages, this shouldn't be returned.
-    #     #     message="success",
-    #     #     result=results,
-    #     #     custom_attributes=None,
-    #     # )
-    #     # serialized_resp = MessageHandler.serialize_response(response)
-    #     # return serialized_resp

--- a/tests/mli/channel.py
+++ b/tests/mli/channel.py
@@ -57,3 +57,16 @@ class FileSystemCommChannel(CommChannelBase):
             f"Channel {self.descriptor.decode('utf-8')} sending message to {self._file_path}"
         )
         self._file_path.write_bytes(value)
+
+    def recv(self) -> t.List[bytes]:
+        """Receieve a message through the underlying communication channel
+        :returns: the received message"""
+        self._file_path.read_bytes()
+
+    @classmethod
+    def from_descriptor(
+        cls,
+        descriptor: str,
+    ) -> "FileSystemCommChannel":
+        path = pathlib.Path(descriptor)
+        return FileSystemCommChannel(path)

--- a/tests/mli/channel.py
+++ b/tests/mli/channel.py
@@ -38,7 +38,8 @@ class FileSystemCommChannel(CommChannelBase):
     """Passes messages by writing to a file"""
 
     def __init__(self, key: t.Union[bytes, pathlib.Path]) -> None:
-        """Initialize the FileSystemCommChannel instance"""
+        """Initialize the FileSystemCommChannel instance
+        :param key: a path to the root directory of the feature store"""
         self._lock = threading.RLock()
         if not isinstance(key, bytes):
             super().__init__(key.as_posix().encode("utf-8"))

--- a/tests/mli/channel.py
+++ b/tests/mli/channel.py
@@ -75,6 +75,9 @@ class FileSystemCommChannel(CommChannelBase):
         cls,
         descriptor: str,
     ) -> "FileSystemCommChannel":
+        """A factory method that creates an instance from a descriptor string
+        :param descriptor: The descriptor that uniquely identifies the resource
+        :returns: An attached FileSystemCommChannel"""
         try:
             path = pathlib.Path(descriptor)
             return FileSystemCommChannel(path)

--- a/tests/mli/channel.py
+++ b/tests/mli/channel.py
@@ -39,6 +39,7 @@ class FileSystemCommChannel(CommChannelBase):
 
     def __init__(self, key: t.Union[bytes, pathlib.Path]) -> None:
         """Initialize the FileSystemCommChannel instance
+
         :param key: a path to the root directory of the feature store"""
         self._lock = threading.RLock()
         if not isinstance(key, bytes):
@@ -55,6 +56,7 @@ class FileSystemCommChannel(CommChannelBase):
 
     def send(self, value: bytes) -> None:
         """Send a message throuh the underlying communication channel
+
         :param value: The value to send"""
         logger.debug(
             f"Channel {self.descriptor.decode('utf-8')} sending message to {self._file_path}"
@@ -64,6 +66,7 @@ class FileSystemCommChannel(CommChannelBase):
 
     def recv(self) -> bytes:
         """Receieve a message through the underlying communication channel
+
         :returns: the received message"""
         with self._lock:
             if self._file_path.exists():
@@ -77,6 +80,7 @@ class FileSystemCommChannel(CommChannelBase):
         descriptor: str,
     ) -> "FileSystemCommChannel":
         """A factory method that creates an instance from a descriptor string
+
         :param descriptor: The descriptor that uniquely identifies the resource
         :returns: An attached FileSystemCommChannel"""
         try:

--- a/tests/mli/channel.py
+++ b/tests/mli/channel.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import pathlib
+import threading
 import typing as t
 
 from smartsim._core.mli.comm.channel.channel import CommChannelBase
@@ -38,6 +39,7 @@ class FileSystemCommChannel(CommChannelBase):
 
     def __init__(self, key: t.Union[bytes, pathlib.Path]) -> None:
         """Initialize the FileSystemCommChannel instance"""
+        self._lock = threading.RLock()
         if not isinstance(key, bytes):
             super().__init__(key.as_posix().encode("utf-8"))
             self._file_path = key
@@ -56,17 +58,26 @@ class FileSystemCommChannel(CommChannelBase):
         logger.debug(
             f"Channel {self.descriptor.decode('utf-8')} sending message to {self._file_path}"
         )
-        self._file_path.write_bytes(value)
+        with self._lock:
+            self._file_path.write_bytes(value)
 
-    def recv(self) -> t.List[bytes]:
+    def recv(self) -> bytes:
         """Receieve a message through the underlying communication channel
         :returns: the received message"""
-        self._file_path.read_bytes()
+        with self._lock:
+            if self._file_path.exists():
+                incoming = self._file_path.read_bytes()
+                self._file_path.unlink()
+            return incoming
 
     @classmethod
     def from_descriptor(
         cls,
         descriptor: str,
     ) -> "FileSystemCommChannel":
-        path = pathlib.Path(descriptor)
-        return FileSystemCommChannel(path)
+        try:
+            path = pathlib.Path(descriptor)
+            return FileSystemCommChannel(path)
+        except:
+            print(f"failed to create fs comm channel: {descriptor}")
+            raise

--- a/tests/mli/featurestore.py
+++ b/tests/mli/featurestore.py
@@ -130,10 +130,10 @@ class FileSystemFeatureStore(FeatureStore):
     def from_descriptor(
         cls,
         descriptor: str,
-        # b64encoded: bool = False,
     ) -> "FileSystemFeatureStore":
-        # if b64encoded:
-        #     descriptor = base64.b64decode(descriptor).encode("utf-8")
+        """A factory method that creates an instance from a descriptor string
+        :param descriptor: The descriptor that uniquely identifies the resource
+        :returns: An attached FileSystemFeatureStore"""
         try:
             path = pathlib.Path(descriptor)
             path.mkdir(parents=True, exist_ok=True)

--- a/tests/mli/featurestore.py
+++ b/tests/mli/featurestore.py
@@ -43,6 +43,7 @@ class MemoryFeatureStore(FeatureStore):
 
     def __getitem__(self, key: str) -> bytes:
         """Retrieve an item using key
+
         :param key: Unique key of an item to retrieve from the feature store"""
         if key not in self._storage:
             raise sse.SmartSimError(f"{key} not found in feature store")
@@ -50,8 +51,9 @@ class MemoryFeatureStore(FeatureStore):
 
     def __setitem__(self, key: str, value: bytes) -> None:
         """Membership operator to test for a key existing within the feature store.
-        Return `True` if the key is found, `False` otherwise
-        :param key: Unique key of an item to retrieve from the feature store"""
+
+        :param key: Unique key of an item to retrieve from the feature store
+        :returns: `True` if the key is found, `False` otherwise"""
         self._storage[key] = value
 
     def __contains__(self, key: str) -> bool:
@@ -62,8 +64,8 @@ class MemoryFeatureStore(FeatureStore):
 
     @property
     def descriptor(self) -> str:
-        """Return a unique identifier enabling a client to connect to
-        the feature store
+        """Unique identifier enabling a client to connect to the feature store
+
         :returns: A descriptor encoded as a string"""
         return "in-memory-fs"
 
@@ -76,6 +78,7 @@ class FileSystemFeatureStore(FeatureStore):
         self, storage_dir: t.Optional[t.Union[pathlib.Path, str]] = None
     ) -> None:
         """Initialize the FileSystemFeatureStore instance
+
         :param storage_dir: (optional) root directory to store all data relative to"""
         if isinstance(storage_dir, str):
             storage_dir = pathlib.Path(storage_dir)
@@ -83,6 +86,7 @@ class FileSystemFeatureStore(FeatureStore):
 
     def __getitem__(self, key: str) -> bytes:
         """Retrieve an item using key
+
         :param key: Unique key of an item to retrieve from the feature store"""
         path = self._key_path(key)
         if not path.exists():
@@ -91,6 +95,7 @@ class FileSystemFeatureStore(FeatureStore):
 
     def __setitem__(self, key: str, value: bytes) -> None:
         """Assign a value using key
+
         :param key: Unique key of an item to set in the feature store
         :param value: Value to persist in the feature store"""
         path = self._key_path(key, create=True)
@@ -98,14 +103,16 @@ class FileSystemFeatureStore(FeatureStore):
 
     def __contains__(self, key: str) -> bool:
         """Membership operator to test for a key existing within the feature store.
-        Return `True` if the key is found, `False` otherwise
-        :param key: Unique key of an item to retrieve from the feature store"""
+
+        :param key: Unique key of an item to retrieve from the feature store
+        :returns: `True` if the key is found, `False` otherwise"""
         path = self._key_path(key)
         return path.exists()
 
     def _key_path(self, key: str, create: bool = False) -> pathlib.Path:
         """Given a key, return a path that is optionally combined with a base
         directory used by the FileSystemFeatureStore.
+
         :param key: Unique key of an item to retrieve from the feature store"""
         value = pathlib.Path(key)
 
@@ -119,8 +126,8 @@ class FileSystemFeatureStore(FeatureStore):
 
     @property
     def descriptor(self) -> str:
-        """Return a unique identifier enabling a client to connect to
-        the feature store
+        """Unique identifier enabling a client to connect to the feature store
+
         :returns: A descriptor encoded as a string"""
         if not self._storage_dir:
             raise ValueError("No storage path configured")
@@ -132,6 +139,7 @@ class FileSystemFeatureStore(FeatureStore):
         descriptor: str,
     ) -> "FileSystemFeatureStore":
         """A factory method that creates an instance from a descriptor string
+
         :param descriptor: The descriptor that uniquely identifies the resource
         :returns: An attached FileSystemFeatureStore"""
         try:

--- a/tests/mli/featurestore.py
+++ b/tests/mli/featurestore.py
@@ -57,6 +57,13 @@ class MemoryFeatureStore(FeatureStore):
         :param key: Unique key of an item to retrieve from the feature store"""
         return key in self._storage
 
+    @property
+    def descriptor(self) -> str:
+        """Return a unique identifier enabling a client to connect to
+        the feature store
+        :returns: A descriptor encoded as a string"""
+        return "file-system-fs"
+
 
 class FileSystemFeatureStore(FeatureStore):
     """Alternative feature store implementation for testing. Stores all
@@ -102,6 +109,13 @@ class FileSystemFeatureStore(FeatureStore):
             value.parent.mkdir(parents=True, exist_ok=True)
 
         return value
+
+    @property
+    def descriptor(self) -> str:
+        """Return a unique identifier enabling a client to connect to
+        the feature store
+        :returns: A descriptor encoded as a string"""
+        return "in-memory-fs"
 
 
 class DragonDict:

--- a/tests/mli/featurestore.py
+++ b/tests/mli/featurestore.py
@@ -62,7 +62,7 @@ class MemoryFeatureStore(FeatureStore):
         """Return a unique identifier enabling a client to connect to
         the feature store
         :returns: A descriptor encoded as a string"""
-        return "file-system-fs"
+        return "in-memory-fs"
 
 
 class FileSystemFeatureStore(FeatureStore):
@@ -115,7 +115,24 @@ class FileSystemFeatureStore(FeatureStore):
         """Return a unique identifier enabling a client to connect to
         the feature store
         :returns: A descriptor encoded as a string"""
-        return "in-memory-fs"
+        if not self._storage_dir:
+            raise ValueError("No storage path configured")
+        return self._storage_dir.as_posix()
+
+    @classmethod
+    def from_descriptor(
+        cls,
+        descriptor: str,
+        # b64encoded: bool = False,
+    ) -> "FileSystemFeatureStore":
+        # if b64encoded:
+        #     descriptor = base64.b64decode(descriptor).encode("utf-8")
+        path = pathlib.Path(descriptor)
+        if not path.is_dir():
+            raise ValueError("FileSystemFeatureStore requires a directory path")
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+        return FileSystemFeatureStore(path)
 
 
 class DragonDict:

--- a/tests/mli/test_core_machine_learning_worker.py
+++ b/tests/mli/test_core_machine_learning_worker.py
@@ -85,12 +85,12 @@ def persist_torch_tensor(test_dir: str) -> pathlib.Path:
 
 
 @pytest.mark.skipif(not torch_available, reason="Torch backend is not installed")
-def test_fetch_model_disk(persist_torch_model: pathlib.Path) -> None:
+def test_fetch_model_disk(persist_torch_model: pathlib.Path, test_dir: str) -> None:
     """Verify that the ML worker successfully retrieves a model
     when given a valid (file system) key"""
     worker = MachineLearningWorkerCore
     key = str(persist_torch_model)
-    feature_store = FileSystemFeatureStore()
+    feature_store = FileSystemFeatureStore(test_dir)
     fsd = feature_store.descriptor
     feature_store[str(persist_torch_model)] = persist_torch_model.read_bytes()
 

--- a/tests/mli/test_core_machine_learning_worker.py
+++ b/tests/mli/test_core_machine_learning_worker.py
@@ -31,6 +31,7 @@ import pytest
 import torch
 
 import smartsim.error as sse
+from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStoreKey
 from smartsim._core.mli.infrastructure.worker.worker import (
     InferenceRequest,
     MachineLearningWorkerCore,
@@ -90,11 +91,12 @@ def test_fetch_model_disk(persist_torch_model: pathlib.Path) -> None:
     worker = MachineLearningWorkerCore
     key = str(persist_torch_model)
     feature_store = FileSystemFeatureStore()
+    fsd = feature_store.descriptor
     feature_store[str(persist_torch_model)] = persist_torch_model.read_bytes()
 
-    request = InferenceRequest(model_key=key)
+    request = InferenceRequest(model_key=FeatureStoreKey(key, fsd))
 
-    fetch_result = worker.fetch_model(request, feature_store)
+    fetch_result = worker.fetch_model(request, {fsd: feature_store})
     assert fetch_result.model_bytes
     assert fetch_result.model_bytes == persist_torch_model.read_bytes()
 
@@ -104,13 +106,14 @@ def test_fetch_model_disk_missing() -> None:
     when given an invalid (file system) key"""
     worker = MachineLearningWorkerCore
     feature_store = MemoryFeatureStore()
+    fsd = feature_store.descriptor
 
     key = "/path/that/doesnt/exist"
 
-    request = InferenceRequest(model_key=key)
+    request = InferenceRequest(model_key=FeatureStoreKey(key, fsd))
 
     with pytest.raises(sse.SmartSimError) as ex:
-        worker.fetch_model(request, feature_store)
+        worker.fetch_model(request, {fsd: feature_store})
 
     # ensure the error message includes key-identifying information
     assert key in ex.value.args[0]
@@ -127,10 +130,11 @@ def test_fetch_model_feature_store(persist_torch_model: pathlib.Path) -> None:
 
     # put model bytes into the feature store
     feature_store = MemoryFeatureStore()
+    fsd = feature_store.descriptor
     feature_store[key] = persist_torch_model.read_bytes()
 
-    request = InferenceRequest(model_key=key)
-    fetch_result = worker.fetch_model(request, feature_store)
+    request = InferenceRequest(model_key=FeatureStoreKey(key, feature_store.descriptor))
+    fetch_result = worker.fetch_model(request, {fsd: feature_store})
     assert fetch_result.model_bytes
     assert fetch_result.model_bytes == persist_torch_model.read_bytes()
 
@@ -142,12 +146,15 @@ def test_fetch_model_feature_store_missing() -> None:
 
     bad_key = "some-key"
     feature_store = MemoryFeatureStore()
+    fsd = feature_store.descriptor
 
-    request = InferenceRequest(model_key=bad_key)
+    request = InferenceRequest(
+        model_key=FeatureStoreKey(bad_key, feature_store.descriptor)
+    )
 
     # todo: consider that raising this exception shows impl. replace...
     with pytest.raises(sse.SmartSimError) as ex:
-        worker.fetch_model(request, feature_store)
+        worker.fetch_model(request, {fsd: feature_store})
 
     # ensure the error message includes key-identifying information
     assert bad_key in ex.value.args[0]
@@ -161,11 +168,12 @@ def test_fetch_model_memory(persist_torch_model: pathlib.Path) -> None:
 
     key = "test-model"
     feature_store = MemoryFeatureStore()
+    fsd = feature_store.descriptor
     feature_store[key] = persist_torch_model.read_bytes()
 
-    request = InferenceRequest(model_key=key)
+    request = InferenceRequest(model_key=FeatureStoreKey(key, feature_store.descriptor))
 
-    fetch_result = worker.fetch_model(request, feature_store)
+    fetch_result = worker.fetch_model(request, {fsd: feature_store})
     assert fetch_result.model_bytes
     assert fetch_result.model_bytes == persist_torch_model.read_bytes()
 
@@ -176,13 +184,14 @@ def test_fetch_input_disk(persist_torch_tensor: pathlib.Path) -> None:
     when given a valid (file system) key"""
     tensor_name = str(persist_torch_tensor)
 
-    request = InferenceRequest(input_keys=[tensor_name])
+    feature_store = MemoryFeatureStore()
+    fsd = feature_store.descriptor
+    request = InferenceRequest(input_keys=[FeatureStoreKey(tensor_name, fsd)])
     worker = MachineLearningWorkerCore
 
-    feature_store = MemoryFeatureStore()
     feature_store[tensor_name] = persist_torch_tensor.read_bytes()
 
-    fetch_result = worker.fetch_inputs(request, feature_store)
+    fetch_result = worker.fetch_inputs(request, {fsd: feature_store})
     assert fetch_result.inputs is not None
 
 
@@ -191,16 +200,17 @@ def test_fetch_input_disk_missing() -> None:
     when given an invalid (file system) key"""
     worker = MachineLearningWorkerCore
 
-    key = "/path/that/doesnt/exist"
     feature_store = MemoryFeatureStore()
+    fsd = feature_store.descriptor
+    key = "/path/that/doesnt/exist", fsd
 
-    request = InferenceRequest(input_keys=[key])
+    request = InferenceRequest(input_keys=[FeatureStoreKey(key, fsd)])
 
     with pytest.raises(sse.SmartSimError) as ex:
-        worker.fetch_inputs(request, feature_store)
+        worker.fetch_inputs(request, {fsd: feature_store})
 
     # ensure the error message includes key-identifying information
-    assert key in ex.value.args[0]
+    assert key[0] in ex.value.args[0]
 
 
 @pytest.mark.skipif(not torch_available, reason="Torch backend is not installed")
@@ -211,13 +221,14 @@ def test_fetch_input_feature_store(persist_torch_tensor: pathlib.Path) -> None:
 
     tensor_name = "test-tensor"
     feature_store = MemoryFeatureStore()
+    fsd = feature_store.descriptor
 
-    request = InferenceRequest(input_keys=[tensor_name])
+    request = InferenceRequest(input_keys=[FeatureStoreKey(tensor_name, fsd)])
 
     # put model bytes into the feature store
     feature_store[tensor_name] = persist_torch_tensor.read_bytes()
 
-    fetch_result = worker.fetch_inputs(request, feature_store)
+    fetch_result = worker.fetch_inputs(request, {fsd: feature_store})
     assert fetch_result.inputs
     assert list(fetch_result.inputs)[0][:10] == persist_torch_tensor.read_bytes()[:10]
 
@@ -230,6 +241,7 @@ def test_fetch_multi_input_feature_store(persist_torch_tensor: pathlib.Path) -> 
 
     tensor_name = "test-tensor"
     feature_store = MemoryFeatureStore()
+    fsd = feature_store.descriptor
 
     # put model bytes into the feature store
     body1 = persist_torch_tensor.read_bytes()
@@ -242,10 +254,14 @@ def test_fetch_multi_input_feature_store(persist_torch_tensor: pathlib.Path) -> 
     feature_store[tensor_name + "3"] = body3
 
     request = InferenceRequest(
-        input_keys=[tensor_name + "1", tensor_name + "2", tensor_name + "3"]
+        input_keys=[
+            FeatureStoreKey(tensor_name + "1", fsd),
+            FeatureStoreKey(tensor_name + "2", fsd),
+            FeatureStoreKey(tensor_name + "3", fsd),
+        ]
     )
 
-    fetch_result = worker.fetch_inputs(request, feature_store)
+    fetch_result = worker.fetch_inputs(request, {fsd: feature_store})
 
     raw_bytes = list(fetch_result.inputs)
     assert raw_bytes
@@ -261,10 +277,11 @@ def test_fetch_input_feature_store_missing() -> None:
 
     bad_key = "some-key"
     feature_store = MemoryFeatureStore()
-    request = InferenceRequest(input_keys=[bad_key])
+    fsd = feature_store.descriptor
+    request = InferenceRequest(input_keys=[FeatureStoreKey(bad_key, fsd)])
 
     with pytest.raises(sse.SmartSimError) as ex:
-        worker.fetch_inputs(request, feature_store)
+        worker.fetch_inputs(request, {fsd: feature_store})
 
     # ensure the error message includes key-identifying information
     assert bad_key in ex.value.args[0]
@@ -276,12 +293,13 @@ def test_fetch_input_memory(persist_torch_tensor: pathlib.Path) -> None:
     when given a valid (file system) key"""
     worker = MachineLearningWorkerCore
     feature_store = MemoryFeatureStore()
+    fsd = feature_store.descriptor
 
     model_name = "test-model"
     feature_store[model_name] = persist_torch_tensor.read_bytes()
-    request = InferenceRequest(input_keys=[model_name])
+    request = InferenceRequest(input_keys=[FeatureStoreKey(model_name, fsd)])
 
-    fetch_result = worker.fetch_inputs(request, feature_store)
+    fetch_result = worker.fetch_inputs(request, {fsd: feature_store})
     assert fetch_result.inputs is not None
 
 
@@ -304,18 +322,23 @@ def test_place_outputs() -> None:
 
     key_name = "test-model"
     feature_store = MemoryFeatureStore()
+    fsd = feature_store.descriptor
 
     # create a key to retrieve from the feature store
-    keys = [key_name + "1", key_name + "2", key_name + "3"]
+    keys = [
+        FeatureStoreKey(key_name + "1", fsd),
+        FeatureStoreKey(key_name + "2", fsd),
+        FeatureStoreKey(key_name + "3", fsd),
+    ]
     data = [b"abcdef", b"ghijkl", b"mnopqr"]
 
-    for k, v in zip(keys, data):
-        feature_store[k] = v
+    for fsk, v in zip(keys, data):
+        feature_store[fsk.key] = v
 
     request = InferenceRequest(output_keys=keys)
     transform_result = TransformOutputResult(data, [1], "c", "float32")
 
-    worker.place_output(request, transform_result, feature_store)
+    worker.place_output(request, transform_result, {fsd: feature_store})
 
     for i in range(3):
-        assert feature_store[keys[i]] == data[i]
+        assert feature_store[keys[i].key] == data[i]

--- a/tests/mli/test_torch_worker.py
+++ b/tests/mli/test_torch_worker.py
@@ -26,12 +26,12 @@
 
 import io
 
-import numpy as np
 import pytest
 import torch
 from torch import nn
 from torch.nn import functional as F
 
+from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStoreKey
 from smartsim._core.mli.infrastructure.worker.torch_worker import TorchWorker
 from smartsim._core.mli.infrastructure.worker.worker import (
     ExecuteResult,
@@ -102,7 +102,7 @@ def get_request() -> InferenceRequest:
     ]
 
     return InferenceRequest(
-        model_key="model",
+        model_key=FeatureStoreKey("model", ""),
         callback=None,
         raw_inputs=tensor_numpy,
         input_keys=None,

--- a/tests/mli/test_torch_worker.py
+++ b/tests/mli/test_torch_worker.py
@@ -102,7 +102,7 @@ def get_request() -> InferenceRequest:
     ]
 
     return InferenceRequest(
-        model_key=FeatureStoreKey("model", ""),
+        model_key=FeatureStoreKey(key="model", descriptor="xyz"),
         callback=None,
         raw_inputs=tensor_numpy,
         input_keys=None,

--- a/tests/mli/test_worker_manager.py
+++ b/tests/mli/test_worker_manager.py
@@ -54,9 +54,9 @@ from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStore
 from smartsim._core.mli.infrastructure.worker.torch_worker import TorchWorker
 from smartsim._core.mli.message_handler import MessageHandler
 from smartsim.log import get_logger
-from tests.mli.featurestore import FileSystemFeatureStore
 
 from .channel import FileSystemCommChannel
+from .featurestore import FileSystemFeatureStore
 
 logger = get_logger(__name__)
 # The tests in this file belong to the dragon group

--- a/tests/mli/test_worker_manager.py
+++ b/tests/mli/test_worker_manager.py
@@ -180,8 +180,6 @@ def test_worker_manager(prepare_environment: pathlib.Path) -> None:
         integrated_worker,
         as_service=True,
         cooldown=5,
-        # comm_channel_type=FileSystemCommChannel,
-        # featurestore_factory=FileSystemFeatureStore.from_descriptor,
         device="cpu",
     )
 
@@ -203,7 +201,7 @@ def test_worker_manager(prepare_environment: pathlib.Path) -> None:
     )
     msg_pump.start()
 
-    # # create a process to process commands
+    # create a process to execute commands
     process = mp.Process(target=worker_manager.execute)
     process.start()
     process.join(timeout=5)

--- a/tests/mli/test_worker_manager.py
+++ b/tests/mli/test_worker_manager.py
@@ -32,6 +32,8 @@ import time
 
 import pytest
 
+from tests.mli.featurestore import FileSystemFeatureStore
+
 torch = pytest.importorskip("torch")
 dragon = pytest.importorskip("dragon")
 
@@ -183,14 +185,11 @@ def test_worker_manager(prepare_environment: pathlib.Path) -> None:
     )
 
     # create a mock client application to populate the request queue
-    feature_stores = config_loader.get_feature_stores()
-    fs_list = list(feature_stores.values())
-
     msg_pump = mp.Process(
         target=mock_messages,
         args=(
             config_loader.get_queue(),
-            fs_list[0],
+            FileSystemFeatureStore(fs_path),
             fs_path,
             comm_path,
         ),

--- a/tests/mli/test_worker_manager.py
+++ b/tests/mli/test_worker_manager.py
@@ -165,7 +165,7 @@ def test_worker_manager(prepare_environment: pathlib.Path) -> None:
 
     # NOTE: env vars should be set prior to instantiating EnvironmentConfigLoader
     # or test environment may be unable to send messages w/queue
-    os.environ["SSQueue"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
+    os.environ["SS_QUEUE"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
 
     config_loader = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,

--- a/tests/mli/test_worker_manager.py
+++ b/tests/mli/test_worker_manager.py
@@ -1,209 +1,209 @@
-# BSD 2-Clause License
-#
-# Copyright (c) 2021-2024, Hewlett Packard Enterprise
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this
-#    list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# # BSD 2-Clause License
+# #
+# # Copyright (c) 2021-2024, Hewlett Packard Enterprise
+# # All rights reserved.
+# #
+# # Redistribution and use in source and binary forms, with or without
+# # modification, are permitted provided that the following conditions are met:
+# #
+# # 1. Redistributions of source code must retain the above copyright notice, this
+# #    list of conditions and the following disclaimer.
+# #
+# # 2. Redistributions in binary form must reproduce the above copyright notice,
+# #    this list of conditions and the following disclaimer in the documentation
+# #    and/or other materials provided with the distribution.
+# #
+# # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# # FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import io
-import logging
-import multiprocessing as mp
-import pathlib
-import time
+# import io
+# import logging
+# import multiprocessing as mp
+# import pathlib
+# import time
 
-import pytest
+# import pytest
 
-torch = pytest.importorskip("torch")
-dragon = pytest.importorskip("dragon")
+# torch = pytest.importorskip("torch")
+# dragon = pytest.importorskip("dragon")
 
-import base64
-import os
+# import base64
+# import os
 
-import dragon.channels as dch
-from dragon import fli
+# import dragon.channels as dch
+# from dragon import fli
 
-from smartsim._core.mli.comm.channel.channel import CommChannelBase
-from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel
-from smartsim._core.mli.infrastructure.control.workermanager import (
-    EnvironmentConfigLoader,
-    WorkerManager,
-)
-from smartsim._core.mli.infrastructure.storage.dragonfeaturestore import (
-    DragonFeatureStore,
-)
-from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStore
-from smartsim._core.mli.infrastructure.worker.torch_worker import TorchWorker
-from smartsim._core.mli.message_handler import MessageHandler
-from smartsim.log import get_logger
+# from smartsim._core.mli.comm.channel.channel import CommChannelBase
+# from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel
+# from smartsim._core.mli.infrastructure.control.workermanager import (
+#     EnvironmentConfigLoader,
+#     WorkerManager,
+# )
+# from smartsim._core.mli.infrastructure.storage.dragonfeaturestore import (
+#     DragonFeatureStore,
+# )
+# from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStore
+# from smartsim._core.mli.infrastructure.worker.torch_worker import TorchWorker
+# from smartsim._core.mli.message_handler import MessageHandler
+# from smartsim.log import get_logger
 
-from .channel import FileSystemCommChannel
-from .featurestore import FileSystemFeatureStore
+# from .channel import FileSystemCommChannel
+# from .featurestore import FileSystemFeatureStore
 
-logger = get_logger(__name__)
-# The tests in this file belong to the dragon group
-pytestmark = pytest.mark.dragon
-
-
-def persist_model_file(model_path: pathlib.Path) -> pathlib.Path:
-    """Create a simple torch model and persist to disk for
-    testing purposes.
-
-    TODO: remove once unit tests are in place"""
-    # test_path = pathlib.Path(work_dir)
-    if not model_path.parent.exists():
-        model_path.parent.mkdir(parents=True, exist_ok=True)
-
-    model_path.unlink(missing_ok=True)
-    # model_path = test_path / "basic.pt"
-
-    model = torch.nn.Linear(2, 1)
-    torch.save(model, model_path)
-
-    return model_path
+# logger = get_logger(__name__)
+# # The tests in this file belong to the dragon group
+# pytestmark = pytest.mark.dragon
 
 
-def mock_messages(
-    worker_manager_queue: CommChannelBase,
-    feature_store: FeatureStore,
-    feature_store_root_dir: pathlib.Path,
-    comm_channel_root_dir: pathlib.Path,
-) -> None:
-    """Mock event producer for triggering the inference pipeline"""
-    feature_store_root_dir.mkdir(parents=True, exist_ok=True)
-    comm_channel_root_dir.mkdir(parents=True, exist_ok=True)
+# def persist_model_file(model_path: pathlib.Path) -> pathlib.Path:
+#     """Create a simple torch model and persist to disk for
+#     testing purposes.
 
-    model_path = persist_model_file(feature_store_root_dir.parent / "model_original.pt")
-    model_bytes = model_path.read_bytes()
-    model_key = str(feature_store_root_dir / "model_fs.pt")
+#     TODO: remove once unit tests are in place"""
+#     # test_path = pathlib.Path(work_dir)
+#     if not model_path.parent.exists():
+#         model_path.parent.mkdir(parents=True, exist_ok=True)
 
-    feature_store[model_key] = model_bytes
+#     model_path.unlink(missing_ok=True)
+#     # model_path = test_path / "basic.pt"
 
-    iteration_number = 0
+#     model = torch.nn.Linear(2, 1)
+#     torch.save(model, model_path)
 
-    while True:
-        iteration_number += 1
-        time.sleep(1)
-        # 1. for demo, ignore upstream and just put stuff into downstream
-        # 2. for demo, only one downstream but we'd normally have to filter
-        #       msg content and send to the correct downstream (worker) queue
-        # timestamp = time.time_ns()
-        # mock_channel = test_path / f"brainstorm-{timestamp}.txt"
-        # mock_channel.touch()
-
-        # thread - just look for key (wait for keys)
-        # call checkpoint, try to get non-persistent key, it blocks
-        # working set size > 1 has side-effects
-        # only incurs cost when working set size has been exceeded
-
-        channel_key = comm_channel_root_dir / f"{iteration_number}/channel.txt"
-        callback_channel = FileSystemCommChannel(pathlib.Path(channel_key))
-
-        input_path = feature_store_root_dir / f"{iteration_number}/input.pt"
-        output_path = feature_store_root_dir / f"{iteration_number}/output.pt"
-
-        input_key = str(input_path)
-        output_key = str(output_path)
-
-        buffer = io.BytesIO()
-        tensor = torch.randn((1, 2), dtype=torch.float32)
-        torch.save(tensor, buffer)
-        feature_store[input_key] = buffer.getvalue()
-        fsd = feature_store.descriptor
-
-        message_tensor_output_key = MessageHandler.build_tensor_key(output_key, fsd)
-        message_tensor_input_key = MessageHandler.build_tensor_key(input_key, fsd)
-        message_model_key = MessageHandler.build_model_key(model_key, fsd)
-
-        request = MessageHandler.build_request(
-            reply_channel=callback_channel.descriptor,
-            model=message_model_key,
-            inputs=[message_tensor_input_key],
-            outputs=[message_tensor_output_key],
-            output_descriptors=[],
-            custom_attributes=None,
-        )
-        request_bytes = MessageHandler.serialize_request(request)
-        worker_manager_queue.send(request_bytes)
+#     return model_path
 
 
-@pytest.fixture
-def prepare_environment(test_dir: str) -> pathlib.Path:
-    """Cleanup prior outputs to run demo repeatedly"""
-    path = pathlib.Path(f"{test_dir}/workermanager.log")
-    logging.basicConfig(filename=path.absolute(), level=logging.DEBUG)
-    return path
+# def mock_messages(
+#     worker_manager_queue: CommChannelBase,
+#     feature_store: FeatureStore,
+#     feature_store_root_dir: pathlib.Path,
+#     comm_channel_root_dir: pathlib.Path,
+# ) -> None:
+#     """Mock event producer for triggering the inference pipeline"""
+#     feature_store_root_dir.mkdir(parents=True, exist_ok=True)
+#     comm_channel_root_dir.mkdir(parents=True, exist_ok=True)
+
+#     model_path = persist_model_file(feature_store_root_dir.parent / "model_original.pt")
+#     model_bytes = model_path.read_bytes()
+#     model_key = str(feature_store_root_dir / "model_fs.pt")
+
+#     feature_store[model_key] = model_bytes
+
+#     iteration_number = 0
+
+#     while True:
+#         iteration_number += 1
+#         time.sleep(1)
+#         # 1. for demo, ignore upstream and just put stuff into downstream
+#         # 2. for demo, only one downstream but we'd normally have to filter
+#         #       msg content and send to the correct downstream (worker) queue
+#         # timestamp = time.time_ns()
+#         # mock_channel = test_path / f"brainstorm-{timestamp}.txt"
+#         # mock_channel.touch()
+
+#         # thread - just look for key (wait for keys)
+#         # call checkpoint, try to get non-persistent key, it blocks
+#         # working set size > 1 has side-effects
+#         # only incurs cost when working set size has been exceeded
+
+#         channel_key = comm_channel_root_dir / f"{iteration_number}/channel.txt"
+#         callback_channel = FileSystemCommChannel(pathlib.Path(channel_key))
+
+#         input_path = feature_store_root_dir / f"{iteration_number}/input.pt"
+#         output_path = feature_store_root_dir / f"{iteration_number}/output.pt"
+
+#         input_key = str(input_path)
+#         output_key = str(output_path)
+
+#         buffer = io.BytesIO()
+#         tensor = torch.randn((1, 2), dtype=torch.float32)
+#         torch.save(tensor, buffer)
+#         feature_store[input_key] = buffer.getvalue()
+#         fsd = feature_store.descriptor
+
+#         message_tensor_output_key = MessageHandler.build_tensor_key(output_key, fsd)
+#         message_tensor_input_key = MessageHandler.build_tensor_key(input_key, fsd)
+#         message_model_key = MessageHandler.build_model_key(model_key, fsd)
+
+#         request = MessageHandler.build_request(
+#             reply_channel=callback_channel.descriptor,
+#             model=message_model_key,
+#             inputs=[message_tensor_input_key],
+#             outputs=[message_tensor_output_key],
+#             output_descriptors=[],
+#             custom_attributes=None,
+#         )
+#         request_bytes = MessageHandler.serialize_request(request)
+#         worker_manager_queue.send(request_bytes)
 
 
-def test_worker_manager(prepare_environment: pathlib.Path) -> None:
-    """Test the worker manager"""
+# @pytest.fixture
+# def prepare_environment(test_dir: str) -> pathlib.Path:
+#     """Cleanup prior outputs to run demo repeatedly"""
+#     path = pathlib.Path(f"{test_dir}/workermanager.log")
+#     logging.basicConfig(filename=path.absolute(), level=logging.DEBUG)
+#     return path
 
-    test_path = prepare_environment
-    fs_path = test_path / "feature_store"
-    comm_path = test_path / "comm_store"
 
-    to_worker_channel = dch.Channel.make_process_local()
-    to_worker_fli = fli.FLInterface(main_ch=to_worker_channel, manager_ch=None)
-    to_worker_fli_serialized = to_worker_fli.serialize()
+# def test_worker_manager(prepare_environment: pathlib.Path) -> None:
+#     """Test the worker manager"""
 
-    # NOTE: env vars should be set prior to instantiating EnvironmentConfigLoader
-    # or test environment may be unable to send messages w/queue
-    os.environ["SSQueue"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
+#     test_path = prepare_environment
+#     fs_path = test_path / "feature_store"
+#     comm_path = test_path / "comm_store"
 
-    config_loader = EnvironmentConfigLoader(
-        featurestore_factory=DragonFeatureStore.from_descriptor,
-        callback_factory=FileSystemCommChannel.from_descriptor,
-        queue_factory=DragonFLIChannel.from_descriptor,
-    )
-    integrated_worker = TorchWorker()
+#     to_worker_channel = dch.Channel.make_process_local()
+#     to_worker_fli = fli.FLInterface(main_ch=to_worker_channel, manager_ch=None)
+#     to_worker_fli_serialized = to_worker_fli.serialize()
 
-    worker_manager = WorkerManager(
-        config_loader,
-        integrated_worker,
-        as_service=True,
-        cooldown=5,
-        device="cpu",
-    )
+#     # NOTE: env vars should be set prior to instantiating EnvironmentConfigLoader
+#     # or test environment may be unable to send messages w/queue
+#     os.environ["SSQueue"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
 
-    worker_queue = config_loader.get_queue()
-    if worker_queue is None:
-        logger.warn(
-            f"FLI input queue not loaded correctly from config_loader: {config_loader._queue_descriptor}"
-        )
+#     config_loader = EnvironmentConfigLoader(
+#         featurestore_factory=DragonFeatureStore.from_descriptor,
+#         callback_factory=FileSystemCommChannel.from_descriptor,
+#         queue_factory=DragonFLIChannel.from_descriptor,
+#     )
+#     integrated_worker = TorchWorker()
 
-    # create a mock client application to populate the request queue
-    msg_pump = mp.Process(
-        target=mock_messages,
-        args=(
-            worker_queue,
-            FileSystemFeatureStore(fs_path),
-            fs_path,
-            comm_path,
-        ),
-    )
-    msg_pump.start()
+#     worker_manager = WorkerManager(
+#         config_loader,
+#         integrated_worker,
+#         as_service=True,
+#         cooldown=5,
+#         device="cpu",
+#     )
 
-    # create a process to execute commands
-    process = mp.Process(target=worker_manager.execute)
-    process.start()
-    process.join(timeout=5)
-    process.kill()
-    msg_pump.kill()
+#     worker_queue = config_loader.get_queue()
+#     if worker_queue is None:
+#         logger.warn(
+#             f"FLI input queue not loaded correctly from config_loader: {config_loader._queue_descriptor}"
+#         )
+
+#     # create a mock client application to populate the request queue
+#     msg_pump = mp.Process(
+#         target=mock_messages,
+#         args=(
+#             worker_queue,
+#             FileSystemFeatureStore(fs_path),
+#             fs_path,
+#             comm_path,
+#         ),
+#     )
+#     msg_pump.start()
+
+#     # create a process to execute commands
+#     process = mp.Process(target=worker_manager.execute)
+#     process.start()
+#     process.join(timeout=5)
+#     process.kill()
+#     msg_pump.kill()

--- a/tests/mli/test_worker_manager.py
+++ b/tests/mli/test_worker_manager.py
@@ -1,209 +1,208 @@
-# # BSD 2-Clause License
-# #
-# # Copyright (c) 2021-2024, Hewlett Packard Enterprise
-# # All rights reserved.
-# #
-# # Redistribution and use in source and binary forms, with or without
-# # modification, are permitted provided that the following conditions are met:
-# #
-# # 1. Redistributions of source code must retain the above copyright notice, this
-# #    list of conditions and the following disclaimer.
-# #
-# # 2. Redistributions in binary form must reproduce the above copyright notice,
-# #    this list of conditions and the following disclaimer in the documentation
-# #    and/or other materials provided with the distribution.
-# #
-# # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-# # FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2024, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# import io
-# import logging
-# import multiprocessing as mp
-# import pathlib
-# import time
+import io
+import logging
+import multiprocessing as mp
+import pathlib
+import time
 
-# import pytest
+import pytest
 
-# torch = pytest.importorskip("torch")
-# dragon = pytest.importorskip("dragon")
+torch = pytest.importorskip("torch")
+dragon = pytest.importorskip("dragon")
 
-# import base64
-# import os
+import base64
+import os
 
-# import dragon.channels as dch
-# from dragon import fli
+import dragon.channels as dch
+from channel import FileSystemCommChannel
+from dragon import fli
+from featurestore import FileSystemFeatureStore
 
-# from smartsim._core.mli.comm.channel.channel import CommChannelBase
-# from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel
-# from smartsim._core.mli.infrastructure.control.workermanager import (
-#     EnvironmentConfigLoader,
-#     WorkerManager,
-# )
-# from smartsim._core.mli.infrastructure.storage.dragonfeaturestore import (
-#     DragonFeatureStore,
-# )
-# from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStore
-# from smartsim._core.mli.infrastructure.worker.torch_worker import TorchWorker
-# from smartsim._core.mli.message_handler import MessageHandler
-# from smartsim.log import get_logger
+from smartsim._core.mli.comm.channel.channel import CommChannelBase
+from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel
+from smartsim._core.mli.infrastructure.control.workermanager import (
+    EnvironmentConfigLoader,
+    WorkerManager,
+)
+from smartsim._core.mli.infrastructure.storage.dragonfeaturestore import (
+    DragonFeatureStore,
+)
+from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStore
+from smartsim._core.mli.infrastructure.worker.torch_worker import TorchWorker
+from smartsim._core.mli.message_handler import MessageHandler
+from smartsim.log import get_logger
 
-# from .channel import FileSystemCommChannel
-# from .featurestore import FileSystemFeatureStore
-
-# logger = get_logger(__name__)
-# # The tests in this file belong to the dragon group
-# pytestmark = pytest.mark.dragon
-
-
-# def persist_model_file(model_path: pathlib.Path) -> pathlib.Path:
-#     """Create a simple torch model and persist to disk for
-#     testing purposes.
-
-#     TODO: remove once unit tests are in place"""
-#     # test_path = pathlib.Path(work_dir)
-#     if not model_path.parent.exists():
-#         model_path.parent.mkdir(parents=True, exist_ok=True)
-
-#     model_path.unlink(missing_ok=True)
-#     # model_path = test_path / "basic.pt"
-
-#     model = torch.nn.Linear(2, 1)
-#     torch.save(model, model_path)
-
-#     return model_path
+logger = get_logger(__name__)
+# The tests in this file belong to the dragon group
+pytestmark = pytest.mark.dragon
 
 
-# def mock_messages(
-#     worker_manager_queue: CommChannelBase,
-#     feature_store: FeatureStore,
-#     feature_store_root_dir: pathlib.Path,
-#     comm_channel_root_dir: pathlib.Path,
-# ) -> None:
-#     """Mock event producer for triggering the inference pipeline"""
-#     feature_store_root_dir.mkdir(parents=True, exist_ok=True)
-#     comm_channel_root_dir.mkdir(parents=True, exist_ok=True)
+def persist_model_file(model_path: pathlib.Path) -> pathlib.Path:
+    """Create a simple torch model and persist to disk for
+    testing purposes.
 
-#     model_path = persist_model_file(feature_store_root_dir.parent / "model_original.pt")
-#     model_bytes = model_path.read_bytes()
-#     model_key = str(feature_store_root_dir / "model_fs.pt")
+    TODO: remove once unit tests are in place"""
+    # test_path = pathlib.Path(work_dir)
+    if not model_path.parent.exists():
+        model_path.parent.mkdir(parents=True, exist_ok=True)
 
-#     feature_store[model_key] = model_bytes
+    model_path.unlink(missing_ok=True)
+    # model_path = test_path / "basic.pt"
 
-#     iteration_number = 0
+    model = torch.nn.Linear(2, 1)
+    torch.save(model, model_path)
 
-#     while True:
-#         iteration_number += 1
-#         time.sleep(1)
-#         # 1. for demo, ignore upstream and just put stuff into downstream
-#         # 2. for demo, only one downstream but we'd normally have to filter
-#         #       msg content and send to the correct downstream (worker) queue
-#         # timestamp = time.time_ns()
-#         # mock_channel = test_path / f"brainstorm-{timestamp}.txt"
-#         # mock_channel.touch()
-
-#         # thread - just look for key (wait for keys)
-#         # call checkpoint, try to get non-persistent key, it blocks
-#         # working set size > 1 has side-effects
-#         # only incurs cost when working set size has been exceeded
-
-#         channel_key = comm_channel_root_dir / f"{iteration_number}/channel.txt"
-#         callback_channel = FileSystemCommChannel(pathlib.Path(channel_key))
-
-#         input_path = feature_store_root_dir / f"{iteration_number}/input.pt"
-#         output_path = feature_store_root_dir / f"{iteration_number}/output.pt"
-
-#         input_key = str(input_path)
-#         output_key = str(output_path)
-
-#         buffer = io.BytesIO()
-#         tensor = torch.randn((1, 2), dtype=torch.float32)
-#         torch.save(tensor, buffer)
-#         feature_store[input_key] = buffer.getvalue()
-#         fsd = feature_store.descriptor
-
-#         message_tensor_output_key = MessageHandler.build_tensor_key(output_key, fsd)
-#         message_tensor_input_key = MessageHandler.build_tensor_key(input_key, fsd)
-#         message_model_key = MessageHandler.build_model_key(model_key, fsd)
-
-#         request = MessageHandler.build_request(
-#             reply_channel=callback_channel.descriptor,
-#             model=message_model_key,
-#             inputs=[message_tensor_input_key],
-#             outputs=[message_tensor_output_key],
-#             output_descriptors=[],
-#             custom_attributes=None,
-#         )
-#         request_bytes = MessageHandler.serialize_request(request)
-#         worker_manager_queue.send(request_bytes)
+    return model_path
 
 
-# @pytest.fixture
-# def prepare_environment(test_dir: str) -> pathlib.Path:
-#     """Cleanup prior outputs to run demo repeatedly"""
-#     path = pathlib.Path(f"{test_dir}/workermanager.log")
-#     logging.basicConfig(filename=path.absolute(), level=logging.DEBUG)
-#     return path
+def mock_messages(
+    worker_manager_queue: CommChannelBase,
+    feature_store: FeatureStore,
+    feature_store_root_dir: pathlib.Path,
+    comm_channel_root_dir: pathlib.Path,
+) -> None:
+    """Mock event producer for triggering the inference pipeline"""
+    feature_store_root_dir.mkdir(parents=True, exist_ok=True)
+    comm_channel_root_dir.mkdir(parents=True, exist_ok=True)
+
+    model_path = persist_model_file(feature_store_root_dir.parent / "model_original.pt")
+    model_bytes = model_path.read_bytes()
+    model_key = str(feature_store_root_dir / "model_fs.pt")
+
+    feature_store[model_key] = model_bytes
+
+    iteration_number = 0
+
+    while True:
+        iteration_number += 1
+        time.sleep(1)
+        # 1. for demo, ignore upstream and just put stuff into downstream
+        # 2. for demo, only one downstream but we'd normally have to filter
+        #       msg content and send to the correct downstream (worker) queue
+        # timestamp = time.time_ns()
+        # mock_channel = test_path / f"brainstorm-{timestamp}.txt"
+        # mock_channel.touch()
+
+        # thread - just look for key (wait for keys)
+        # call checkpoint, try to get non-persistent key, it blocks
+        # working set size > 1 has side-effects
+        # only incurs cost when working set size has been exceeded
+
+        channel_key = comm_channel_root_dir / f"{iteration_number}/channel.txt"
+        callback_channel = FileSystemCommChannel(pathlib.Path(channel_key))
+
+        input_path = feature_store_root_dir / f"{iteration_number}/input.pt"
+        output_path = feature_store_root_dir / f"{iteration_number}/output.pt"
+
+        input_key = str(input_path)
+        output_key = str(output_path)
+
+        buffer = io.BytesIO()
+        tensor = torch.randn((1, 2), dtype=torch.float32)
+        torch.save(tensor, buffer)
+        feature_store[input_key] = buffer.getvalue()
+        fsd = feature_store.descriptor
+
+        message_tensor_output_key = MessageHandler.build_tensor_key(output_key, fsd)
+        message_tensor_input_key = MessageHandler.build_tensor_key(input_key, fsd)
+        message_model_key = MessageHandler.build_model_key(model_key, fsd)
+
+        request = MessageHandler.build_request(
+            reply_channel=callback_channel.descriptor,
+            model=message_model_key,
+            inputs=[message_tensor_input_key],
+            outputs=[message_tensor_output_key],
+            output_descriptors=[],
+            custom_attributes=None,
+        )
+        request_bytes = MessageHandler.serialize_request(request)
+        worker_manager_queue.send(request_bytes)
 
 
-# def test_worker_manager(prepare_environment: pathlib.Path) -> None:
-#     """Test the worker manager"""
+@pytest.fixture
+def prepare_environment(test_dir: str) -> pathlib.Path:
+    """Cleanup prior outputs to run demo repeatedly"""
+    path = pathlib.Path(f"{test_dir}/workermanager.log")
+    logging.basicConfig(filename=path.absolute(), level=logging.DEBUG)
+    return path
 
-#     test_path = prepare_environment
-#     fs_path = test_path / "feature_store"
-#     comm_path = test_path / "comm_store"
 
-#     to_worker_channel = dch.Channel.make_process_local()
-#     to_worker_fli = fli.FLInterface(main_ch=to_worker_channel, manager_ch=None)
-#     to_worker_fli_serialized = to_worker_fli.serialize()
+def test_worker_manager(prepare_environment: pathlib.Path) -> None:
+    """Test the worker manager"""
 
-#     # NOTE: env vars should be set prior to instantiating EnvironmentConfigLoader
-#     # or test environment may be unable to send messages w/queue
-#     os.environ["SSQueue"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
+    test_path = prepare_environment
+    fs_path = test_path / "feature_store"
+    comm_path = test_path / "comm_store"
 
-#     config_loader = EnvironmentConfigLoader(
-#         featurestore_factory=DragonFeatureStore.from_descriptor,
-#         callback_factory=FileSystemCommChannel.from_descriptor,
-#         queue_factory=DragonFLIChannel.from_descriptor,
-#     )
-#     integrated_worker = TorchWorker()
+    to_worker_channel = dch.Channel.make_process_local()
+    to_worker_fli = fli.FLInterface(main_ch=to_worker_channel, manager_ch=None)
+    to_worker_fli_serialized = to_worker_fli.serialize()
 
-#     worker_manager = WorkerManager(
-#         config_loader,
-#         integrated_worker,
-#         as_service=True,
-#         cooldown=5,
-#         device="cpu",
-#     )
+    # NOTE: env vars should be set prior to instantiating EnvironmentConfigLoader
+    # or test environment may be unable to send messages w/queue
+    os.environ["SSQueue"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
 
-#     worker_queue = config_loader.get_queue()
-#     if worker_queue is None:
-#         logger.warn(
-#             f"FLI input queue not loaded correctly from config_loader: {config_loader._queue_descriptor}"
-#         )
+    config_loader = EnvironmentConfigLoader(
+        featurestore_factory=DragonFeatureStore.from_descriptor,
+        callback_factory=FileSystemCommChannel.from_descriptor,
+        queue_factory=DragonFLIChannel.from_descriptor,
+    )
+    integrated_worker = TorchWorker()
 
-#     # create a mock client application to populate the request queue
-#     msg_pump = mp.Process(
-#         target=mock_messages,
-#         args=(
-#             worker_queue,
-#             FileSystemFeatureStore(fs_path),
-#             fs_path,
-#             comm_path,
-#         ),
-#     )
-#     msg_pump.start()
+    worker_manager = WorkerManager(
+        config_loader,
+        integrated_worker,
+        as_service=True,
+        cooldown=5,
+        device="cpu",
+    )
 
-#     # create a process to execute commands
-#     process = mp.Process(target=worker_manager.execute)
-#     process.start()
-#     process.join(timeout=5)
-#     process.kill()
-#     msg_pump.kill()
+    worker_queue = config_loader.get_queue()
+    if worker_queue is None:
+        logger.warn(
+            f"FLI input queue not loaded correctly from config_loader: {config_loader._queue_descriptor}"
+        )
+
+    # create a mock client application to populate the request queue
+    msg_pump = mp.Process(
+        target=mock_messages,
+        args=(
+            worker_queue,
+            FileSystemFeatureStore(fs_path),
+            fs_path,
+            comm_path,
+        ),
+    )
+    msg_pump.start()
+
+    # create a process to execute commands
+    process = mp.Process(target=worker_manager.execute)
+    process.start()
+    process.join(timeout=5)
+    process.kill()
+    msg_pump.kill()

--- a/tests/mli/test_worker_manager.py
+++ b/tests/mli/test_worker_manager.py
@@ -165,7 +165,8 @@ def test_worker_manager(prepare_environment: pathlib.Path) -> None:
 
     # NOTE: env vars should be set prior to instantiating EnvironmentConfigLoader
     # or test environment may be unable to send messages w/queue
-    os.environ["SS_QUEUE"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
+    descriptor = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
+    os.environ["SS_REQUEST_QUEUE"] = descriptor
 
     config_loader = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,

--- a/tests/mli/test_worker_manager.py
+++ b/tests/mli/test_worker_manager.py
@@ -32,8 +32,6 @@ import time
 
 import pytest
 
-from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel
-
 torch = pytest.importorskip("torch")
 dragon = pytest.importorskip("dragon")
 
@@ -44,6 +42,7 @@ import dragon.channels as dch
 from dragon import fli
 
 from smartsim._core.mli.comm.channel.channel import CommChannelBase
+from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel
 from smartsim._core.mli.infrastructure.control.workermanager import (
     EnvironmentConfigLoader,
     WorkerManager,

--- a/tests/mli/test_worker_manager.py
+++ b/tests/mli/test_worker_manager.py
@@ -32,48 +32,36 @@ import time
 
 import pytest
 
-from tests.mli.featurestore import FileSystemFeatureStore
+from smartsim._core.mli.comm.channel.dragonfli import DragonFLIChannel
 
 torch = pytest.importorskip("torch")
 dragon = pytest.importorskip("dragon")
 
+import base64
+import os
+
+import dragon.channels as dch
+from dragon import fli
+
+from smartsim._core.mli.comm.channel.channel import CommChannelBase
 from smartsim._core.mli.infrastructure.control.workermanager import (
     EnvironmentConfigLoader,
     WorkerManager,
 )
+from smartsim._core.mli.infrastructure.storage.dragonfeaturestore import (
+    DragonFeatureStore,
+)
 from smartsim._core.mli.infrastructure.storage.featurestore import FeatureStore
+from smartsim._core.mli.infrastructure.worker.torch_worker import TorchWorker
 from smartsim._core.mli.message_handler import MessageHandler
 from smartsim.log import get_logger
+from tests.mli.featurestore import FileSystemFeatureStore
 
 from .channel import FileSystemCommChannel
-from .worker import IntegratedTorchWorker
 
 logger = get_logger(__name__)
 # The tests in this file belong to the dragon group
 pytestmark = pytest.mark.dragon
-
-
-def mock_work(worker_manager_queue: "mp.Queue[bytes]") -> None:
-    """Mock event producer for triggering the inference pipeline"""
-    # todo: move to unit tests
-    while True:
-        time.sleep(1)
-        # 1. for demo, ignore upstream and just put stuff into downstream
-        # 2. for demo, only one downstream but we'd normally have to filter
-        #       msg content and send to the correct downstream (worker) queue
-        timestamp = time.time_ns()
-        output_dir = "/lus/bnchlu1/mcbridch/code/ss/_tmp"
-        output_path = pathlib.Path(output_dir)
-
-        mock_channel = output_path / f"brainstorm-{timestamp}.txt"
-        mock_model = output_path / "brainstorm.pt"
-
-        output_path.mkdir(parents=True, exist_ok=True)
-        mock_channel.touch()
-        mock_model.touch()
-
-        msg = f"PyTorch:{mock_model}:MockInputToReplace:{mock_channel}"
-        worker_manager_queue.put(msg.encode("utf-8"))
 
 
 def persist_model_file(model_path: pathlib.Path) -> pathlib.Path:
@@ -95,7 +83,7 @@ def persist_model_file(model_path: pathlib.Path) -> pathlib.Path:
 
 
 def mock_messages(
-    worker_manager_queue: "mp.Queue[bytes]",
+    worker_manager_queue: CommChannelBase,
     feature_store: FeatureStore,
     feature_store_root_dir: pathlib.Path,
     comm_channel_root_dir: pathlib.Path,
@@ -140,7 +128,7 @@ def mock_messages(
         tensor = torch.randn((1, 2), dtype=torch.float32)
         torch.save(tensor, buffer)
         feature_store[input_key] = buffer.getvalue()
-        fsd = feature_store.descriptor()
+        fsd = feature_store.descriptor
 
         message_tensor_output_key = MessageHandler.build_tensor_key(output_key, fsd)
         message_tensor_input_key = MessageHandler.build_tensor_key(input_key, fsd)
@@ -155,7 +143,7 @@ def mock_messages(
             custom_attributes=None,
         )
         request_bytes = MessageHandler.serialize_request(request)
-        worker_manager_queue.put(request_bytes)
+        worker_manager_queue.send(request_bytes)
 
 
 @pytest.fixture
@@ -173,22 +161,42 @@ def test_worker_manager(prepare_environment: pathlib.Path) -> None:
     fs_path = test_path / "feature_store"
     comm_path = test_path / "comm_store"
 
-    config_loader = EnvironmentConfigLoader()
-    integrated_worker = IntegratedTorchWorker()
+    to_worker_channel = dch.Channel.make_process_local()
+    to_worker_fli = fli.FLInterface(main_ch=to_worker_channel, manager_ch=None)
+    to_worker_fli_serialized = to_worker_fli.serialize()
+
+    # NOTE: env vars should be set prior to instantiating EnvironmentConfigLoader
+    # or test environment may be unable to send messages w/queue
+    os.environ["SSQueue"] = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
+
+    config_loader = EnvironmentConfigLoader(
+        featurestore_factory=DragonFeatureStore.from_descriptor,
+        callback_factory=FileSystemCommChannel.from_descriptor,
+        queue_factory=DragonFLIChannel.from_descriptor,
+    )
+    integrated_worker = TorchWorker()
 
     worker_manager = WorkerManager(
         config_loader,
         integrated_worker,
         as_service=True,
-        cooldown=10,
-        comm_channel_type=FileSystemCommChannel,
+        cooldown=5,
+        # comm_channel_type=FileSystemCommChannel,
+        # featurestore_factory=FileSystemFeatureStore.from_descriptor,
+        device="cpu",
     )
+
+    worker_queue = config_loader.get_queue()
+    if worker_queue is None:
+        logger.warn(
+            f"FLI input queue not loaded correctly from config_loader: {config_loader._queue_descriptor}"
+        )
 
     # create a mock client application to populate the request queue
     msg_pump = mp.Process(
         target=mock_messages,
         args=(
-            config_loader.get_queue(),
+            worker_queue,
             FileSystemFeatureStore(fs_path),
             fs_path,
             comm_path,

--- a/tests/mli/worker.py
+++ b/tests/mli/worker.py
@@ -47,7 +47,7 @@ class IntegratedTorchWorker(mliw.MachineLearningWorkerBase):
 
     @staticmethod
     def load_model(
-        request: mliw.InferenceRequest, fetch_result: mliw.FetchModelResult
+        request: mliw.InferenceRequest, fetch_result: mliw.FetchModelResult, device: str
     ) -> mliw.LoadModelResult:
         model_bytes = fetch_result.model_bytes or request.raw_model
         if not model_bytes:
@@ -61,6 +61,7 @@ class IntegratedTorchWorker(mliw.MachineLearningWorkerBase):
     def transform_input(
         request: mliw.InferenceRequest,
         fetch_result: mliw.FetchInputResult,
+        device: str,
     ) -> mliw.TransformInputResult:
         # extra metadata for assembly can be found in request.input_meta
         raw_inputs = request.raw_inputs or fetch_result.inputs
@@ -93,6 +94,7 @@ class IntegratedTorchWorker(mliw.MachineLearningWorkerBase):
     def transform_output(
         request: mliw.InferenceRequest,
         execute_result: mliw.ExecuteResult,
+        result_device: str,
     ) -> mliw.TransformOutputResult:
         # transformed = [item.clone() for item in execute_result.predictions]
         # return OutputTransformResult(transformed)

--- a/tests/mli/worker.py
+++ b/tests/mli/worker.py
@@ -96,35 +96,9 @@ class IntegratedTorchWorker(mliw.MachineLearningWorkerBase):
         execute_result: mliw.ExecuteResult,
         result_device: str,
     ) -> mliw.TransformOutputResult:
-        # transformed = [item.clone() for item in execute_result.predictions]
-        # return OutputTransformResult(transformed)
-
-        # transformed = [item.bytes() for item in execute_result.predictions]
-
-        # OutputTransformResult.transformed SHOULD be a list of
-        # capnproto Tensors Or tensor descriptors accompanying bytes
-
         # send the original tensors...
         execute_result.predictions = [t.detach() for t in execute_result.predictions]
         # todo: solve sending all tensor metadata that coincisdes with each prediction
         return mliw.TransformOutputResult(
             execute_result.predictions, [1], "c", "float32"
         )
-        # return OutputTransformResult(transformed)
-
-    # @staticmethod
-    # def serialize_reply(
-    #     request: InferenceRequest, results: OutputTransformResult
-    # ) -> t.Any:
-    #     # results = IntegratedTorchWorker._prepare_outputs(results.outputs)
-    #     # return results
-    #     return None
-    #     # response = MessageHandler.build_response(
-    #     #     status=200,  # todo: are we satisfied with 0/1 (success, fail)
-    #     #     # todo: if not detailed messages, this shouldn't be returned.
-    #     #     message="success",
-    #     #     result=results,
-    #     #     custom_attributes=None,
-    #     # )
-    #     # serialized_resp = MessageHandler.serialize_response(response)
-    #     # return serialized_resp

--- a/tests/test_dragon_installer.py
+++ b/tests/test_dragon_installer.py
@@ -156,60 +156,60 @@ def test_cleanup_archive_exists(test_archive: pathlib.Path) -> None:
     assert not test_archive.exists()
 
 
-def test_retrieve_cached(
-    test_dir: str,
-    # archive_path: pathlib.Path,
-    test_archive: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Verify that a previously retrieved asset archive is re-used and the
-    release asset retrieval is not attempted"""
+# def test_retrieve_cached(
+#     test_dir: str,
+#     # archive_path: pathlib.Path,
+#     test_archive: pathlib.Path,
+#     monkeypatch: pytest.MonkeyPatch,
+# ) -> None:
+#     """Verify that a previously retrieved asset archive is re-used and the
+#     release asset retrieval is not attempted"""
 
-    asset_id = 123
+#     asset_id = 123
 
-    def mock_webtgz_extract(self_, target_) -> None:
-        mock_extraction_dir = pathlib.Path(target_)
-        with tarfile.TarFile.open(test_archive) as tar:
-            tar.extractall(mock_extraction_dir)
+#     def mock_webtgz_extract(self_, target_) -> None:
+#         mock_extraction_dir = pathlib.Path(target_)
+#         with tarfile.TarFile.open(test_archive) as tar:
+#             tar.extractall(mock_extraction_dir)
 
-    # we'll use the mock extract to create the files that would normally be downloaded
-    expected_output_dir = test_archive.parent / str(asset_id)
-    mock_webtgz_extract(None, expected_output_dir)
+#     # we'll use the mock extract to create the files that would normally be downloaded
+#     expected_output_dir = test_archive.parent / str(asset_id)
+#     mock_webtgz_extract(None, expected_output_dir)
 
-    # get modification time of directory holding the "downloaded" archive
-    ts1 = expected_output_dir.stat().st_ctime
+#     # get modification time of directory holding the "downloaded" archive
+#     ts1 = expected_output_dir.stat().st_ctime
 
-    requester = Requester(
-        auth=None,
-        base_url="https://github.com",
-        user_agent="mozilla",
-        per_page=10,
-        verify=False,
-        timeout=1,
-        retry=1,
-        pool_size=1,
-    )
-    headers = {"mock-header": "mock-value"}
-    attributes = {"mock-attr": "mock-attr-value"}
-    completed = True
+#     requester = Requester(
+#         auth=None,
+#         base_url="https://github.com",
+#         user_agent="mozilla",
+#         per_page=10,
+#         verify=False,
+#         timeout=1,
+#         retry=1,
+#         pool_size=1,
+#     )
+#     headers = {"mock-header": "mock-value"}
+#     attributes = {"mock-attr": "mock-attr-value"}
+#     completed = True
 
-    asset = GitReleaseAsset(requester, headers, attributes, completed)
+#     asset = GitReleaseAsset(requester, headers, attributes, completed)
 
-    # ensure mocked asset has values that we use...
-    monkeypatch.setattr(asset, "_browser_download_url", _git_attr(value="http://foo"))
-    monkeypatch.setattr(asset, "_name", _git_attr(value=mock_archive_name))
-    monkeypatch.setattr(asset, "_id", _git_attr(value=asset_id))
+#     # ensure mocked asset has values that we use...
+#     monkeypatch.setattr(asset, "_browser_download_url", _git_attr(value="http://foo"))
+#     monkeypatch.setattr(asset, "_name", _git_attr(value=mock_archive_name))
+#     monkeypatch.setattr(asset, "_id", _git_attr(value=asset_id))
 
-    # show that retrieving an asset w/a different ID results in ignoring
-    # other wheels from prior downloads in the parent directory of the asset
-    asset_path = retrieve_asset(test_archive.parent, asset)
-    ts2 = asset_path.stat().st_ctime
+#     # show that retrieving an asset w/a different ID results in ignoring
+#     # other wheels from prior downloads in the parent directory of the asset
+#     asset_path = retrieve_asset(test_archive.parent, asset)
+#     ts2 = asset_path.stat().st_ctime
 
-    # NOTE: the file should be written to a subdir based on the asset ID
-    assert (
-        asset_path == expected_output_dir
-    )  # shows that the expected path matches the output path
-    assert ts1 == ts2  # show that the file wasn't changed...
+#     # NOTE: the file should be written to a subdir based on the asset ID
+#     assert (
+#         asset_path == expected_output_dir
+#     )  # shows that the expected path matches the output path
+#     assert ts1 == ts2  # show that the file wasn't changed...
 
 
 def test_retrieve_updated(

--- a/tests/test_dragon_installer.py
+++ b/tests/test_dragon_installer.py
@@ -156,60 +156,60 @@ def test_cleanup_archive_exists(test_archive: pathlib.Path) -> None:
     assert not test_archive.exists()
 
 
-# def test_retrieve_cached(
-#     test_dir: str,
-#     # archive_path: pathlib.Path,
-#     test_archive: pathlib.Path,
-#     monkeypatch: pytest.MonkeyPatch,
-# ) -> None:
-#     """Verify that a previously retrieved asset archive is re-used and the
-#     release asset retrieval is not attempted"""
+def test_retrieve_cached(
+    test_dir: str,
+    # archive_path: pathlib.Path,
+    test_archive: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that a previously retrieved asset archive is re-used and the
+    release asset retrieval is not attempted"""
 
-#     asset_id = 123
+    asset_id = 123
 
-#     def mock_webtgz_extract(self_, target_) -> None:
-#         mock_extraction_dir = pathlib.Path(target_)
-#         with tarfile.TarFile.open(test_archive) as tar:
-#             tar.extractall(mock_extraction_dir)
+    def mock_webtgz_extract(self_, target_) -> None:
+        mock_extraction_dir = pathlib.Path(target_)
+        with tarfile.TarFile.open(test_archive) as tar:
+            tar.extractall(mock_extraction_dir)
 
-#     # we'll use the mock extract to create the files that would normally be downloaded
-#     expected_output_dir = test_archive.parent / str(asset_id)
-#     mock_webtgz_extract(None, expected_output_dir)
+    # we'll use the mock extract to create the files that would normally be downloaded
+    expected_output_dir = test_archive.parent / str(asset_id)
+    mock_webtgz_extract(None, expected_output_dir)
 
-#     # get modification time of directory holding the "downloaded" archive
-#     ts1 = expected_output_dir.stat().st_ctime
+    # get modification time of directory holding the "downloaded" archive
+    ts1 = expected_output_dir.stat().st_ctime
 
-#     requester = Requester(
-#         auth=None,
-#         base_url="https://github.com",
-#         user_agent="mozilla",
-#         per_page=10,
-#         verify=False,
-#         timeout=1,
-#         retry=1,
-#         pool_size=1,
-#     )
-#     headers = {"mock-header": "mock-value"}
-#     attributes = {"mock-attr": "mock-attr-value"}
-#     completed = True
+    requester = Requester(
+        auth=None,
+        base_url="https://github.com",
+        user_agent="mozilla",
+        per_page=10,
+        verify=False,
+        timeout=1,
+        retry=1,
+        pool_size=1,
+    )
+    headers = {"mock-header": "mock-value"}
+    attributes = {"mock-attr": "mock-attr-value"}
+    completed = True
 
-#     asset = GitReleaseAsset(requester, headers, attributes, completed)
+    asset = GitReleaseAsset(requester, headers, attributes, completed)
 
-#     # ensure mocked asset has values that we use...
-#     monkeypatch.setattr(asset, "_browser_download_url", _git_attr(value="http://foo"))
-#     monkeypatch.setattr(asset, "_name", _git_attr(value=mock_archive_name))
-#     monkeypatch.setattr(asset, "_id", _git_attr(value=asset_id))
+    # ensure mocked asset has values that we use...
+    monkeypatch.setattr(asset, "_browser_download_url", _git_attr(value="http://foo"))
+    monkeypatch.setattr(asset, "_name", _git_attr(value=mock_archive_name))
+    monkeypatch.setattr(asset, "_id", _git_attr(value=asset_id))
 
-#     # show that retrieving an asset w/a different ID results in ignoring
-#     # other wheels from prior downloads in the parent directory of the asset
-#     asset_path = retrieve_asset(test_archive.parent, asset)
-#     ts2 = asset_path.stat().st_ctime
+    # show that retrieving an asset w/a different ID results in ignoring
+    # other wheels from prior downloads in the parent directory of the asset
+    asset_path = retrieve_asset(test_archive.parent, asset)
+    ts2 = asset_path.stat().st_ctime
 
-#     # NOTE: the file should be written to a subdir based on the asset ID
-#     assert (
-#         asset_path == expected_output_dir
-#     )  # shows that the expected path matches the output path
-#     assert ts1 == ts2  # show that the file wasn't changed...
+    # NOTE: the file should be written to a subdir based on the asset ID
+    assert (
+        asset_path == expected_output_dir
+    )  # shows that the expected path matches the output path
+    assert ts1 == ts2  # show that the file wasn't changed...
 
 
 def test_retrieve_updated(

--- a/tests/test_dragon_run_policy.py
+++ b/tests/test_dragon_run_policy.py
@@ -143,7 +143,6 @@ def test_create_run_policy_run_request_no_run_policy() -> None:
     assert policy.device == Policy.Device.DEFAULT
     assert set(policy.cpu_affinity) == set()
     assert policy.gpu_affinity == []
-    assert policy.affinity == Policy.Affinity.DEFAULT
 
 
 @pytest.mark.skipif(not dragon_loaded, reason="Test is only for Dragon WLM systems")
@@ -167,7 +166,6 @@ def test_create_run_policy_run_request_default_run_policy() -> None:
 
     assert set(policy.cpu_affinity) == set()
     assert set(policy.gpu_affinity) == set()
-    assert policy.affinity == Policy.Affinity.DEFAULT
 
 
 @pytest.mark.skipif(not dragon_loaded, reason="Test is only for Dragon WLM systems")
@@ -192,7 +190,6 @@ def test_create_run_policy_run_request_cpu_affinity_no_device() -> None:
 
     assert set(policy.cpu_affinity) == affinity
     assert policy.gpu_affinity == []
-    assert policy.affinity == Policy.Affinity.SPECIFIC
 
 
 @pytest.mark.skipif(not dragon_loaded, reason="Test is only for Dragon WLM systems")
@@ -216,7 +213,6 @@ def test_create_run_policy_run_request_cpu_affinity() -> None:
 
     assert set(policy.cpu_affinity) == affinity
     assert policy.gpu_affinity == []
-    assert policy.affinity == Policy.Affinity.SPECIFIC
 
 
 @pytest.mark.skipif(not dragon_loaded, reason="Test is only for Dragon WLM systems")
@@ -240,7 +236,6 @@ def test_create_run_policy_run_request_gpu_affinity() -> None:
 
     assert policy.cpu_affinity == []
     assert set(policy.gpu_affinity) == set(affinity)
-    assert policy.affinity == Policy.Affinity.SPECIFIC
 
 
 @pytest.mark.skipif(not dragon_loaded, reason="Test is only for Dragon WLM systems")

--- a/tests/test_message_handler/test_build_model_key.py
+++ b/tests/test_message_handler/test_build_model_key.py
@@ -35,10 +35,13 @@ handler = MessageHandler()
 
 
 def test_build_model_key_successful():
-    model_key = handler.build_model_key("tensor_key")
+    fsd = "mock-feature-store-descriptor"
+    model_key = handler.build_model_key("tensor_key", fsd)
     assert model_key.key == "tensor_key"
+    assert model_key.featureStoreDescriptor == fsd
 
 
 def test_build_model_key_unsuccessful():
     with pytest.raises(ValueError):
-        model_key = handler.build_model_key(100)
+        fsd = "mock-feature-store-descriptor"
+        model_key = handler.build_model_key(100, fsd)

--- a/tests/test_message_handler/test_build_tensor_key.py
+++ b/tests/test_message_handler/test_build_tensor_key.py
@@ -35,10 +35,12 @@ handler = MessageHandler()
 
 
 def test_build_tensor_key_successful():
-    tensor_key = handler.build_tensor_key("tensor_key")
+    fsd = "mock-feature-store-descriptor"
+    tensor_key = handler.build_tensor_key("tensor_key", fsd)
     assert tensor_key.key == "tensor_key"
 
 
 def test_build_tensor_key_unsuccessful():
     with pytest.raises(ValueError):
-        tensor_key = handler.build_tensor_key(100)
+        fsd = "mock-feature-store-descriptor"
+        tensor_key = handler.build_tensor_key(100, fsd)

--- a/tests/test_message_handler/test_output_descriptor.py
+++ b/tests/test_message_handler/test_output_descriptor.py
@@ -33,7 +33,8 @@ pytestmark = pytest.mark.group_a
 
 handler = MessageHandler()
 
-tensor_key = handler.build_tensor_key("key")
+fsd = "mock-feature-store-descriptor"
+tensor_key = handler.build_tensor_key("key", fsd)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_message_handler/test_request.py
+++ b/tests/test_message_handler/test_request.py
@@ -31,14 +31,16 @@ from smartsim._core.mli.message_handler import MessageHandler
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a
 
-model_key = MessageHandler.build_model_key("model_key")
+fsd = "mock-feature-store-descriptor"
+
+model_key = MessageHandler.build_model_key("model_key", fsd)
 model = MessageHandler.build_model(b"model data", "model_name", "v0.0.1")
 
-input_key1 = MessageHandler.build_tensor_key("input_key1")
-input_key2 = MessageHandler.build_tensor_key("input_key2")
+input_key1 = MessageHandler.build_tensor_key("input_key1", fsd)
+input_key2 = MessageHandler.build_tensor_key("input_key2", fsd)
 
-output_key1 = MessageHandler.build_tensor_key("output_key1")
-output_key2 = MessageHandler.build_tensor_key("output_key2")
+output_key1 = MessageHandler.build_tensor_key("output_key1", fsd)
+output_key2 = MessageHandler.build_tensor_key("output_key2", fsd)
 
 output_descriptor1 = MessageHandler.build_output_tensor_descriptor(
     "c", [output_key1, output_key2], "int64", []

--- a/tests/test_message_handler/test_response.py
+++ b/tests/test_message_handler/test_response.py
@@ -31,9 +31,10 @@ from smartsim._core.mli.message_handler import MessageHandler
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a
 
+fsd = "mock-feature-store-descriptor"
 
-result_key1 = MessageHandler.build_tensor_key("result_key1")
-result_key2 = MessageHandler.build_tensor_key("result_key2")
+result_key1 = MessageHandler.build_tensor_key("result_key1", fsd)
+result_key2 = MessageHandler.build_tensor_key("result_key2", fsd)
 
 torch_attributes = MessageHandler.build_torch_response_attributes()
 tf_attributes = MessageHandler.build_tf_response_attributes()


### PR DESCRIPTION
- Enables using multiple feature stores by enhancing the existing tensor/model-key classes to include the feature store descriptor.
- Update the `EnvironmentConfigLoader` to retrieve _multiple_ feature stores from environment using the prior key as a prefix to query with
- Minor (lift & shift) refactor of top-level functions in worker manager module to reduce number of touch-points for converting to `FeatureStoreKey` from capnproto type
    - now, only `worker.py` deals with this conversion.