### PR TITLE
Fix dragon installation issues

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -120,6 +120,7 @@ jobs:
         run: |
           smart build --device cpu --onnx --dragon -v
           echo "LD_LIBRARY_PATH=$(python -c 'import site; print(site.getsitepackages()[0])')/smartsim/_core/.dragon/dragon-0.9/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          python -m pip install "numpy<2"
 
       - name: Install ML Runtimes with Smart (no ONNX,TF on Apple Silicon)
         if: contains( matrix.os, 'macos-14' )

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install SmartSim (with ML backends)
         run: |
           python -m pip install git+https://github.com/CrayLabs/SmartRedis.git@develop#egg=smartredis
-          python -m pip install .[dev,ml]
+          python -m pip install .[dev,mypy,ml]
 
       - name: Install ML Runtimes with Smart (with pt, tf, and onnx support)
         if: (contains( matrix.os, 'ubuntu' ) || contains( matrix.os, 'macos-12')) && ( matrix.subset != 'dragon' )
@@ -127,9 +127,7 @@ jobs:
         run: smart build --device cpu --no_tf -v
 
       - name: Run mypy
-        run: |
-          python -m pip install .[mypy]
-          make check-mypy
+        run: make check-mypy
 
       - name: Run Pylint
         run: make check-lint

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -30,6 +30,7 @@ To be released at some future point in time
 
 Description
 
+- Fix dragon installation bug
 - Fix internal host name representation for Dragon backend
 - Make dependencies more discoverable in setup.py
 - Add hardware pinning capability when using dragon
@@ -41,6 +42,11 @@ Description
 - Remove broken oss.redis.com URI blocking documentation generation
 
 Detailed Notes
+
+- Fixed a bug in the dragon installer where a too-relaxed path is 
+  searched for wheels. The resulting list may cause the wrong wheel to be
+  installed or may report failures when it attempts to install old wheels.
+  ([SmartSim-PRXXX](https://github.com/CrayLabs/SmartSim/pull/XXX))
 
 - setup.py used to define dependencies in a way that was not amenable
   to code scanning tools. Direct dependencies now appear directly

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -46,8 +46,7 @@ Detailed Notes
 - Fixed a bug in the dragon installer where a too-relaxed path is 
   searched for wheels. The resulting list may cause the wrong wheel to be
   installed or may report failures when it attempts to install old wheels.
-  ([SmartSim-PRXXX](https://github.com/CrayLabs/SmartSim/pull/XXX))
-
+  ([SmartSim-PR651](https://github.com/CrayLabs/SmartSim/pull/651))
 - setup.py used to define dependencies in a way that was not amenable
   to code scanning tools. Direct dependencies now appear directly
   in the setup call and the definition of the SmartRedis version

--- a/smartsim/_core/_cli/scripts/dragon_install.py
+++ b/smartsim/_core/_cli/scripts/dragon_install.py
@@ -156,14 +156,18 @@ def retrieve_asset(working_dir: pathlib.Path, asset: GitReleaseAsset) -> pathlib
     :param working_dir: location in file system where assets should be written
     :param asset: GitHub release asset to retrieve
     :returns: path to the downloaded asset"""
-    if working_dir.exists() and list(working_dir.rglob("*.whl")):
-        return working_dir
+
+    target_dir = working_dir / str(asset.id)
+    if target_dir.exists() and list(target_dir.rglob("*.whl")):
+        return target_dir
+
+    target_dir.mkdir(parents=True)
 
     archive = WebTGZ(asset.browser_download_url)
-    archive.extract(working_dir)
+    archive.extract(target_dir)
 
-    logger.debug(f"Retrieved {asset.browser_download_url} to {working_dir}")
-    return working_dir
+    logger.debug(f"Retrieved {asset.browser_download_url} to {target_dir}")
+    return target_dir
 
 
 def install_package(asset_dir: pathlib.Path) -> int:

--- a/tests/test_dragon_installer.py
+++ b/tests/test_dragon_installer.py
@@ -44,6 +44,7 @@ from smartsim._core._cli.scripts.dragon_install import (
     retrieve_asset,
     retrieve_asset_info,
 )
+from smartsim._core._install.builder import WebTGZ
 from smartsim.error.errors import SmartSimCLIActionCancelled
 
 # The tests in this file belong to the group_a group
@@ -51,6 +52,7 @@ pytestmark = pytest.mark.group_a
 
 
 mock_archive_name = "dragon-0.8-py3.9.4.1-CRAYEX-ac132fe95.tar.gz"
+updated_archive_name = "dragon-0.9-py3.9.4.1-CRAYEX-ac132fe95.tar.gz"
 _git_attr = namedtuple("_git_attr", "value")
 
 
@@ -58,14 +60,25 @@ _git_attr = namedtuple("_git_attr", "value")
 def test_archive(test_dir: str, archive_path: pathlib.Path) -> pathlib.Path:
     """Fixture for returning a simple tarfile to test on"""
     num_files = 10
+
+    archive_name = archive_path.name
+    archive_name = archive_name.replace(".tar.gz", "")
+
     with tarfile.TarFile.open(archive_path, mode="w:gz") as tar:
-        mock_whl = pathlib.Path(test_dir) / "mock.whl"
+        mock_whl = pathlib.Path(test_dir) / archive_name / f"{archive_name}.whl"
+        mock_whl.parent.mkdir(parents=True, exist_ok=True)
         mock_whl.touch()
 
+        tar.add(mock_whl)
+
         for i in range(num_files):
-            content = pathlib.Path(test_dir) / f"{i:04}.txt"
+            content = pathlib.Path(test_dir) / archive_name / f"{i:04}.txt"
             content.write_text(f"i am file {i}\n")
             tar.add(content)
+            content.unlink()
+
+        mock_whl.unlink()
+
     return archive_path
 
 
@@ -118,6 +131,7 @@ def test_assets(monkeypatch: pytest.MonkeyPatch) -> t.Dict[str, GitReleaseAsset]
                     _git_attr(value=f"http://foo/{archive_name}"),
                 )
                 monkeypatch.setattr(asset, "_name", _git_attr(value=archive_name))
+                monkeypatch.setattr(asset, "_id", _git_attr(value=123))
                 assets.append(asset)
 
     return assets
@@ -149,10 +163,19 @@ def test_retrieve_cached(
     test_archive: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify that a previously retrieved asset archive is re-used"""
-    with tarfile.TarFile.open(test_archive) as tar:
-        tar.extractall(test_dir)
+    """Verify that a previously retrieved asset archive is re-used and the
+    release asset retrieval is not attempted"""
 
+    asset_id = 123
+
+    def mock_webtgz_extract(self_, target_) -> None:
+        mock_extraction_dir = pathlib.Path(target_)
+        with tarfile.TarFile.open(test_archive) as tar:
+            tar.extractall(mock_extraction_dir)
+
+    # we'll use the mock extract to create the files that would normally be downloaded
+    expected_output_dir = test_archive.parent / str(asset_id)
+    mock_webtgz_extract(None, expected_output_dir)
     ts1 = test_archive.parent.stat().st_ctime
 
     requester = Requester(
@@ -174,14 +197,73 @@ def test_retrieve_cached(
     # ensure mocked asset has values that we use...
     monkeypatch.setattr(asset, "_browser_download_url", _git_attr(value="http://foo"))
     monkeypatch.setattr(asset, "_name", _git_attr(value=mock_archive_name))
+    monkeypatch.setattr(asset, "_id", _git_attr(value=asset_id))
 
     asset_path = retrieve_asset(test_archive.parent, asset)
     ts2 = asset_path.stat().st_ctime
 
+    # NOTE: the file should be written to a subdir based on the asset ID
     assert (
-        asset_path == test_archive.parent
-    )  # show that the expected path matches the output path
+        asset_path == expected_output_dir
+    )  # shows that the expected path matches the output path
     assert ts1 == ts2  # show that the file wasn't changed...
+
+
+def test_retrieve_updated(
+    test_archive: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that a previously retrieved asset archive is not re-used if a new
+    version is found"""
+
+    old_asset_id = 100
+    asset_id = 123
+
+    def mock_webtgz_extract(self_, target_) -> None:
+        mock_extraction_dir = pathlib.Path(target_)
+        with tarfile.TarFile.open(test_archive) as tar:
+            tar.extractall(mock_extraction_dir)
+
+    # we'll use the mock extract to create the files that would normally be downloaded
+    expected_output_dir = test_archive.parent / str(asset_id)
+    old_output_dir = test_archive.parent / str(old_asset_id)
+    mock_webtgz_extract(None, old_output_dir)
+
+    requester = Requester(
+        auth=None,
+        base_url="https://github.com",
+        user_agent="mozilla",
+        per_page=10,
+        verify=False,
+        timeout=1,
+        retry=1,
+        pool_size=1,
+    )
+    headers = {"mock-header": "mock-value"}
+    attributes = {"mock-attr": "mock-attr-value"}
+    completed = True
+
+    asset = GitReleaseAsset(requester, headers, attributes, completed)
+
+    # ensure mocked asset has values that we use...
+    monkeypatch.setattr(asset, "_browser_download_url", _git_attr(value="http://foo"))
+    monkeypatch.setattr(asset, "_name", _git_attr(value=mock_archive_name))
+    monkeypatch.setattr(asset, "_id", _git_attr(value=asset_id))
+    monkeypatch.setattr(
+        WebTGZ,
+        "extract",
+        # lambda self, target_url: None,
+        lambda s_, t_: mock_webtgz_extract(s_, expected_output_dir),
+    )  # mock the retrieval of the updated archive
+
+    # tell it to retrieve. it should return the path to the new download, not the old one
+    asset_path = retrieve_asset(test_archive.parent, asset)
+
+    # sanity check we don't have the same paths
+    assert old_output_dir != expected_output_dir
+
+    # verify the "cached" copy wasn't used
+    assert asset_path == expected_output_dir
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix two dragon installation issues:

1. Fix issue where search for `*.whl` files may include previously extracted versions of the dragon package
2. (temporarily) Fix issue where dragon updates `numpy` to a version greater than `2.0.0` and breaks mli workers