### PR TITLE
Mitigate dragon/numpy, mypy/typing_extension dependency issues

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install SmartSim (with ML backends)
         run: |
           python -m pip install git+https://github.com/CrayLabs/SmartRedis.git@develop#egg=smartredis
-          python -m pip install .[dev,ml]
+          python -m pip install .[dev,mypy,ml]
 
       - name: Install ML Runtimes with Smart (with pt, tf, and onnx support)
         if: contains( matrix.os, 'ubuntu' ) || contains( matrix.os, 'macos-12')
@@ -121,7 +121,6 @@ jobs:
 
       - name: Run mypy
         run: |
-          python -m pip install .[mypy]
           make check-mypy
 
       - name: Run Pylint

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -33,7 +33,7 @@ Detailed Notes
   caused runtime failures. The build actions were tweaked to include
   all optional dependencies to be considered by pip during resolution.
   Additionally, the numpy version was capped on dragon installations.
-  ([SmartSim-PR635](https://github.com/CrayLabs/SmartSim/pull/635))
+  ([SmartSim-PR653](https://github.com/CrayLabs/SmartSim/pull/653))
 - setup.py used to define dependencies in a way that was not amenable
   to code scanning tools. Direct dependencies now appear directly
   in the setup call and the definition of the SmartRedis version

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -15,6 +15,7 @@ To be released at some future point in time
 
 Description
 
+- Mitigate dependency installation issues
 - Fix internal host name representation for Dragon backend
 - Make dependencies more discoverable in setup.py
 - Add hardware pinning capability when using dragon
@@ -27,6 +28,12 @@ Description
 
 Detailed Notes
 
+- Installation of mypy or dragon in separate build actions caused
+  some dependencies (typing_extensions, numpy) to be upgraded and
+  caused runtime failures. The build actions were tweaked to include
+  all optional dependencies to be considered by pip during resolution.
+  Additionally, the numpy version was capped on dragon installations.
+  ([SmartSim-PR635](https://github.com/CrayLabs/SmartSim/pull/635))
 - setup.py used to define dependencies in a way that was not amenable
   to code scanning tools. Direct dependencies now appear directly
   in the setup call and the definition of the SmartRedis version

--- a/smartsim/_core/_cli/scripts/dragon_install.py
+++ b/smartsim/_core/_cli/scripts/dragon_install.py
@@ -182,7 +182,7 @@ def install_package(asset_dir: pathlib.Path) -> int:
         logger.info(f"Installing package: {wheel_path.absolute()}")
 
         try:
-            pip("install", "--force-reinstall", str(wheel_path))
+            pip("install", "--force-reinstall", str(wheel_path), "numpy<2")
             wheel_path = next(wheels, None)
         except Exception:
             logger.error(f"Unable to install from {asset_dir}")


### PR DESCRIPTION
This PR mitigates two issues encountered during installation on build agents

## mypy/typing_extensions

Installation of mypy or dragon in separate build actions caused some dependencies (typing_extensions, numpy) to be upgraded. Those upgrades result in runtime failures. The build actions were tweaked to allow pip to consider all optional dependencies during resolution. 

## dragon/numpy

Additionally, the numpy version was capped on dragon installations.