### PR TITLE
Simple Status Checking

### DIFF
--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -228,7 +228,7 @@ class JobManager:
     def get_status(
         self,
         entity: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]],
-    ) -> SmartSimStatus | FailedToFetchStatus:
+    ) -> t.Union[SmartSimStatus, FailedToFetchStatus]:
         """Return the status of a job.
 
         :param entity: SmartSimEntity or EntitySequence instance

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -36,7 +36,7 @@ from ..._core.launcher.step import Step
 from ...database import FeatureStore
 from ...entity import EntitySequence, FSNode, SmartSimEntity
 from ...log import ContextThread, get_logger
-from ...status import TERMINAL_STATUSES, SmartSimStatus
+from ...status import TERMINAL_STATUSES, FailedToFetchStatus, SmartSimStatus
 from ..config import CONFIG
 from ..launcher import Launcher, LocalLauncher
 from ..utils.network import get_ip_from_host
@@ -228,7 +228,7 @@ class JobManager:
     def get_status(
         self,
         entity: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]],
-    ) -> SmartSimStatus:
+    ) -> SmartSimStatus | FailedToFetchStatus:
         """Return the status of a job.
 
         :param entity: SmartSimEntity or EntitySequence instance
@@ -242,7 +242,7 @@ class JobManager:
                 job: Job = self[entity.name]  # locked
                 return job.status
 
-            return SmartSimStatus.STATUS_NEVER_STARTED
+            return FailedToFetchStatus.STATUS_NEVER_STARTED
 
     def set_launcher(self, launcher: Launcher) -> None:
         """Set the launcher of the job manager to a specific launcher instance

--- a/smartsim/_core/control/launch_history.py
+++ b/smartsim/_core/control/launch_history.py
@@ -1,0 +1,96 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2024, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import annotations
+
+import dataclasses
+import typing as t
+
+from smartsim._core.utils import helpers as _helpers
+
+if t.TYPE_CHECKING:
+    from smartsim.settings.dispatch import LauncherProtocol
+    from smartsim.types import LaunchedJobID
+
+
+@dataclasses.dataclass(frozen=True)
+class LaunchHistory:
+    """A cache to manage and quickly look up which launched job ids were
+    issued by which launcher
+    """
+
+    _id_to_issuer: dict[LaunchedJobID, LauncherProtocol[t.Any]] = dataclasses.field(
+        default_factory=dict
+    )
+
+    def save_launch(
+        self, launcher: LauncherProtocol[t.Any], id_: LaunchedJobID
+    ) -> None:
+        """Save a launcher and a launch job id that it issued for later
+        reference.
+
+        :param launcher: A launcher that started a job and issued an id for
+            that job
+        :param id_: The id of the launched job started by the launcher
+        :raises ValueError: An id of equal value has already been saved
+        """
+        if id_ in self._id_to_issuer:
+            raise ValueError("An ID of that value has already been saved")
+        self._id_to_issuer[id_] = launcher
+
+    def iter_past_launchers(self) -> t.Iterable[LauncherProtocol[t.Any]]:
+        """Iterate over the unique launcher instances stored in history
+
+        :returns: An iterator over unique launcher instances
+        """
+        return _helpers.unique(self._id_to_issuer.values())
+
+    def group_by_launcher(
+        self, ids: t.Collection[LaunchedJobID] | None = None, unknown_ok: bool = False
+    ) -> dict[LauncherProtocol[t.Any], set[LaunchedJobID]]:
+        """Return a mapping of launchers to launched job ids issued by that
+        launcher.
+
+        :param ids: The subset launch ids to group by common launchers.
+        :param unknown_ok: If set to `True` and the history is unable to
+            determine which launcher instance issued a requested launched job
+            id, the history will silently omit the id from the returned
+            mapping. If set to `False` a `ValueError` will be raised instead.
+            Set to `False` by default.
+        :raises ValueError: An unknown launch id was requested to be grouped by
+            launcher, and `unknown_ok` is set to `False`.
+        :returns: A mapping of launchers to collections of launched job ids
+            that were issued by that launcher.
+        """
+        if ids is None:
+            ids = self._id_to_issuer
+        launchers_to_launched = _helpers.group_by(self._id_to_issuer.get, ids)
+        unknown = launchers_to_launched.get(None, [])
+        if unknown and not unknown_ok:
+            formatted_unknown = ", ".join(unknown)
+            msg = f"IDs {formatted_unknown} could not be mapped back to a launcher"
+            raise ValueError(msg)
+        return {k: set(v) for k, v in launchers_to_launched.items() if k is not None}

--- a/smartsim/_core/launcher/dragon/dragonBackend.py
+++ b/smartsim/_core/launcher/dragon/dragonBackend.py
@@ -690,7 +690,7 @@ class DragonBackend:
             else:
                 self._queued_steps[step_id] = request
                 self._group_infos[step_id] = ProcessGroupInfo(
-                    status=SmartSimStatus.STATUS_NEVER_STARTED
+                    status=SmartSimStatus.STATUS_NEW
                 )
             return DragonRunResponse(step_id=step_id, error_message=err)
 

--- a/smartsim/_core/launcher/dragon/dragonLauncher.py
+++ b/smartsim/_core/launcher/dragon/dragonLauncher.py
@@ -145,9 +145,11 @@ class DragonLauncher(WLMLauncher):
         res = _assert_schema_type(self._connector.send_request(req), DragonRunResponse)
         return LaunchedJobID(res.step_id)
 
-    def get_status(self, *launched_ids: LaunchedJobID) -> tuple[SmartSimStatus, ...]:
+    def get_status(
+        self, *launched_ids: LaunchedJobID
+    ) -> t.Mapping[LaunchedJobID, SmartSimStatus]:
         infos = self._get_managed_step_update(list(launched_ids))
-        return tuple(info.status for info in infos)
+        return {id_: info.status for id_, info in zip(launched_ids, infos)}
 
     def run(self, step: Step) -> t.Optional[str]:
         """Run a job step through Slurm
@@ -341,7 +343,7 @@ class DragonLauncher(WLMLauncher):
             return [step_id_updates[step_id] for step_id in step_ids]
         except KeyError:
             msg = "A step info could not be found for one or more of the requested ids"
-            raise errors.UnrecognizedLaunchedJobError(msg) from None
+            raise errors.LauncherJobNotFound(msg) from None
 
     def __str__(self) -> str:
         return "Dragon"

--- a/smartsim/_core/launcher/dragon/dragonLauncher.py
+++ b/smartsim/_core/launcher/dragon/dragonLauncher.py
@@ -30,6 +30,7 @@ import os
 import typing as t
 
 from smartsim._core.schemas.dragonRequests import DragonRunPolicy
+from smartsim.error import errors
 from smartsim.types import LaunchedJobID
 
 from ...._core.launcher.stepMapping import StepMap
@@ -143,6 +144,10 @@ class DragonLauncher(WLMLauncher):
         req = DragonRunRequest(**dict(req_args), current_env=merged_env, policy=policy)
         res = _assert_schema_type(self._connector.send_request(req), DragonRunResponse)
         return LaunchedJobID(res.step_id)
+
+    def get_status(self, *launched_ids: LaunchedJobID) -> tuple[SmartSimStatus, ...]:
+        infos = self._get_managed_step_update(list(launched_ids))
+        return tuple(info.status for info in infos)
 
     def run(self, step: Step) -> t.Optional[str]:
         """Run a job step through Slurm
@@ -331,8 +336,12 @@ class DragonLauncher(WLMLauncher):
 
                 step_id_updates[step_id] = info
 
-        # Order matters as we return an ordered list of StepInfo objects
-        return [step_id_updates[step_id] for step_id in step_ids]
+        try:
+            # Order matters as we return an ordered list of StepInfo objects
+            return [step_id_updates[step_id] for step_id in step_ids]
+        except KeyError:
+            msg = "A step info could not be found for one or more of the requested ids"
+            raise errors.UnrecognizedLaunchedJobError(msg) from None
 
     def __str__(self) -> str:
         return "Dragon"

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -48,6 +48,7 @@ if t.TYPE_CHECKING:
 
 
 _T = t.TypeVar("_T")
+_HashableT = t.TypeVar("_HashableT", bound=t.Hashable)
 _TSignalHandlerFn = t.Callable[[int, t.Optional["FrameType"]], object]
 
 
@@ -434,6 +435,22 @@ def first(predicate: t.Callable[[_T], bool], iterable: t.Iterable[_T]) -> _T | N
               return `True`
     """
     return next((item for item in iterable if predicate(item)), None)
+
+
+def unique(iterable: t.Iterable[_HashableT]) -> t.Iterable[_HashableT]:
+    seen = set()
+    for item in filter(lambda x: x not in seen, iterable):
+        seen.add(item)
+        yield item
+
+
+def group_by(
+    fn: t.Callable[[_T], _HashableT], items: t.Iterable[_T]
+) -> t.Mapping[_HashableT, t.Collection[_T]]:
+    groups = collections.defaultdict[_HashableT, list[_T]](list)
+    for item in items:
+        groups[fn(item)].append(item)
+    return groups
 
 
 @t.final

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -461,7 +461,7 @@ def group_by(
 ) -> t.Mapping[_HashableT, t.Collection[_T]]:
     """Iterate over an iterable and group the items based on the return of some
     mapping function. Works similar to SQL's "GROUP BY" statement, but works
-    over an arbitary mapping function.
+    over an arbitrary mapping function.
 
     :param fn: A function mapping the iterable values to some hashable values
     :items: An iterable yielding items to group by mapping function return.

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -438,6 +438,18 @@ def first(predicate: t.Callable[[_T], bool], iterable: t.Iterable[_T]) -> _T | N
 
 
 def unique(iterable: t.Iterable[_HashableT]) -> t.Iterable[_HashableT]:
+    """Iterate over an iterable, yielding only unique values.
+
+    This helper function will maintain a set of seen values in memory and yield
+    any values not previously seen during iteration. This is nice if you know
+    you will be iterating over the iterable exactly once, but if you need to
+    iterate over the iterable multiple times, it would likely use less memory
+    to cast the iterable to a set first.
+
+    :param iterable: An iterable of possibly not unique values.
+    :returns: An iterable of unique values with order unchanged from the
+        original iterable.
+    """
     seen = set()
     for item in filter(lambda x: x not in seen, iterable):
         seen.add(item)
@@ -447,10 +459,19 @@ def unique(iterable: t.Iterable[_HashableT]) -> t.Iterable[_HashableT]:
 def group_by(
     fn: t.Callable[[_T], _HashableT], items: t.Iterable[_T]
 ) -> t.Mapping[_HashableT, t.Collection[_T]]:
+    """Iterate over an iterable and group the items based on the return of some
+    mapping function. Works similar to SQL's "GROUP BY" statement, but works
+    over an arbitary mapping function.
+
+    :param fn: A function mapping the iterable values to some hashable values
+    :items: An iterable yielding items to group by mapping function return.
+    :returns: A mapping of mapping function return values to collection of
+        items that returned that value when fed to the mapping function.
+    """
     groups = collections.defaultdict[_HashableT, list[_T]](list)
     for item in items:
         groups[fn(item)].append(item)
-    return groups
+    return dict(groups)
 
 
 @t.final

--- a/smartsim/error/errors.py
+++ b/smartsim/error/errors.py
@@ -116,6 +116,10 @@ class LauncherNotFoundError(LauncherError):
     """A requested launcher could not be found"""
 
 
+class UnrecognizedLaunchedJobError(LauncherError):
+    """Launcher was asked to get information about a job it did not start"""
+
+
 class AllocationError(LauncherError):
     """Raised when there is a problem with the user WLM allocation"""
 

--- a/smartsim/error/errors.py
+++ b/smartsim/error/errors.py
@@ -116,7 +116,7 @@ class LauncherNotFoundError(LauncherError):
     """A requested launcher could not be found"""
 
 
-class UnrecognizedLaunchedJobError(LauncherError):
+class LauncherJobNotFound(LauncherError):
     """Launcher was asked to get information about a job it did not start"""
 
 

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -234,6 +234,26 @@ class Experiment:
         return execute_dispatch(job), *map(execute_dispatch, jobs)
 
     def get_status(self, *ids: LaunchedJobID) -> tuple[SmartSimStatus, ...]:
+        """Get the status of jobs launched through the `Experiment` from their
+        launched job id returned when calling `Experiment.start`.
+
+        The `Experiment` will map the launched ID back to the launcher that
+        started the job and request a status update. The order of the returned
+        statuses exactly matches the order of the launched job ids.
+
+        If the `Experiment` cannot find any launcher that started the job
+        associated with the launched job id, then a
+        `SmartSimStatus.STATUS_NEVER_STARTED` status is returned for that id.
+
+        If the experiment maps the launched job id to multiple launchers, then
+        a `ValueError` is raised. This should only happen in the case when
+        launched job ids issued by user defined launcher are not sufficiently
+        unique.
+
+        :param ids: A sequence of launched job ids issued by the experiment.
+        :returns: A tuple of statuses with order respective of the order of the
+            calling arguments.
+        """
         ids_ = set(ids)
         to_query = tuple(
             (launcher, requested_ids)

--- a/smartsim/settings/dispatch.py
+++ b/smartsim/settings/dispatch.py
@@ -26,6 +26,7 @@
 
 from __future__ import annotations
 
+import abc
 import collections.abc
 import dataclasses
 import subprocess as sp
@@ -383,8 +384,11 @@ class ExecutableProtocol(t.Protocol):
 
 class LauncherProtocol(collections.abc.Hashable, t.Protocol[_T_contra]):
     @classmethod
+    @abc.abstractmethod
     def create(cls, exp: Experiment, /) -> Self: ...
+    @abc.abstractmethod
     def start(self, launchable: _T_contra, /) -> LaunchedJobID: ...
+    @abc.abstractmethod
     def get_status(
         self, *launched_ids: LaunchedJobID
     ) -> tuple[SmartSimStatus, ...]: ...

--- a/smartsim/status.py
+++ b/smartsim/status.py
@@ -35,8 +35,11 @@ class SmartSimStatus(Enum):
     STATUS_FAILED = "Failed"
     STATUS_NEW = "New"
     STATUS_PAUSED = "Paused"
-    STATUS_NEVER_STARTED = "NeverStarted"
     STATUS_QUEUED = "Queued"
+
+
+class FailedToFetchStatus(Enum):
+    STATUS_NEVER_STARTED = "Never Started"
 
 
 TERMINAL_STATUSES = {

--- a/smartsim/status.py
+++ b/smartsim/status.py
@@ -28,6 +28,7 @@ from enum import Enum
 
 
 class SmartSimStatus(Enum):
+    STATUS_UNKNOWN = "Unknown"
     STATUS_RUNNING = "Running"
     STATUS_COMPLETED = "Completed"
     STATUS_CANCELLED = "Cancelled"

--- a/tests/temp_tests/test_settings/conftest.py
+++ b/tests/temp_tests/test_settings/conftest.py
@@ -52,11 +52,16 @@ def mock_launch_args():
 @pytest.fixture
 def mock_launcher():
     class _MockLauncher(dispatch.LauncherProtocol):
+        __hash__ = object.__hash__
+
         def start(self, launchable):
             return dispatch.create_job_id()
 
         @classmethod
         def create(cls, exp):
             return cls()
+
+        def get_status(self, *ids):
+            raise NotImplementedError
 
     yield _MockLauncher()

--- a/tests/temp_tests/test_settings/test_dispatch.py
+++ b/tests/temp_tests/test_settings/test_dispatch.py
@@ -28,6 +28,7 @@ import abc
 import contextlib
 import dataclasses
 import io
+import sys
 
 import pytest
 
@@ -246,6 +247,9 @@ def test_register_dispatch_to_launcher_types(request, cls, ctx):
 @dataclasses.dataclass(frozen=True)
 class BufferWriterLauncher(dispatch.LauncherProtocol[list[str]]):
     buf: io.StringIO
+
+    if sys.version_info < (3, 10):
+        __hash__ = object.__hash__
 
     @classmethod
     def create(cls, exp):

--- a/tests/temp_tests/test_settings/test_dispatch.py
+++ b/tests/temp_tests/test_settings/test_dispatch.py
@@ -255,6 +255,9 @@ class BufferWriterLauncher(dispatch.LauncherProtocol[list[str]]):
         self.buf.writelines(f"{s}\n" for s in strs)
         return dispatch.create_job_id()
 
+    def get_status(self, *ids):
+        raise NotImplementedError
+
 
 class BufferWriterLauncherSubclass(BufferWriterLauncher): ...
 

--- a/tests/temp_tests/test_settings/test_dispatch.py
+++ b/tests/temp_tests/test_settings/test_dispatch.py
@@ -243,7 +243,7 @@ def test_register_dispatch_to_launcher_types(request, cls, ctx):
         d.dispatch(to_launcher=cls, with_format=format_fn)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class BufferWriterLauncher(dispatch.LauncherProtocol[list[str]]):
     buf: io.StringIO
 

--- a/tests/test_launch_history.py
+++ b/tests/test_launch_history.py
@@ -1,0 +1,200 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2024, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import contextlib
+import itertools
+
+import pytest
+
+from smartsim._core.control.launch_history import LaunchHistory
+from smartsim.settings.dispatch import LauncherProtocol, create_job_id
+
+
+class MockLancher(LauncherProtocol):
+    __hash__ = object.__hash__
+
+    @classmethod
+    def create(cls, _):
+        raise NotImplementedError
+
+    def start(self, _):
+        raise NotImplementedError
+
+    def get_status(self, *_):
+        raise NotImplementedError
+
+
+LAUNCHER_INSTANCE_A = MockLancher()
+LAUNCHER_INSTANCE_B = MockLancher()
+
+
+@pytest.mark.parametrize(
+    "initial_state, to_save",
+    (
+        pytest.param(
+            {},
+            [(MockLancher(), create_job_id())],
+            id="Empty state, one save",
+        ),
+        pytest.param(
+            {},
+            [(MockLancher(), create_job_id()), (MockLancher(), create_job_id())],
+            id="Empty state, many save",
+        ),
+        pytest.param(
+            {},
+            [
+                (LAUNCHER_INSTANCE_A, create_job_id()),
+                (LAUNCHER_INSTANCE_A, create_job_id()),
+            ],
+            id="Empty state, repeat launcher instance",
+        ),
+        pytest.param(
+            {create_job_id(): MockLancher()},
+            [(MockLancher(), create_job_id())],
+            id="Preexisting state, one save",
+        ),
+        pytest.param(
+            {create_job_id(): MockLancher()},
+            [(MockLancher(), create_job_id()), (MockLancher(), create_job_id())],
+            id="Preexisting state, many save",
+        ),
+        pytest.param(
+            {create_job_id(): LAUNCHER_INSTANCE_A},
+            [(LAUNCHER_INSTANCE_A, create_job_id())],
+            id="Preexisting state, repeat launcher instance",
+        ),
+    ),
+)
+def test_save_launch(initial_state, to_save):
+    history = LaunchHistory(initial_state)
+    launcher = MockLancher()
+
+    assert history._id_to_issuer == initial_state
+    for launcher, id_ in to_save:
+        history.save_launch(launcher, id_)
+    assert history._id_to_issuer == initial_state | {id_: l for l, id_ in to_save}
+
+
+def test_save_launch_raises_if_id_already_in_use():
+    launcher = MockLancher()
+    other_launcher = MockLancher()
+    id_ = create_job_id()
+    history = LaunchHistory()
+    history.save_launch(launcher, id_)
+    with pytest.raises(ValueError):
+        history.save_launch(other_launcher, id_)
+
+
+@pytest.mark.parametrize(
+    "ids_to_issuer, expected_num_launchers",
+    (
+        pytest.param(
+            {create_job_id(): MockLancher()},
+            1,
+            id="One launch, one instance",
+        ),
+        pytest.param(
+            {create_job_id(): LAUNCHER_INSTANCE_A for _ in range(5)},
+            1,
+            id="Many launch, one instance",
+        ),
+        pytest.param(
+            {create_job_id(): MockLancher() for _ in range(5)},
+            5,
+            id="Many launch, many instance",
+        ),
+    ),
+)
+def test_iter_past_launchers(ids_to_issuer, expected_num_launchers):
+    history = LaunchHistory(ids_to_issuer)
+    assert len(list(history.iter_past_launchers())) == expected_num_launchers
+    known_launchers = set(history._id_to_issuer.values())
+    assert all(
+        launcher in known_launchers for launcher in history.iter_past_launchers()
+    )
+
+
+ID_A = create_job_id()
+ID_B = create_job_id()
+ID_C = create_job_id()
+
+
+@pytest.mark.parametrize(
+    "init_state, ids, expected_group_by",
+    (
+        pytest.param(
+            {ID_A: LAUNCHER_INSTANCE_A, ID_B: LAUNCHER_INSTANCE_A},
+            None,
+            {LAUNCHER_INSTANCE_A: {ID_A, ID_B}},
+            id="All known ids, single launcher",
+        ),
+        pytest.param(
+            {ID_A: LAUNCHER_INSTANCE_A, ID_B: LAUNCHER_INSTANCE_A},
+            {ID_A},
+            {LAUNCHER_INSTANCE_A: {ID_A}},
+            id="Subset known ids, single launcher",
+        ),
+        pytest.param(
+            {ID_A: LAUNCHER_INSTANCE_A, ID_B: LAUNCHER_INSTANCE_B},
+            None,
+            {LAUNCHER_INSTANCE_A: {ID_A}, LAUNCHER_INSTANCE_B: {ID_B}},
+            id="All known ids, many launchers",
+        ),
+        pytest.param(
+            {ID_A: LAUNCHER_INSTANCE_A, ID_B: LAUNCHER_INSTANCE_B},
+            {ID_A},
+            {LAUNCHER_INSTANCE_A: {ID_A}},
+            id="Subset known ids, many launchers, same issuer",
+        ),
+        pytest.param(
+            {
+                ID_A: LAUNCHER_INSTANCE_A,
+                ID_B: LAUNCHER_INSTANCE_B,
+                ID_C: LAUNCHER_INSTANCE_A,
+            },
+            {ID_A, ID_B},
+            {LAUNCHER_INSTANCE_A: {ID_A}, LAUNCHER_INSTANCE_B: {ID_B}},
+            id="Subset known ids, many launchers, many issuer",
+        ),
+    ),
+)
+def test_group_by_launcher(init_state, ids, expected_group_by):
+    histroy = LaunchHistory(init_state)
+    assert histroy.group_by_launcher(ids) == expected_group_by
+
+
+@pytest.mark.parametrize(
+    "ctx, unknown_ok",
+    (
+        pytest.param(pytest.raises(ValueError), False, id="unknown_ok=False"),
+        pytest.param(contextlib.nullcontext(), True, id="unknown_ok=True"),
+    ),
+)
+def test_group_by_launcher_encounters_unknown_launch_id(ctx, unknown_ok):
+    histroy = LaunchHistory()
+    with ctx:
+        assert histroy.group_by_launcher([create_job_id()], unknown_ok=unknown_ok) == {}

--- a/tests/test_launch_history.py
+++ b/tests/test_launch_history.py
@@ -32,6 +32,8 @@ import pytest
 from smartsim._core.control.launch_history import LaunchHistory
 from smartsim.settings.dispatch import LauncherProtocol, create_job_id
 
+pytestmark = pytest.mark.group_a
+
 
 class MockLancher(LauncherProtocol):
     __hash__ = object.__hash__


### PR DESCRIPTION
Add ability for the `Experiment` to fetch the status a launched job that it started given a `LaunchedJobID`. Teach the `ShellLauncher` and `DragonLauncher` to get statuses of jobs they have launched.