### PR TITLE
Use `torch.from_numpy` instead of `torch.tensor` to reduce a copy

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@ Jump to:
 
 Description
 
+- Reduce a copy by using torch.from_numpy instead of torch.tensor
 - Enable dynamic feature store selection
 - Fix dragon package installation bug
 - Adjust schemas for better performance

--- a/ex/high_throughput_inference/mock_app.py
+++ b/ex/high_throughput_inference/mock_app.py
@@ -157,11 +157,9 @@ class ProtoClient:
             self.measure_time("deserialize_response")
             # list of data blobs? recv depending on the len(response.result.descriptors)?
             data_blob = from_recvh.recv_bytes(timeout=None)
-            result = torch.from_numpy(
-                numpy.frombuffer(
-                    data_blob,
-                    dtype=str(response.result.descriptors[0].dataType),
-                )
+            result = numpy.frombuffer(
+                data_blob,
+                dtype=str(response.result.descriptors[0].dataType),
             )
             self.measure_time("deserialize_tensor")
 

--- a/smartsim/_core/mli/infrastructure/worker/torch_worker.py
+++ b/smartsim/_core/mli/infrastructure/worker/torch_worker.py
@@ -80,7 +80,7 @@ class TorchWorker(MachineLearningWorkerBase):
         for item, item_meta in zip(fetch_result.inputs, fetch_result.meta):
             tensor_desc: tensor_capnp.TensorDescriptor = item_meta
             result.append(
-                torch.tensor(np.frombuffer(item, dtype=str(tensor_desc.dataType)))
+                torch.from_numpy(np.frombuffer(item, dtype=str(tensor_desc.dataType)))
                 .to(device)
                 .reshape(tuple(dim for dim in tensor_desc.dimensions))
             )


### PR DESCRIPTION
During memory profiling we found that `torch.tensor` makes a copy and `torch.from_numpy` does not. We only use `torch.tensor` in `torch_worker.py`, so this is a very small change.

I also added in a change to `mock_app.py` after some discussion that we may not want to return tensors, but we can have more discussion surrounding this if necessary.