### PR TITLE
Rename Status Enums

### DIFF
--- a/smartsim/_core/control/controller.py
+++ b/smartsim/_core/control/controller.py
@@ -65,7 +65,7 @@ from ...error import (
 )
 from ...log import get_logger
 from ...servertype import CLUSTERED, STANDALONE
-from ...status import TERMINAL_STATUSES, SmartSimStatus
+from ...status import TERMINAL_STATUSES, JobStatus
 from ..config import CONFIG
 from ..launcher import (
     DragonLauncher,
@@ -265,7 +265,7 @@ class Controller:
 
                         job = self._jobs[node.name]
                         job.set_status(
-                            SmartSimStatus.STATUS_CANCELLED,
+                            JobStatus.CANCELLED,
                             "",
                             0,
                             output=None,
@@ -297,7 +297,7 @@ class Controller:
 
     def get_entity_status(
         self, entity: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]]
-    ) -> SmartSimStatus:
+    ) -> JobStatus:
         """Get the status of an entity
 
         :param entity: entity to get status of
@@ -313,7 +313,7 @@ class Controller:
 
     def get_entity_list_status(
         self, entity_list: EntitySequence[SmartSimEntity]
-    ) -> t.List[SmartSimStatus]:
+    ) -> t.List[JobStatus]:
         """Get the statuses of an entity list
 
         :param entity_list: entity list containing entities to
@@ -836,7 +836,7 @@ class Controller:
 
                 # _jobs.get_status acquires JM lock for main thread, no need for locking
                 statuses = self.get_entity_list_status(featurestore)
-                if all(stat == SmartSimStatus.STATUS_RUNNING for stat in statuses):
+                if all(stat == JobStatus.RUNNING for stat in statuses):
                     ready = True
                     # TODO: Add a node status check
                 elif any(stat in TERMINAL_STATUSES for stat in statuses):

--- a/smartsim/_core/control/job.py
+++ b/smartsim/_core/control/job.py
@@ -30,7 +30,7 @@ import typing as t
 from dataclasses import dataclass
 
 from ...entity import EntitySequence, SmartSimEntity
-from ...status import SmartSimStatus
+from ...status import JobStatus
 
 
 @dataclass(frozen=True)
@@ -215,7 +215,7 @@ class Job:
         self.name = job_name
         self.jid = job_id
         self.entity = entity
-        self.status = SmartSimStatus.STATUS_NEW
+        self.status = JobStatus.NEW
         # status before smartsim status mapping is applied
         self.raw_status: t.Optional[str] = None
         self.returncode: t.Optional[int] = None
@@ -235,7 +235,7 @@ class Job:
 
     def set_status(
         self,
-        new_status: SmartSimStatus,
+        new_status: JobStatus,
         raw_status: str,
         returncode: t.Optional[int],
         error: t.Optional[str] = None,
@@ -274,7 +274,7 @@ class Job:
         """
         self.name = new_job_name
         self.jid = new_job_id
-        self.status = SmartSimStatus.STATUS_NEW
+        self.status = JobStatus.NEW
         self.returncode = None
         self.output = None
         self.error = None
@@ -327,14 +327,14 @@ class History:
         """
         self.runs = runs
         self.jids: t.Dict[int, t.Optional[str]] = {}
-        self.statuses: t.Dict[int, SmartSimStatus] = {}
+        self.statuses: t.Dict[int, JobStatus] = {}
         self.returns: t.Dict[int, t.Optional[int]] = {}
         self.job_times: t.Dict[int, float] = {}
 
     def record(
         self,
         job_id: t.Optional[str],
-        status: SmartSimStatus,
+        status: JobStatus,
         returncode: t.Optional[int],
         job_time: float,
     ) -> None:

--- a/smartsim/_core/control/jobmanager.py
+++ b/smartsim/_core/control/jobmanager.py
@@ -36,7 +36,7 @@ from ..._core.launcher.step import Step
 from ...database import FeatureStore
 from ...entity import EntitySequence, FSNode, SmartSimEntity
 from ...log import ContextThread, get_logger
-from ...status import TERMINAL_STATUSES, FailedToFetchStatus, SmartSimStatus
+from ...status import TERMINAL_STATUSES, InvalidJobStatus, JobStatus
 from ..config import CONFIG
 from ..launcher import Launcher, LocalLauncher
 from ..utils.network import get_ip_from_host
@@ -228,7 +228,7 @@ class JobManager:
     def get_status(
         self,
         entity: t.Union[SmartSimEntity, EntitySequence[SmartSimEntity]],
-    ) -> t.Union[SmartSimStatus, FailedToFetchStatus]:
+    ) -> t.Union[JobStatus, InvalidJobStatus]:
         """Return the status of a job.
 
         :param entity: SmartSimEntity or EntitySequence instance
@@ -242,7 +242,7 @@ class JobManager:
                 job: Job = self[entity.name]  # locked
                 return job.status
 
-            return FailedToFetchStatus.STATUS_NEVER_STARTED
+            return InvalidJobStatus.NEVER_STARTED
 
     def set_launcher(self, launcher: Launcher) -> None:
         """Set the launcher of the job manager to a specific launcher instance

--- a/smartsim/_core/launcher/dragon/dragonBackend.py
+++ b/smartsim/_core/launcher/dragon/dragonBackend.py
@@ -62,7 +62,7 @@ from ...._core.schemas import (
 )
 from ...._core.utils.helpers import create_short_id_str
 from ....log import get_logger
-from ....status import TERMINAL_STATUSES, SmartSimStatus
+from ....status import TERMINAL_STATUSES, JobStatus
 
 logger = get_logger(__name__)
 
@@ -77,7 +77,7 @@ class DragonStatus(str, Enum):
 
 @dataclass
 class ProcessGroupInfo:
-    status: SmartSimStatus
+    status: JobStatus
     """Status of step"""
     process_group: t.Optional[dragon_process_group.ProcessGroup] = None
     """Internal Process Group object, None for finished or not started steps"""
@@ -91,7 +91,7 @@ class ProcessGroupInfo:
     """Workers used to redirect stdout and stderr to file"""
 
     @property
-    def smartsim_info(self) -> t.Tuple[SmartSimStatus, t.Optional[t.List[int]]]:
+    def smartsim_info(self) -> t.Tuple[JobStatus, t.Optional[t.List[int]]]:
         """Information needed by SmartSim Launcher and Job Manager"""
         return (self.status, self.return_codes)
 
@@ -424,7 +424,7 @@ class DragonBackend:
                         except Exception as e:
                             logger.error(e)
 
-                self._group_infos[step_id].status = SmartSimStatus.STATUS_CANCELLED
+                self._group_infos[step_id].status = JobStatus.CANCELLED
                 self._group_infos[step_id].return_codes = [-9]
 
     @staticmethod
@@ -508,10 +508,10 @@ class DragonBackend:
                 try:
                     grp.init()
                     grp.start()
-                    grp_status = SmartSimStatus.STATUS_RUNNING
+                    grp_status = JobStatus.RUNNING
                 except Exception as e:
                     logger.error(e)
-                    grp_status = SmartSimStatus.STATUS_FAILED
+                    grp_status = JobStatus.FAILED
 
                 puids = None
                 try:
@@ -533,7 +533,7 @@ class DragonBackend:
                 if (
                     puids is not None
                     and len(puids) == len(policies)
-                    and grp_status == SmartSimStatus.STATUS_RUNNING
+                    and grp_status == JobStatus.RUNNING
                 ):
                     redir_grp = DragonBackend._create_redirect_workers(
                         global_policy,
@@ -550,7 +550,7 @@ class DragonBackend:
                             f"Could not redirect stdout and stderr for PUIDS {puids}"
                         ) from e
                     self._group_infos[step_id].redir_workers = redir_grp
-                elif puids is not None and grp_status == SmartSimStatus.STATUS_RUNNING:
+                elif puids is not None and grp_status == JobStatus.RUNNING:
                     logger.error("Cannot redirect workers: some PUIDS are missing")
 
             if started:
@@ -574,11 +574,11 @@ class DragonBackend:
                 group_info = self._group_infos[step_id]
                 grp = group_info.process_group
                 if grp is None:
-                    group_info.status = SmartSimStatus.STATUS_FAILED
+                    group_info.status = JobStatus.FAILED
                     group_info.return_codes = [-1]
                 elif group_info.status not in TERMINAL_STATUSES:
                     if grp.status == str(DragonStatus.RUNNING):
-                        group_info.status = SmartSimStatus.STATUS_RUNNING
+                        group_info.status = JobStatus.RUNNING
                     else:
                         puids = group_info.puids
                         if puids is not None and all(
@@ -594,12 +594,12 @@ class DragonBackend:
                                 group_info.return_codes = [-1 for _ in puids]
                         else:
                             group_info.return_codes = [0]
-                        if not group_info.status == SmartSimStatus.STATUS_CANCELLED:
+                        if not group_info.status == JobStatus.CANCELLED:
                             group_info.status = (
-                                SmartSimStatus.STATUS_FAILED
+                                JobStatus.FAILED
                                 if any(group_info.return_codes)
                                 or grp.status == DragonStatus.ERROR
-                                else SmartSimStatus.STATUS_COMPLETED
+                                else JobStatus.COMPLETED
                             )
 
                 if group_info.status in TERMINAL_STATUSES:
@@ -685,13 +685,11 @@ class DragonBackend:
             honorable, err = self._can_honor(request)
             if not honorable:
                 self._group_infos[step_id] = ProcessGroupInfo(
-                    status=SmartSimStatus.STATUS_FAILED, return_codes=[-1]
+                    status=JobStatus.FAILED, return_codes=[-1]
                 )
             else:
                 self._queued_steps[step_id] = request
-                self._group_infos[step_id] = ProcessGroupInfo(
-                    status=SmartSimStatus.STATUS_NEW
-                )
+                self._group_infos[step_id] = ProcessGroupInfo(status=JobStatus.NEW)
             return DragonRunResponse(step_id=step_id, error_message=err)
 
     @process_request.register

--- a/smartsim/_core/launcher/dragon/dragonLauncher.py
+++ b/smartsim/_core/launcher/dragon/dragonLauncher.py
@@ -43,7 +43,7 @@ from ....settings import (
     SbatchSettings,
     SettingsBase,
 )
-from ....status import SmartSimStatus
+from ....status import JobStatus
 from ...schemas import (
     DragonRunRequest,
     DragonRunRequestView,
@@ -147,7 +147,7 @@ class DragonLauncher(WLMLauncher):
 
     def get_status(
         self, *launched_ids: LaunchedJobID
-    ) -> t.Mapping[LaunchedJobID, SmartSimStatus]:
+    ) -> t.Mapping[LaunchedJobID, JobStatus]:
         infos = self._get_managed_step_update(list(launched_ids))
         return {id_: info.status for id_, info in zip(launched_ids, infos)}
 
@@ -256,9 +256,9 @@ class DragonLauncher(WLMLauncher):
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
         step_info.status = (
-            SmartSimStatus.STATUS_CANCELLED  # set status to cancelled instead of failed
+            JobStatus.CANCELLED  # set status to cancelled instead of failed
         )
-        step_info.launcher_status = str(SmartSimStatus.STATUS_CANCELLED)
+        step_info.launcher_status = str(JobStatus.CANCELLED)
         return step_info
 
     @staticmethod
@@ -318,8 +318,8 @@ class DragonLauncher(WLMLauncher):
                         msg += response.error_message
                     logger.error(msg)
                     info = StepInfo(
-                        SmartSimStatus.STATUS_FAILED,
-                        SmartSimStatus.STATUS_FAILED.value,
+                        JobStatus.FAILED,
+                        JobStatus.FAILED.value,
                         -1,
                     )
                 else:

--- a/smartsim/_core/launcher/lsf/lsfLauncher.py
+++ b/smartsim/_core/launcher/lsf/lsfLauncher.py
@@ -38,7 +38,7 @@ from ....settings import (
     RunSettings,
     SettingsBase,
 )
-from ....status import SmartSimStatus
+from ....status import JobStatus
 from ...config import CONFIG
 from ..launcher import WLMLauncher
 from ..step import (
@@ -152,7 +152,7 @@ class LSFLauncher(WLMLauncher):
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
         step_info.status = (
-            SmartSimStatus.STATUS_CANCELLED
+            JobStatus.CANCELLED
         )  # set status to cancelled instead of failed
         return step_info
 
@@ -203,7 +203,7 @@ class LSFLauncher(WLMLauncher):
                 # create LSFBatchStepInfo objects to return
                 batch_info = LSFBatchStepInfo(stat, None)
                 # account for case where job history is not logged by LSF
-                if batch_info.status == SmartSimStatus.STATUS_COMPLETED:
+                if batch_info.status == JobStatus.COMPLETED:
                     batch_info.returncode = 0
                 updates.append(batch_info)
         return updates

--- a/smartsim/_core/launcher/pbs/pbsLauncher.py
+++ b/smartsim/_core/launcher/pbs/pbsLauncher.py
@@ -39,7 +39,7 @@ from ....settings import (
     RunSettings,
     SettingsBase,
 )
-from ....status import SmartSimStatus
+from ....status import JobStatus
 from ...config import CONFIG
 from ..launcher import WLMLauncher
 from ..step import (
@@ -150,7 +150,7 @@ class PBSLauncher(WLMLauncher):
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
         step_info.status = (
-            SmartSimStatus.STATUS_CANCELLED
+            JobStatus.CANCELLED
         )  # set status to cancelled instead of failed
         return step_info
 
@@ -202,7 +202,7 @@ class PBSLauncher(WLMLauncher):
         for stat, _ in zip(stats, step_ids):
             info = PBSStepInfo(stat or "NOTFOUND", None)
             # account for case where job history is not logged by PBS
-            if info.status == SmartSimStatus.STATUS_COMPLETED:
+            if info.status == JobStatus.COMPLETED:
                 info.returncode = 0
 
             updates.append(info)

--- a/smartsim/_core/launcher/sge/sgeLauncher.py
+++ b/smartsim/_core/launcher/sge/sgeLauncher.py
@@ -37,7 +37,7 @@ from ....settings import (
     SettingsBase,
     SgeQsubBatchSettings,
 )
-from ....status import SmartSimStatus
+from ....status import JobStatus
 from ...config import CONFIG
 from ..launcher import WLMLauncher
 from ..step import (
@@ -137,7 +137,7 @@ class SGELauncher(WLMLauncher):
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
         step_info.status = (
-            SmartSimStatus.STATUS_CANCELLED
+            JobStatus.CANCELLED
         )  # set status to cancelled instead of failed
         return step_info
 
@@ -166,13 +166,13 @@ class SGELauncher(WLMLauncher):
                 if qacct_output:
                     failed = bool(int(parse_qacct_job_output(qacct_output, "failed")))
                     if failed:
-                        info.status = SmartSimStatus.STATUS_FAILED
+                        info.status = JobStatus.FAILED
                         info.returncode = 0
                     else:
-                        info.status = SmartSimStatus.STATUS_COMPLETED
+                        info.status = JobStatus.COMPLETED
                         info.returncode = 0
                 else:  # Assume if qacct did not find it, that the job completed
-                    info.status = SmartSimStatus.STATUS_COMPLETED
+                    info.status = JobStatus.COMPLETED
                     info.returncode = 0
             else:
                 info = SGEStepInfo(stat)

--- a/smartsim/_core/launcher/slurm/slurmLauncher.py
+++ b/smartsim/_core/launcher/slurm/slurmLauncher.py
@@ -40,7 +40,7 @@ from ....settings import (
     SettingsBase,
     SrunSettings,
 )
-from ....status import SmartSimStatus
+from ....status import JobStatus
 from ...config import CONFIG
 from ..launcher import WLMLauncher
 from ..step import (
@@ -213,7 +213,7 @@ class SlurmLauncher(WLMLauncher):
             raise LauncherError(f"Could not get step_info for job step {step_name}")
 
         step_info.status = (
-            SmartSimStatus.STATUS_CANCELLED
+            JobStatus.CANCELLED
         )  # set status to cancelled instead of failed
         return step_info
 

--- a/smartsim/_core/schemas/dragonResponses.py
+++ b/smartsim/_core/schemas/dragonResponses.py
@@ -29,7 +29,7 @@ import typing as t
 from pydantic import BaseModel, Field
 
 import smartsim._core.schemas.utils as _utils
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # Black and Pylint disagree about where to put the `...`
 # pylint: disable=multiple-statements
@@ -51,7 +51,7 @@ class DragonUpdateStatusResponse(DragonResponse):
     # status is a dict: {step_id: (is_alive, returncode)}
     statuses: t.Mapping[
         t.Annotated[str, Field(min_length=1)],
-        t.Tuple[SmartSimStatus, t.Optional[t.List[int]]],
+        t.Tuple[JobStatus, t.Optional[t.List[int]]],
     ] = {}
 
 

--- a/smartsim/_core/utils/telemetry/util.py
+++ b/smartsim/_core/utils/telemetry/util.py
@@ -31,7 +31,7 @@ import pathlib
 import typing as t
 
 from smartsim._core.launcher.stepInfo import StepInfo
-from smartsim.status import TERMINAL_STATUSES, SmartSimStatus
+from smartsim.status import TERMINAL_STATUSES, JobStatus
 
 _EventClass = t.Literal["start", "stop", "timestep"]
 
@@ -106,8 +106,6 @@ def map_return_code(step_info: StepInfo) -> t.Optional[int]:
     :return: a return code if the step is finished, otherwise None
     """
     rc_map = {s: 1 for s in TERMINAL_STATUSES}  # return `1` for all terminal statuses
-    rc_map.update(
-        {SmartSimStatus.STATUS_COMPLETED: os.EX_OK}
-    )  # return `0` for full success
+    rc_map.update({JobStatus.COMPLETED: os.EX_OK})  # return `0` for full success
 
     return rc_map.get(step_info.status, None)  # return `None` when in-progress

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -42,7 +42,7 @@ from smartsim._core.config import CONFIG
 from smartsim._core.control.launch_history import LaunchHistory as _LaunchHistory
 from smartsim.error import errors
 from smartsim.settings import dispatch
-from smartsim.status import FailedToFetchStatus, SmartSimStatus
+from smartsim.status import InvalidJobStatus, JobStatus
 
 from ._core import Controller, Generator, Manifest, previewrenderer
 from .database import FeatureStore
@@ -232,7 +232,7 @@ class Experiment:
 
     def get_status(
         self, *ids: LaunchedJobID
-    ) -> tuple[SmartSimStatus | FailedToFetchStatus, ...]:
+    ) -> tuple[JobStatus | InvalidJobStatus, ...]:
         """Get the status of jobs launched through the `Experiment` from their
         launched job id returned when calling `Experiment.start`.
 
@@ -242,8 +242,7 @@ class Experiment:
 
         If the `Experiment` cannot find any launcher that started the job
         associated with the launched job id, then a
-        `FailedToFetchStatus.STATUS_NEVER_STARTED` status is returned for that
-        id.
+        `InvalidJobStatus.NEVER_STARTED` status is returned for that id.
 
         If the experiment maps the launched job id to multiple launchers, then
         a `ValueError` is raised. This should only happen in the case when
@@ -259,9 +258,7 @@ class Experiment:
         ).items()
         stats_iter = (launcher.get_status(*ids).items() for launcher, ids in to_query)
         stats_map = dict(itertools.chain.from_iterable(stats_iter))
-        stats = (
-            stats_map.get(i, FailedToFetchStatus.STATUS_NEVER_STARTED) for i in ids
-        )
+        stats = (stats_map.get(i, InvalidJobStatus.NEVER_STARTED) for i in ids)
         return tuple(stats)
 
     @_contextualize

--- a/smartsim/status.py
+++ b/smartsim/status.py
@@ -27,23 +27,23 @@
 from enum import Enum
 
 
-class SmartSimStatus(Enum):
-    STATUS_UNKNOWN = "Unknown"
-    STATUS_RUNNING = "Running"
-    STATUS_COMPLETED = "Completed"
-    STATUS_CANCELLED = "Cancelled"
-    STATUS_FAILED = "Failed"
-    STATUS_NEW = "New"
-    STATUS_PAUSED = "Paused"
-    STATUS_QUEUED = "Queued"
+class JobStatus(Enum):
+    UNKNOWN = "Unknown"
+    RUNNING = "Running"
+    COMPLETED = "Completed"
+    CANCELLED = "Cancelled"
+    FAILED = "Failed"
+    NEW = "New"
+    PAUSED = "Paused"
+    QUEUED = "Queued"
 
 
-class FailedToFetchStatus(Enum):
-    STATUS_NEVER_STARTED = "Never Started"
+class InvalidJobStatus(Enum):
+    NEVER_STARTED = "Never Started"
 
 
 TERMINAL_STATUSES = {
-    SmartSimStatus.STATUS_CANCELLED,
-    SmartSimStatus.STATUS_COMPLETED,
-    SmartSimStatus.STATUS_FAILED,
+    JobStatus.CANCELLED,
+    JobStatus.COMPLETED,
+    JobStatus.FAILED,
 }

--- a/tests/_legacy/backends/test_dataloader.py
+++ b/tests/_legacy/backends/test_dataloader.py
@@ -35,7 +35,7 @@ from smartsim.error.errors import SSInternalError
 from smartsim.experiment import Experiment
 from smartsim.log import get_logger
 from smartsim.ml.data import DataInfo, TrainingDataUploader
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 logger = get_logger(__name__)
 
@@ -283,7 +283,7 @@ def test_torch_dataloaders(
         trainer = create_trainer_torch(wlm_experiment, config_dir, wlmutils)
         wlm_experiment.start(trainer, block=True)
 
-        assert wlm_experiment.get_status(trainer)[0] == SmartSimStatus.STATUS_COMPLETED
+        assert wlm_experiment.get_status(trainer)[0] == JobStatus.COMPLETED
 
     except Exception as e:
         raise e

--- a/tests/_legacy/backends/test_dbmodel.py
+++ b/tests/_legacy/backends/test_dbmodel.py
@@ -35,7 +35,7 @@ from smartsim.entity import Ensemble
 from smartsim.entity.dbobject import FSModel
 from smartsim.error.errors import SSUnsupportedError
 from smartsim.log import get_logger
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 logger = get_logger(__name__)
 
@@ -212,7 +212,7 @@ def test_tf_fs_model(
     wlm_experiment.start(smartsim_model, block=True)
     statuses = wlm_experiment.get_status(smartsim_model)
     assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+        stat == JobStatus.COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -270,7 +270,7 @@ def test_pt_fs_model(
     wlm_experiment.start(smartsim_model, block=True)
     statuses = wlm_experiment.get_status(smartsim_model)
     assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+        stat == JobStatus.COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -362,7 +362,7 @@ def test_fs_model_ensemble(
     wlm_experiment.start(smartsim_ensemble, block=True)
     statuses = wlm_experiment.get_status(smartsim_ensemble)
     assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+        stat == JobStatus.COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -432,7 +432,7 @@ def test_colocated_fs_model_tf(fileutils, test_dir, wlmutils, mlutils):
         exp.start(colo_model, block=True)
         statuses = exp.get_status(colo_model)
         assert all(
-            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+            stat == JobStatus.COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(colo_model)
@@ -492,7 +492,7 @@ def test_colocated_fs_model_pytorch(fileutils, test_dir, wlmutils, mlutils):
         exp.start(colo_model, block=True)
         statuses = exp.get_status(colo_model)
         assert all(
-            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+            stat == JobStatus.COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(colo_model)
@@ -593,7 +593,7 @@ def test_colocated_fs_model_ensemble(fileutils, test_dir, wlmutils, mlutils):
         exp.start(colo_ensemble, block=True)
         statuses = exp.get_status(colo_ensemble)
         assert all(
-            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+            stat == JobStatus.COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(colo_ensemble)
@@ -697,7 +697,7 @@ def test_colocated_fs_model_ensemble_reordered(fileutils, test_dir, wlmutils, ml
         exp.start(colo_ensemble, block=True)
         statuses = exp.get_status(colo_ensemble)
         assert all(
-            stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+            stat == JobStatus.COMPLETED for stat in statuses
         ), f"Statuses: {statuses}"
     finally:
         exp.stop(colo_ensemble)

--- a/tests/_legacy/backends/test_dbscript.py
+++ b/tests/_legacy/backends/test_dbscript.py
@@ -36,7 +36,7 @@ from smartsim.entity.dbobject import FSScript
 from smartsim.error.errors import SSUnsupportedError
 from smartsim.log import get_logger
 from smartsim.settings import MpiexecSettings, MpirunSettings
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 logger = get_logger(__name__)
 
@@ -119,7 +119,7 @@ def test_fs_script(wlm_experiment, prepare_fs, single_fs, fileutils, mlutils):
     # Launch and check successful completion
     wlm_experiment.start(smartsim_application, block=True)
     statuses = wlm_experiment.get_status(smartsim_application)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 @pytest.mark.skipif(not should_run, reason="Test needs Torch to run")
@@ -208,7 +208,7 @@ def test_fs_script_ensemble(wlm_experiment, prepare_fs, single_fs, fileutils, ml
 
     wlm_experiment.start(ensemble, block=True)
     statuses = wlm_experiment.get_status(ensemble)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 @pytest.mark.skipif(not should_run, reason="Test needs Torch to run")
@@ -273,7 +273,7 @@ def test_colocated_fs_script(fileutils, test_dir, wlmutils, mlutils):
     try:
         exp.start(colo_application, block=True)
         statuses = exp.get_status(colo_application)
-        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == JobStatus.COMPLETED for stat in statuses])
     finally:
         exp.stop(colo_application)
 
@@ -373,7 +373,7 @@ def test_colocated_fs_script_ensemble(fileutils, test_dir, wlmutils, mlutils):
     try:
         exp.start(colo_ensemble, block=True)
         statuses = exp.get_status(colo_ensemble)
-        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == JobStatus.COMPLETED for stat in statuses])
     finally:
         exp.stop(colo_ensemble)
 
@@ -471,7 +471,7 @@ def test_colocated_fs_script_ensemble_reordered(fileutils, test_dir, wlmutils, m
     try:
         exp.start(colo_ensemble, block=True)
         statuses = exp.get_status(colo_ensemble)
-        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == JobStatus.COMPLETED for stat in statuses])
     finally:
         exp.stop(colo_ensemble)
 

--- a/tests/_legacy/backends/test_onnx.py
+++ b/tests/_legacy/backends/test_onnx.py
@@ -32,7 +32,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim._core.utils import installed_redisai_backends
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 sklearn_available = True
 try:
@@ -94,4 +94,4 @@ def test_sklearn_onnx(wlm_experiment, prepare_fs, single_fs, mlutils, wlmutils):
 
     # if model failed, test will fail
     model_status = wlm_experiment.get_status(model)
-    assert model_status[0] != SmartSimStatus.STATUS_FAILED
+    assert model_status[0] != JobStatus.FAILED

--- a/tests/_legacy/backends/test_tf.py
+++ b/tests/_legacy/backends/test_tf.py
@@ -32,7 +32,7 @@ import pytest
 from smartsim import Experiment
 from smartsim._core.utils import installed_redisai_backends
 from smartsim.error import SmartSimError
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 tf_available = True
 try:
@@ -81,7 +81,7 @@ def test_keras_model(wlm_experiment, prepare_fs, single_fs, mlutils, wlmutils):
 
     # if model failed, test will fail
     model_status = wlm_experiment.get_status(model)[0]
-    assert model_status != SmartSimStatus.STATUS_FAILED
+    assert model_status != JobStatus.FAILED
 
 
 def create_tf_model():

--- a/tests/_legacy/backends/test_torch.py
+++ b/tests/_legacy/backends/test_torch.py
@@ -31,7 +31,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim._core.utils import installed_redisai_backends
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 torch_available = True
 try:
@@ -82,4 +82,4 @@ def test_torch_model_and_script(
 
     # if model failed, test will fail
     model_status = wlm_experiment.get_status(model)[0]
-    assert model_status != SmartSimStatus.STATUS_FAILED
+    assert model_status != JobStatus.FAILED

--- a/tests/_legacy/full_wlm/test_generic_batch_launch.py
+++ b/tests/_legacy/full_wlm/test_generic_batch_launch.py
@@ -30,7 +30,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim.settings import QsubBatchSettings
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -74,7 +74,7 @@ def test_batch_application(fileutils, test_dir, wlmutils):
     exp.start(application, block=True)
     statuses = exp.get_status(application)
     assert len(statuses) == 1
-    assert statuses[0] == SmartSimStatus.STATUS_COMPLETED
+    assert statuses[0] == JobStatus.COMPLETED
 
 
 def test_batch_ensemble(fileutils, test_dir, wlmutils):
@@ -99,7 +99,7 @@ def test_batch_ensemble(fileutils, test_dir, wlmutils):
     exp.generate(ensemble)
     exp.start(ensemble, block=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_batch_ensemble_replicas(fileutils, test_dir, wlmutils):
@@ -119,7 +119,7 @@ def test_batch_ensemble_replicas(fileutils, test_dir, wlmutils):
 
     exp.start(ensemble, block=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_batch_run_args_leading_dashes(fileutils, test_dir, wlmutils):
@@ -142,4 +142,4 @@ def test_batch_run_args_leading_dashes(fileutils, test_dir, wlmutils):
 
     exp.start(model, block=True)
     statuses = exp.get_status(model)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])

--- a/tests/_legacy/full_wlm/test_generic_orc_launch_batch.py
+++ b/tests/_legacy/full_wlm/test_generic_orc_launch_batch.py
@@ -32,7 +32,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim.settings.pbsSettings import QsubBatchSettings
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -79,13 +79,13 @@ def test_launch_feature_store_auto_batch(test_dir, wlmutils):
     statuses = exp.get_status(feature_store)
 
     # don't use assert so that we don't leave an orphan process
-    if SmartSimStatus.STATUS_FAILED in statuses:
+    if JobStatus.FAILED in statuses:
         exp.stop(feature_store)
         assert False
 
     exp.stop(feature_store)
     statuses = exp.get_status(feature_store)
-    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == JobStatus.CANCELLED for stat in statuses])
 
 
 def test_launch_cluster_feature_store_batch_single(test_dir, wlmutils):
@@ -116,13 +116,13 @@ def test_launch_cluster_feature_store_batch_single(test_dir, wlmutils):
     statuses = exp.get_status(feature_store)
 
     # don't use assert so that feature_store we don't leave an orphan process
-    if SmartSimStatus.STATUS_FAILED in statuses:
+    if JobStatus.FAILED in statuses:
         exp.stop(feature_store)
         assert False
 
     exp.stop(feature_store)
     statuses = exp.get_status(feature_store)
-    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == JobStatus.CANCELLED for stat in statuses])
 
 
 def test_launch_cluster_feature_store_batch_multi(test_dir, wlmutils):
@@ -153,13 +153,13 @@ def test_launch_cluster_feature_store_batch_multi(test_dir, wlmutils):
     statuses = exp.get_status(feature_store)
 
     # don't use assert so that feature_store we don't leave an orphan process
-    if SmartSimStatus.STATUS_FAILED in statuses:
+    if JobStatus.FAILED in statuses:
         exp.stop(feature_store)
         assert False
 
     exp.stop(feature_store)
     statuses = exp.get_status(feature_store)
-    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == JobStatus.CANCELLED for stat in statuses])
 
 
 def test_launch_cluster_feature_store_reconnect(test_dir, wlmutils):
@@ -186,7 +186,7 @@ def test_launch_cluster_feature_store_reconnect(test_dir, wlmutils):
 
     statuses = exp.get_status(feature_store)
     try:
-        assert all(stat == SmartSimStatus.STATUS_RUNNING for stat in statuses)
+        assert all(stat == JobStatus.RUNNING for stat in statuses)
     except Exception:
         exp.stop(feature_store)
         raise
@@ -204,7 +204,7 @@ def test_launch_cluster_feature_store_reconnect(test_dir, wlmutils):
         time.sleep(5)
 
         statuses = exp_2.get_status(reloaded_feature_store)
-        assert all(stat == SmartSimStatus.STATUS_RUNNING for stat in statuses)
+        assert all(stat == JobStatus.RUNNING for stat in statuses)
     except Exception:
         # Something went wrong! Let the experiment that started the FS
         # clean up the FS
@@ -215,7 +215,7 @@ def test_launch_cluster_feature_store_reconnect(test_dir, wlmutils):
         # Test experiment 2 can stop the FS
         exp_2.stop(reloaded_feature_store)
         assert all(
-            stat == SmartSimStatus.STATUS_CANCELLED
+            stat == JobStatus.CANCELLED
             for stat in exp_2.get_status(reloaded_feature_store)
         )
     except Exception:
@@ -227,6 +227,5 @@ def test_launch_cluster_feature_store_reconnect(test_dir, wlmutils):
         # Ensure  it is the same FS that Experiment 1 was tracking
         time.sleep(5)
         assert not any(
-            stat == SmartSimStatus.STATUS_RUNNING
-            for stat in exp.get_status(feature_store)
+            stat == JobStatus.RUNNING for stat in exp.get_status(feature_store)
         )

--- a/tests/_legacy/full_wlm/test_mpmd.py
+++ b/tests/_legacy/full_wlm/test_mpmd.py
@@ -30,7 +30,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim._core.utils.helpers import is_valid_cmd
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -92,8 +92,8 @@ def test_mpmd(fileutils, test_dir, wlmutils):
         )
         exp.start(mpmd_application, block=True)
         statuses = exp.get_status(mpmd_application)
-        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
         exp.start(mpmd_application, block=True)
         statuses = exp.get_status(mpmd_application)
-        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == JobStatus.COMPLETED for stat in statuses])

--- a/tests/_legacy/on_wlm/test_base_settings_on_wlm.py
+++ b/tests/_legacy/on_wlm/test_base_settings_on_wlm.py
@@ -29,7 +29,7 @@ import time
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 """
 Test the launch and stop of applications and ensembles using base
@@ -55,7 +55,7 @@ def test_application_on_wlm(fileutils, test_dir, wlmutils):
     for _ in range(2):
         exp.start(M1, M2, block=True)
         statuses = exp.get_status(M1, M2)
-        assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+        assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_application_stop_on_wlm(fileutils, test_dir, wlmutils):
@@ -75,4 +75,4 @@ def test_application_stop_on_wlm(fileutils, test_dir, wlmutils):
     assert M1.name in exp._control._jobs.completed
     assert M2.name in exp._control._jobs.completed
     statuses = exp.get_status(M1, M2)
-    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == JobStatus.CANCELLED for stat in statuses])

--- a/tests/_legacy/on_wlm/test_colocated_model.py
+++ b/tests/_legacy/on_wlm/test_colocated_model.py
@@ -30,7 +30,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim.entity import Application
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 if sys.platform == "darwin":
     supported_fss = ["tcp", "deprecated"]
@@ -63,14 +63,14 @@ def test_launch_colocated_application_defaults(fileutils, test_dir, coloutils, f
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
     assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+        stat == JobStatus.COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
     # test restarting the colocated application
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
     assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+        stat == JobStatus.COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -94,7 +94,7 @@ def test_colocated_application_disable_pinning(fileutils, test_dir, coloutils, f
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
     assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+        stat == JobStatus.COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -121,7 +121,7 @@ def test_colocated_application_pinning_auto_2cpu(
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
     assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+        stat == JobStatus.COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -149,7 +149,7 @@ def test_colocated_application_pinning_range(fileutils, test_dir, coloutils, fs_
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
     assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+        stat == JobStatus.COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -176,7 +176,7 @@ def test_colocated_application_pinning_list(fileutils, test_dir, coloutils, fs_t
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
     assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+        stat == JobStatus.COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"
 
 
@@ -203,5 +203,5 @@ def test_colocated_application_pinning_mixed(fileutils, test_dir, coloutils, fs_
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
     assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
+        stat == JobStatus.COMPLETED for stat in statuses
     ), f"Statuses: {statuses}"

--- a/tests/_legacy/on_wlm/test_containers_wlm.py
+++ b/tests/_legacy/on_wlm/test_containers_wlm.py
@@ -31,7 +31,7 @@ import pytest
 from smartsim import Experiment
 from smartsim.entity import Ensemble
 from smartsim.settings.containers import Singularity
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 """Test SmartRedis container integration on a supercomputer with a WLM."""
 
@@ -92,7 +92,7 @@ def test_singularity_wlm_smartredis(fileutils, test_dir, wlmutils):
 
     # get and confirm statuses
     statuses = exp.get_status(ensemble)
-    if not all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses]):
+    if not all([stat == JobStatus.COMPLETED for stat in statuses]):
         exp.stop(feature_store)
         assert False  # client ensemble failed
 

--- a/tests/_legacy/on_wlm/test_dragon.py
+++ b/tests/_legacy/on_wlm/test_dragon.py
@@ -27,7 +27,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim._core.launcher.dragon.dragonLauncher import DragonLauncher
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher != "dragon":
@@ -48,7 +48,7 @@ def test_dragon_global_path(global_dragon_teardown, wlmutils, test_dir, monkeypa
     exp.start(model, block=True)
 
     try:
-        assert exp.get_status(model)[0] == SmartSimStatus.STATUS_COMPLETED
+        assert exp.get_status(model)[0] == JobStatus.COMPLETED
     finally:
         launcher: DragonLauncher = exp._control._launcher
         launcher.cleanup()
@@ -68,7 +68,7 @@ def test_dragon_exp_path(global_dragon_teardown, wlmutils, test_dir, monkeypatch
     exp.generate(model)
     exp.start(model, block=True)
     try:
-        assert exp.get_status(model)[0] == SmartSimStatus.STATUS_COMPLETED
+        assert exp.get_status(model)[0] == JobStatus.COMPLETED
     finally:
         launcher: DragonLauncher = exp._control._launcher
         launcher.cleanup()
@@ -88,7 +88,7 @@ def test_dragon_cannot_honor(wlmutils, test_dir):
     exp.start(model, block=True)
 
     try:
-        assert exp.get_status(model)[0] == SmartSimStatus.STATUS_FAILED
+        assert exp.get_status(model)[0] == JobStatus.FAILED
     finally:
         launcher: DragonLauncher = exp._control._launcher
         launcher.cleanup()

--- a/tests/_legacy/on_wlm/test_generic_orc_launch.py
+++ b/tests/_legacy/on_wlm/test_generic_orc_launch.py
@@ -27,7 +27,7 @@
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -55,13 +55,13 @@ def test_launch_feature_store_auto(test_dir, wlmutils):
     statuses = exp.get_status(feature_store)
 
     # don't use assert so that we don't leave an orphan process
-    if SmartSimStatus.STATUS_FAILED in statuses:
+    if JobStatus.FAILED in statuses:
         exp.stop(feature_store)
         assert False
 
     exp.stop(feature_store)
     statuses = exp.get_status(feature_store)
-    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == JobStatus.CANCELLED for stat in statuses])
 
 
 def test_launch_cluster_feature_store_single(test_dir, wlmutils):
@@ -87,13 +87,13 @@ def test_launch_cluster_feature_store_single(test_dir, wlmutils):
     statuses = exp.get_status(feature_store)
 
     # don't use assert so that feature_store we don't leave an orphan process
-    if SmartSimStatus.STATUS_FAILED in statuses:
+    if JobStatus.FAILED in statuses:
         exp.stop(feature_store)
         assert False
 
     exp.stop(feature_store)
     statuses = exp.get_status(feature_store)
-    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == JobStatus.CANCELLED for stat in statuses])
 
 
 def test_launch_cluster_feature_store_multi(test_dir, wlmutils):
@@ -119,10 +119,10 @@ def test_launch_cluster_feature_store_multi(test_dir, wlmutils):
     statuses = exp.get_status(feature_store)
 
     # don't use assert so that feature_store we don't leave an orphan process
-    if SmartSimStatus.STATUS_FAILED in statuses:
+    if JobStatus.FAILED in statuses:
         exp.stop(feature_store)
         assert False
 
     exp.stop(feature_store)
     statuses = exp.get_status(feature_store)
-    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == JobStatus.CANCELLED for stat in statuses])

--- a/tests/_legacy/on_wlm/test_launch_errors.py
+++ b/tests/_legacy/on_wlm/test_launch_errors.py
@@ -30,7 +30,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim.error import SmartSimError
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -57,7 +57,7 @@ def test_failed_status(fileutils, test_dir, wlmutils):
         time.sleep(2)
     stat = exp.get_status(application)
     assert len(stat) == 1
-    assert stat[0] == SmartSimStatus.STATUS_FAILED
+    assert stat[0] == JobStatus.FAILED
 
 
 def test_bad_run_command_args(fileutils, test_dir, wlmutils):

--- a/tests/_legacy/on_wlm/test_launch_ompi_lsf.py
+++ b/tests/_legacy/on_wlm/test_launch_ompi_lsf.py
@@ -27,7 +27,7 @@
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -52,4 +52,4 @@ def test_launch_openmpi_lsf(fileutils, test_dir, wlmutils):
     )
     exp.start(application, block=True)
     statuses = exp.get_status(application)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])

--- a/tests/_legacy/on_wlm/test_restart.py
+++ b/tests/_legacy/on_wlm/test_restart.py
@@ -29,7 +29,7 @@ from copy import deepcopy
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # retrieved from pytest fixtures
 if pytest.test_launcher not in pytest.wlm_options:
@@ -49,10 +49,10 @@ def test_restart(fileutils, test_dir, wlmutils):
 
     exp.start(M1, M2, block=True)
     statuses = exp.get_status(M1, M2)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
     exp.start(M1, M2, block=True)
     statuses = exp.get_status(M1, M2)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
     # TODO add job history check here.

--- a/tests/_legacy/on_wlm/test_simple_base_settings_on_wlm.py
+++ b/tests/_legacy/on_wlm/test_simple_base_settings_on_wlm.py
@@ -30,7 +30,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim.settings.settings import RunSettings
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 """
 Test the launch and stop of simple applications and ensembles that use base
@@ -64,7 +64,7 @@ def test_simple_application_on_wlm(fileutils, test_dir, wlmutils):
     # launch application twice to show that it can also be restarted
     for _ in range(2):
         exp.start(M, block=True)
-        assert exp.get_status(M)[0] == SmartSimStatus.STATUS_COMPLETED
+        assert exp.get_status(M)[0] == JobStatus.COMPLETED
 
 
 def test_simple_application_stop_on_wlm(fileutils, test_dir, wlmutils):
@@ -84,4 +84,4 @@ def test_simple_application_stop_on_wlm(fileutils, test_dir, wlmutils):
     time.sleep(2)
     exp.stop(M)
     assert M.name in exp._control._jobs.completed
-    assert exp.get_status(M)[0] == SmartSimStatus.STATUS_CANCELLED
+    assert exp.get_status(M)[0] == JobStatus.CANCELLED

--- a/tests/_legacy/on_wlm/test_simple_entity_launch.py
+++ b/tests/_legacy/on_wlm/test_simple_entity_launch.py
@@ -31,7 +31,7 @@ from pathlib import Path
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 """
 Test the launch of simple entity types on pre-existing allocations.
@@ -62,7 +62,7 @@ def test_applications(fileutils, test_dir, wlmutils):
 
     exp.start(M1, M2, block=True)
     statuses = exp.get_status(M1, M2)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_multinode_app(mpi_app_path, test_dir, wlmutils):
@@ -108,7 +108,7 @@ def test_ensemble(fileutils, test_dir, wlmutils):
 
     exp.start(ensemble, block=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_summary(fileutils, test_dir, wlmutils):
@@ -132,8 +132,8 @@ def test_summary(fileutils, test_dir, wlmutils):
 
     # start and poll
     exp.start(sleep_exp, bad)
-    assert exp.get_status(bad)[0] == SmartSimStatus.STATUS_FAILED
-    assert exp.get_status(sleep_exp)[0] == SmartSimStatus.STATUS_COMPLETED
+    assert exp.get_status(bad)[0] == JobStatus.FAILED
+    assert exp.get_status(sleep_exp)[0] == JobStatus.COMPLETED
 
     summary_str = exp.summary(style="plain")
     print(summary_str)

--- a/tests/_legacy/on_wlm/test_stop.py
+++ b/tests/_legacy/on_wlm/test_stop.py
@@ -29,7 +29,7 @@ import time
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 """
 Test Stopping launched entities.
@@ -56,7 +56,7 @@ def test_stop_entity(fileutils, test_dir, wlmutils):
     time.sleep(5)
     exp.stop(M1)
     assert M1.name in exp._control._jobs.completed
-    assert exp.get_status(M1)[0] == SmartSimStatus.STATUS_CANCELLED
+    assert exp.get_status(M1)[0] == JobStatus.CANCELLED
 
 
 def test_stop_entity_list(fileutils, test_dir, wlmutils):
@@ -73,5 +73,5 @@ def test_stop_entity_list(fileutils, test_dir, wlmutils):
     time.sleep(5)
     exp.stop(ensemble)
     statuses = exp.get_status(ensemble)
-    assert all([stat == SmartSimStatus.STATUS_CANCELLED for stat in statuses])
+    assert all([stat == JobStatus.CANCELLED for stat in statuses])
     assert all([m.name in exp._control._jobs.completed for m in ensemble])

--- a/tests/_legacy/test_colo_model_local.py
+++ b/tests/_legacy/test_colo_model_local.py
@@ -31,7 +31,7 @@ import pytest
 from smartsim import Experiment
 from smartsim.entity import Application
 from smartsim.error import SSUnsupportedError
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the slow_tests group
 pytestmark = pytest.mark.slow_tests
@@ -149,14 +149,12 @@ def test_launch_colocated_application_defaults(
     exp.generate(colo_application)
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
-    assert all(stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses)
+    assert all(stat == JobStatus.COMPLETED for stat in statuses)
 
     # test restarting the colocated application
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
-    assert all(
-        stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses
-    ), f"Statuses {statuses}"
+    assert all(stat == JobStatus.COMPLETED for stat in statuses), f"Statuses {statuses}"
 
 
 @pytest.mark.parametrize("fs_type", supported_fss)
@@ -191,12 +189,12 @@ def test_launch_multiple_colocated_applications(
     exp.generate(*colo_applications)
     exp.start(*colo_applications, block=True)
     statuses = exp.get_status(*colo_applications)
-    assert all(stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses)
+    assert all(stat == JobStatus.COMPLETED for stat in statuses)
 
     # test restarting the colocated application
     exp.start(*colo_applications, block=True)
     statuses = exp.get_status(*colo_applications)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 @pytest.mark.parametrize("fs_type", supported_fss)
@@ -222,7 +220,7 @@ def test_colocated_application_disable_pinning(
     exp.generate(colo_application)
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 @pytest.mark.parametrize("fs_type", supported_fss)
@@ -256,7 +254,7 @@ def test_colocated_application_pinning_auto_2cpu(
     exp.generate(colo_application)
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 @pytest.mark.skipif(is_mac, reason="unsupported on MacOSX")
@@ -285,7 +283,7 @@ def test_colocated_application_pinning_range(
     exp.generate(colo_application)
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 @pytest.mark.skipif(is_mac, reason="unsupported on MacOSX")
@@ -312,7 +310,7 @@ def test_colocated_application_pinning_list(
     exp.generate(colo_application)
     exp.start(colo_application, block=True)
     statuses = exp.get_status(colo_application)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_colo_uds_verifies_socket_file_name(test_dir, launcher="local"):

--- a/tests/_legacy/test_containers.py
+++ b/tests/_legacy/test_containers.py
@@ -34,7 +34,7 @@ import pytest
 from smartsim import Experiment, status
 from smartsim.entity import Ensemble
 from smartsim.settings.containers import Singularity
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a
@@ -109,7 +109,7 @@ def test_singularity_basic(fileutils, test_dir):
 
     # get and confirm status
     stat = exp.get_status(application)[0]
-    assert stat == SmartSimStatus.STATUS_COMPLETED
+    assert stat == JobStatus.COMPLETED
 
     print(exp.summary())
 
@@ -136,7 +136,7 @@ def test_singularity_args(fileutils, test_dir):
 
     # get and confirm status
     stat = exp.get_status(application)[0]
-    assert stat == SmartSimStatus.STATUS_COMPLETED
+    assert stat == JobStatus.COMPLETED
 
     print(exp.summary())
 
@@ -180,5 +180,5 @@ def test_singularity_smartredis(local_experiment, prepare_fs, local_fs, fileutil
 
     # get and confirm statuses
     statuses = local_experiment.get_status(ensemble)
-    if not all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses]):
+    if not all([stat == JobStatus.COMPLETED for stat in statuses]):
         assert False  # client ensemble failed

--- a/tests/_legacy/test_experiment.py
+++ b/tests/_legacy/test_experiment.py
@@ -40,7 +40,7 @@ from smartsim.entity import Application
 from smartsim.error import SmartSimError
 from smartsim.error.errors import SSUnsupportedError
 from smartsim.settings import RunSettings
-from smartsim.status import SmartSimStatus
+from smartsim.status import InvalidJobStatus
 
 if t.TYPE_CHECKING:
     import conftest
@@ -113,7 +113,7 @@ def test_status_typeerror() -> None:
 def test_status_pre_launch() -> None:
     application = Application("name", {}, "./", RunSettings("python"))
     exp = Experiment("test")
-    assert exp.get_status(application)[0] == SmartSimStatus.STATUS_NEVER_STARTED
+    assert exp.get_status(application)[0] == InvalidJobStatus.NEVER_STARTED
 
 
 def test_bad_ensemble_init_no_rs(test_dir: str) -> None:

--- a/tests/_legacy/test_launch_errors.py
+++ b/tests/_legacy/test_launch_errors.py
@@ -31,7 +31,7 @@ from smartsim import Experiment
 from smartsim.database import FeatureStore
 from smartsim.error import SSUnsupportedError
 from smartsim.settings import JsrunSettings, RunSettings
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a
@@ -58,7 +58,7 @@ def test_model_failure(fileutils, test_dir):
 
     exp.start(M1, block=True)
     statuses = exp.get_status(M1)
-    assert all([stat == SmartSimStatus.STATUS_FAILED for stat in statuses])
+    assert all([stat == JobStatus.FAILED for stat in statuses])
 
 
 def test_feature_store_relaunch(test_dir, wlmutils):

--- a/tests/_legacy/test_local_launch.py
+++ b/tests/_legacy/test_local_launch.py
@@ -27,7 +27,7 @@
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a
@@ -50,7 +50,7 @@ def test_applications(fileutils, test_dir):
 
     exp.start(M1, M2, block=True, summary=True)
     statuses = exp.get_status(M1, M2)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_ensemble(fileutils, test_dir):
@@ -64,4 +64,4 @@ def test_ensemble(fileutils, test_dir):
 
     exp.start(ensemble, block=True, summary=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])

--- a/tests/_legacy/test_local_multi_run.py
+++ b/tests/_legacy/test_local_multi_run.py
@@ -27,7 +27,7 @@
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the group_a group
 pytestmark = pytest.mark.group_a
@@ -50,9 +50,9 @@ def test_applications(fileutils, test_dir):
 
     exp.start(M1, block=False)
     statuses = exp.get_status(M1)
-    assert all([stat != SmartSimStatus.STATUS_FAILED for stat in statuses])
+    assert all([stat != JobStatus.FAILED for stat in statuses])
 
     # start another while first application is running
     exp.start(M2, block=True)
     statuses = exp.get_status(M1, M2)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])

--- a/tests/_legacy/test_local_restart.py
+++ b/tests/_legacy/test_local_restart.py
@@ -27,7 +27,7 @@
 import pytest
 
 from smartsim import Experiment
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the group_b group
 pytestmark = pytest.mark.group_b
@@ -49,12 +49,12 @@ def test_restart(fileutils, test_dir):
 
     exp.start(M1, block=True)
     statuses = exp.get_status(M1)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
     # restart the application
     exp.start(M1, block=True)
     statuses = exp.get_status(M1)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_ensemble(fileutils, test_dir):
@@ -68,9 +68,9 @@ def test_ensemble(fileutils, test_dir):
 
     exp.start(ensemble, block=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
     # restart the ensemble
     exp.start(ensemble, block=True)
     statuses = exp.get_status(ensemble)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])

--- a/tests/_legacy/test_multidb.py
+++ b/tests/_legacy/test_multidb.py
@@ -32,7 +32,7 @@ from smartsim.database import FeatureStore
 from smartsim.entity.entity import SmartSimEntity
 from smartsim.error.errors import SSDBIDConflictError
 from smartsim.log import get_logger
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the group_b group
 pytestmark = pytest.mark.group_b
@@ -52,7 +52,7 @@ def make_entity_context(exp: Experiment, entity: SmartSimEntity):
     try:
         yield entity
     finally:
-        if exp.get_status(entity)[0] == SmartSimStatus.STATUS_RUNNING:
+        if exp.get_status(entity)[0] == JobStatus.RUNNING:
             exp.stop(entity)
 
 
@@ -66,7 +66,7 @@ def choose_host(wlmutils, index=0):
 
 def check_not_failed(exp, *args):
     statuses = exp.get_status(*args)
-    assert all(stat is not SmartSimStatus.STATUS_FAILED for stat in statuses)
+    assert all(stat is not JobStatus.FAILED for stat in statuses)
 
 
 @pytest.mark.parametrize("fs_type", supported_fss)

--- a/tests/_legacy/test_reconnect_orchestrator.py
+++ b/tests/_legacy/test_reconnect_orchestrator.py
@@ -31,7 +31,7 @@ import pytest
 
 from smartsim import Experiment
 from smartsim.database import FeatureStore
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the group_b group
 pytestmark = pytest.mark.group_b
@@ -55,7 +55,7 @@ def test_local_feature_store(test_dir, wlmutils):
 
     exp.start(feature_store)
     statuses = exp.get_status(feature_store)
-    assert [stat != SmartSimStatus.STATUS_FAILED for stat in statuses]
+    assert [stat != JobStatus.FAILED for stat in statuses]
 
     # simulate user shutting down main thread
     exp._control._jobs.actively_monitoring = False
@@ -78,7 +78,7 @@ def test_reconnect_local_feature_store(test_dir):
 
     statuses = exp_2.get_status(reloaded_feature_store)
     for stat in statuses:
-        if stat == SmartSimStatus.STATUS_FAILED:
+        if stat == JobStatus.FAILED:
             exp_2.stop(reloaded_feature_store)
             assert False
     exp_2.stop(reloaded_feature_store)

--- a/tests/_legacy/test_run_settings.py
+++ b/tests/_legacy/test_run_settings.py
@@ -42,7 +42,7 @@ from smartsim.settings import (
     Singularity,
 )
 from smartsim.settings.settings import create_run_settings
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the slow_tests group
 pytestmark = pytest.mark.slow_tests
@@ -586,7 +586,7 @@ def test_create_run_settings_run_args_leading_dashes(test_dir, wlmutils):
     exp.start(model)
 
     statuses = exp.get_status(model)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_set_run_args_leading_dashes(test_dir, wlmutils):
@@ -603,7 +603,7 @@ def test_set_run_args_leading_dashes(test_dir, wlmutils):
     model = exp.create_model("sr_issue_model", run_settings=settings)
     exp.start(model)
     statuses = exp.get_status(model)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_run_args_integer(test_dir, wlmutils):
@@ -620,4 +620,4 @@ def test_run_args_integer(test_dir, wlmutils):
     model = exp.create_model("sr_issue_model", run_settings=settings)
     exp.start(model)
     statuses = exp.get_status(model)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])

--- a/tests/_legacy/test_smartredis.py
+++ b/tests/_legacy/test_smartredis.py
@@ -31,7 +31,7 @@ from smartsim import Experiment
 from smartsim._core.utils import installed_redisai_backends
 from smartsim.database import FeatureStore
 from smartsim.entity import Application, Ensemble
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the group_b group
 pytestmark = pytest.mark.group_b
@@ -92,7 +92,7 @@ def test_exchange(local_experiment, local_fs, prepare_fs, fileutils):
 
     # get and confirm statuses
     statuses = local_experiment.get_status(ensemble)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])
 
 
 def test_consumer(local_experiment, local_fs, prepare_fs, fileutils):
@@ -131,4 +131,4 @@ def test_consumer(local_experiment, local_fs, prepare_fs, fileutils):
 
     # get and confirm statuses
     statuses = local_experiment.get_status(ensemble)
-    assert all([stat == SmartSimStatus.STATUS_COMPLETED for stat in statuses])
+    assert all([stat == JobStatus.COMPLETED for stat in statuses])

--- a/tests/_legacy/test_step_info.py
+++ b/tests/_legacy/test_step_info.py
@@ -27,7 +27,7 @@
 import pytest
 
 from smartsim._core.launcher.stepInfo import *
-from smartsim.status import SmartSimStatus
+from smartsim.status import JobStatus
 
 # The tests in this file belong to the group_b group
 pytestmark = pytest.mark.group_b
@@ -35,7 +35,7 @@ pytestmark = pytest.mark.group_b
 
 def test_str():
     step_info = StepInfo(
-        status=SmartSimStatus.STATUS_COMPLETED,
+        status=JobStatus.COMPLETED,
         launcher_status="COMPLETED",
         returncode=0,
     )
@@ -47,4 +47,4 @@ def test_str():
 def test_default():
     step_info = UnmanagedStepInfo()
 
-    assert step_info._get_smartsim_status(None) == SmartSimStatus.STATUS_FAILED
+    assert step_info._get_smartsim_status(None) == JobStatus.FAILED

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -42,7 +42,7 @@ from smartsim.experiment import Experiment
 from smartsim.launchable import job
 from smartsim.settings import dispatch, launchSettings
 from smartsim.settings.arguments import launchArguments
-from smartsim.status import FailedToFetchStatus, SmartSimStatus
+from smartsim.status import InvalidJobStatus, JobStatus
 
 pytestmark = pytest.mark.group_a
 
@@ -285,7 +285,7 @@ def test_start_can_start_a_job_multiple_times_accross_multiple_calls(
 
 class GetStatusLauncher(dispatch.LauncherProtocol):
     def __init__(self):
-        self.id_to_status = {dispatch.create_job_id(): stat for stat in SmartSimStatus}
+        self.id_to_status = {dispatch.create_job_id(): stat for stat in JobStatus}
 
     __hash__ = object.__hash__
 
@@ -361,7 +361,7 @@ def test_get_status_returns_not_started_for_unrecognized_ids(
     )
     new_history = LaunchHistory({id_: launcher for id_ in rest})
     monkeypatch.setattr(exp, "_launch_history", new_history)
-    expected_stats = (FailedToFetchStatus.STATUS_NEVER_STARTED,) * 2
+    expected_stats = (InvalidJobStatus.NEVER_STARTED,) * 2
     actual_stats = exp.get_status(brand_new_id, id_not_known_by_exp)
     assert expected_stats == actual_stats
 


### PR DESCRIPTION
Renames `SmartSimStatus` to `JobStatus`.
Renames `FailedToFetchStatus` to `InvalidJobStatus`.
Removes the `STATUS_` prefix from enum values.