### PR TITLE
MLI environment variables updated using new naming convention

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@ Jump to:
 
 Description
 
+- Update MLI environment variables using new naming convention
 - Reduce a copy by using torch.from_numpy instead of torch.tensor
 - Enable dynamic feature store selection
 - Fix dragon package installation bug

--- a/ex/high_throughput_inference/mock_app.py
+++ b/ex/high_throughput_inference/mock_app.py
@@ -56,7 +56,7 @@ logger = get_logger("App")
 class ProtoClient:
     def __init__(self, timing_on: bool):
         connect_to_infrastructure()
-        ddict_str = os.environ["SS_INFRA_BACKBONE"]
+        ddict_str = os.environ["_SMARTSIM_INFRA_BACKBONE"]
         self._ddict = DDict.attach(ddict_str)
         self._backbone_descriptor = DragonFeatureStore(self._ddict).descriptor
         to_worker_fli_str = None

--- a/ex/high_throughput_inference/standalone_workermanager.py
+++ b/ex/high_throughput_inference/standalone_workermanager.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     connect_to_infrastructure()
-    ddict_str = os.environ["SS_INFRA_BACKBONE"]
+    ddict_str = os.environ["_SMARTSIM_INFRA_BACKBONE"]
     ddict = DDict.attach(ddict_str)
 
     to_worker_channel = Channel.make_process_local()
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     torch_worker = cloudpickle.loads(worker_type_name)()
 
     descriptor = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
-    os.environ["SS_REQUEST_QUEUE"] = descriptor
+    os.environ["_SMARTSIM_REQUEST_QUEUE"] = descriptor
 
     config_loader = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,

--- a/smartsim/_core/launcher/dragon/dragonBackend.py
+++ b/smartsim/_core/launcher/dragon/dragonBackend.py
@@ -515,7 +515,7 @@ class DragonBackend:
                         env={
                             **request.current_env,
                             **request.env,
-                            "SS_INFRA_BACKBONE": self.infra_ddict,
+                            "_SMARTSIM_INFRA_BACKBONE": self.infra_ddict,
                         },
                         stdout=dragon_process.Popen.PIPE,
                         stderr=dragon_process.Popen.PIPE,

--- a/smartsim/_core/mli/infrastructure/environmentloader.py
+++ b/smartsim/_core/mli/infrastructure/environmentloader.py
@@ -72,8 +72,8 @@ class EnvironmentConfigLoader:
         an environment variable. The backbone is a standalone, system-created
         feature store used to share internal information among MLI components
 
-        :returns: The attached feature store via SS_INFRA_BACKBONE"""
-        descriptor = os.getenv("SS_INFRA_BACKBONE", "")
+        :returns: The attached feature store via _SMARTSIM_INFRA_BACKBONE"""
+        descriptor = os.getenv("_SMARTSIM_INFRA_BACKBONE", "")
 
         if not descriptor:
             logger.warning("No backbone descriptor is configured")
@@ -90,8 +90,8 @@ class EnvironmentConfigLoader:
         """Attach to a queue-like communication channel using the descriptor
         found in an environment variable.
 
-        :returns: The attached queue specified via `SS_REQUEST_QUEUE`"""
-        descriptor = os.getenv("SS_REQUEST_QUEUE", "")
+        :returns: The attached queue specified via `_SMARTSIM_REQUEST_QUEUE`"""
+        descriptor = os.getenv("_SMARTSIM_REQUEST_QUEUE", "")
 
         if not descriptor:
             logger.warning("No queue descriptor is configured")

--- a/tests/dragon/test_environment_loader.py
+++ b/tests/dragon/test_environment_loader.py
@@ -55,7 +55,9 @@ def test_environment_loader_attach_fli(content: bytes, monkeypatch: pytest.Monke
     """A descriptor can be stored, loaded, and reattached"""
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SS_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv(
+        "_SMARTSIM_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize())
+    )
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
@@ -76,7 +78,9 @@ def test_environment_loader_serialize_fli(monkeypatch: pytest.MonkeyPatch):
     queue are the same"""
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SS_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv(
+        "_SMARTSIM_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize())
+    )
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
@@ -89,7 +93,7 @@ def test_environment_loader_serialize_fli(monkeypatch: pytest.MonkeyPatch):
 
 def test_environment_loader_flifails(monkeypatch: pytest.MonkeyPatch):
     """An incorrect serialized descriptor will fails to attach"""
-    monkeypatch.setenv("SS_REQUEST_QUEUE", "randomstring")
+    monkeypatch.setenv("_SMARTSIM_REQUEST_QUEUE", "randomstring")
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,
         callback_factory=None,
@@ -104,7 +108,7 @@ def test_environment_loader_backbone_load_dfs(monkeypatch: pytest.MonkeyPatch):
     """Verify the dragon feature store is loaded correctly by the
     EnvironmentConfigLoader to demonstrate featurestore_factory correctness"""
     feature_store = DragonFeatureStore(DDict())
-    monkeypatch.setenv("SS_INFRA_BACKBONE", feature_store.descriptor)
+    monkeypatch.setenv("_SMARTSIM_INFRA_BACKBONE", feature_store.descriptor)
 
     config = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,

--- a/tests/dragon/test_error_handling.py
+++ b/tests/dragon/test_error_handling.py
@@ -89,9 +89,11 @@ def setup_worker_manager_model_bytes(
 
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SS_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv(
+        "_SMARTSIM_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize())
+    )
     # Put backbone descriptor into env var for the `EnvironmentConfigLoader`
-    monkeypatch.setenv("SS_INFRA_BACKBONE", backbone_descriptor)
+    monkeypatch.setenv("_SMARTSIM_INFRA_BACKBONE", backbone_descriptor)
 
     worker_manager = WorkerManager(
         EnvironmentConfigLoader(
@@ -127,9 +129,11 @@ def setup_worker_manager_model_key(
 
     chan = Channel.make_process_local()
     queue = FLInterface(main_ch=chan)
-    monkeypatch.setenv("SS_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize()))
+    monkeypatch.setenv(
+        "_SMARTSIM_REQUEST_QUEUE", du.B64.bytes_to_str(queue.serialize())
+    )
     # Put backbone descriptor into env var for the `EnvironmentConfigLoader`
-    monkeypatch.setenv("SS_INFRA_BACKBONE", backbone_descriptor)
+    monkeypatch.setenv("_SMARTSIM_INFRA_BACKBONE", backbone_descriptor)
 
     worker_manager = WorkerManager(
         EnvironmentConfigLoader(

--- a/tests/dragon/test_worker_manager.py
+++ b/tests/dragon/test_worker_manager.py
@@ -167,7 +167,7 @@ def test_worker_manager(prepare_environment: pathlib.Path) -> None:
     # NOTE: env vars should be set prior to instantiating EnvironmentConfigLoader
     # or test environment may be unable to send messages w/queue
     descriptor = base64.b64encode(to_worker_fli_serialized).decode("utf-8")
-    os.environ["SS_REQUEST_QUEUE"] = descriptor
+    os.environ["_SMARTSIM_REQUEST_QUEUE"] = descriptor
 
     config_loader = EnvironmentConfigLoader(
         featurestore_factory=DragonFeatureStore.from_descriptor,


### PR DESCRIPTION
`SS_INFRA_BACKBONE` has been updated to `_SMARTSIM_INFRA_BACKBONE` and `SS_REQUEST_QUEUE` is now `_SMARTSIM_REQUEST_QUEUE`.