### PR TITLE
SmartSim environment variables updated using new naming convention

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,7 +13,6 @@ Jump to:
 
 Description
 
-
 - Update SmartSim environment variables using new naming convention
 - Add RequestDispatcher and the possibility of batching inference requests
 - Enable hostname selection for dragon tasks

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@ Jump to:
 
 Description
 
+- Update SmartSim environment variables using new naming convention
 - Reduce a copy by using torch.from_numpy instead of torch.tensor
 - Enable dynamic feature store selection
 - Fix dragon package installation bug

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -78,22 +78,22 @@ def check_py_tf_version(versions: Versioner) -> None:
 def check_backends_install() -> bool:
     """Checks if backends have already been installed.
     Logs details on how to proceed forward
-    if the SMARTSIM_RAI_PATH environment variable is set or if
+    if the SMARTSIM_RAI_LIB environment variable is set or if
     backends have already been installed.
     """
-    rai_path = os.environ.get("SMARTSIM_RAI_PATH", "")
+    rai_path = os.environ.get("SMARTSIM_RAI_LIB", "")
     installed = installed_redisai_backends()
     msg = ""
 
     if rai_path and installed:
         msg = (
             f"There is no need to build. backends are already built and "
-            f"specified in the environment at 'SMARTSIM_RAI_PATH': {CONFIG.redisai}"
+            f"specified in the environment at 'SMARTSIM_RAI_LIB': {CONFIG.redisai}"
         )
     elif rai_path and not installed:
         msg = (
-            "Before running 'smart build', unset your SMARTSIM_RAI_PATH environment "
-            "variable with 'unset SMARTSIM_RAI_PATH'."
+            "Before running 'smart build', unset your SMARTSIM_RAI_LIB environment "
+            "variable with 'unset SMARTSIM_RAI_LIB'."
         )
     elif not rai_path and installed:
         msg = (

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -78,22 +78,22 @@ def check_py_tf_version(versions: Versioner) -> None:
 def check_backends_install() -> bool:
     """Checks if backends have already been installed.
     Logs details on how to proceed forward
-    if the RAI_PATH environment variable is set or if
+    if the SMARTSIM_RAI_PATH environment variable is set or if
     backends have already been installed.
     """
-    rai_path = os.environ.get("RAI_PATH", "")
+    rai_path = os.environ.get("SMARTSIM_RAI_PATH", "")
     installed = installed_redisai_backends()
     msg = ""
 
     if rai_path and installed:
         msg = (
             f"There is no need to build. backends are already built and "
-            f"specified in the environment at 'RAI_PATH': {CONFIG.redisai}"
+            f"specified in the environment at 'SMARTSIM_RAI_PATH': {CONFIG.redisai}"
         )
     elif rai_path and not installed:
         msg = (
-            "Before running 'smart build', unset your RAI_PATH environment "
-            "variable with 'unset RAI_PATH'."
+            "Before running 'smart build', unset your SMARTSIM_RAI_PATH environment "
+            "variable with 'unset SMARTSIM_RAI_PATH'."
         )
     elif not rai_path and installed:
         msg = (
@@ -368,7 +368,7 @@ def _configure_keydb_build(versions: Versioner) -> None:
     CONFIG.conf_path = Path(CONFIG.core_path, "config", "keydb.conf")
     if not CONFIG.conf_path.resolve().is_file():
         raise SSConfigError(
-            "Database configuration file at REDIS_CONF could not be found"
+            "Database configuration file at SMARTSIM_REDIS_CONF could not be found"
         )
 
 

--- a/smartsim/_core/_install/builder.py
+++ b/smartsim/_core/_install/builder.py
@@ -343,7 +343,7 @@ class DatabaseBuilder(Builder):
         try:
             database_exe = next(bin_path.glob("*-server"))
             database = Path(
-                os.environ.get("SMARTSIM_REDIS_PATH", database_exe)
+                os.environ.get("SMARTSIM_REDIS_SERVER_EXE", database_exe)
             ).resolve()
             _ = expand_exe_path(str(database))
         except (TypeError, FileNotFoundError) as e:
@@ -353,7 +353,7 @@ class DatabaseBuilder(Builder):
         try:
             redis_cli_exe = next(bin_path.glob("*-cli"))
             redis_cli = Path(
-                os.environ.get("SMARTSIM_REDIS_CLI_PATH", redis_cli_exe)
+                os.environ.get("SMARTSIM_REDIS_CLI_EXE", redis_cli_exe)
             ).resolve()
             _ = expand_exe_path(str(redis_cli))
         except (TypeError, FileNotFoundError) as e:

--- a/smartsim/_core/_install/builder.py
+++ b/smartsim/_core/_install/builder.py
@@ -342,7 +342,9 @@ class DatabaseBuilder(Builder):
         bin_path = Path(dependency_path, "bin").resolve()
         try:
             database_exe = next(bin_path.glob("*-server"))
-            database = Path(os.environ.get("REDIS_PATH", database_exe)).resolve()
+            database = Path(
+                os.environ.get("SMARTSIM_REDIS_PATH", database_exe)
+            ).resolve()
             _ = expand_exe_path(str(database))
         except (TypeError, FileNotFoundError) as e:
             raise BuildError("Installation of redis-server failed!") from e
@@ -350,7 +352,9 @@ class DatabaseBuilder(Builder):
         # validate install -- redis-cli
         try:
             redis_cli_exe = next(bin_path.glob("*-cli"))
-            redis_cli = Path(os.environ.get("REDIS_CLI_PATH", redis_cli_exe)).resolve()
+            redis_cli = Path(
+                os.environ.get("SMARTSIM_REDIS_CLI_PATH", redis_cli_exe)
+            ).resolve()
             _ = expand_exe_path(str(redis_cli))
         except (TypeError, FileNotFoundError) as e:
             raise BuildError("Installation of redis-cli failed!") from e

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -40,7 +40,7 @@ from ..utils.helpers import expand_exe_path
 # These values can be set through environment variables to
 # override the default behavior of SmartSim.
 #
-# SMARTSIM_RAI_PATH
+# SMARTSIM_RAI_LIB
 #   - Path to the RAI shared library
 #   - Default: /smartsim/smartsim/_core/lib/redisai.so
 #
@@ -48,11 +48,11 @@ from ..utils.helpers import expand_exe_path
 #   - Path to the redis.conf file
 #   - Default: /SmartSim/smartsim/_core/config/redis.conf
 #
-# SMARTSIM_REDIS_PATH
+# SMARTSIM_REDIS_SERVER_EXE
 #   - Path to the redis-server executable
 #   - Default: /SmartSim/smartsim/_core/bin/redis-server
 #
-# SMARTSIM_REDIS_CLI_PATH
+# SMARTSIM_REDIS_CLI_EXE
 #   - Path to the redis-cli executable
 #   - Default: /SmartSim/smartsim/_core/bin/redis-cli
 #
@@ -105,11 +105,11 @@ class Config:
     @property
     def redisai(self) -> str:
         rai_path = self.lib_path / "redisai.so"
-        redisai = Path(os.environ.get("SMARTSIM_RAI_PATH", rai_path)).resolve()
+        redisai = Path(os.environ.get("SMARTSIM_RAI_LIB", rai_path)).resolve()
         if not redisai.is_file():
             raise SSConfigError(
                 "RedisAI dependency not found. Build with `smart` cli "
-                "or specify SMARTSIM_RAI_PATH"
+                "or specify SMARTSIM_RAI_LIB"
             )
         return str(redisai)
 
@@ -127,13 +127,13 @@ class Config:
         try:
             database_exe = next(self.bin_path.glob("*-server"))
             database = Path(
-                os.environ.get("SMARTSIM_REDIS_PATH", database_exe)
+                os.environ.get("SMARTSIM_REDIS_SERVER_EXE", database_exe)
             ).resolve()
             exe = expand_exe_path(str(database))
             return exe
         except (TypeError, FileNotFoundError) as e:
             raise SSConfigError(
-                "Specified database binary at SMARTSIM_REDIS_PATH could not be used"
+                "Specified database binary at SMARTSIM_REDIS_SERVER_EXE could not be used"
             ) from e
 
     @property
@@ -141,13 +141,13 @@ class Config:
         try:
             redis_cli_exe = next(self.bin_path.glob("*-cli"))
             redis_cli = Path(
-                os.environ.get("SMARTSIM_REDIS_CLI_PATH", redis_cli_exe)
+                os.environ.get("SMARTSIM_REDIS_CLI_EXE", redis_cli_exe)
             ).resolve()
             exe = expand_exe_path(str(redis_cli))
             return exe
         except (TypeError, FileNotFoundError) as e:
             raise SSConfigError(
-                "Specified Redis binary at SMARTSIM_REDIS_CLI_PATH could not be used"
+                "Specified Redis binary at SMARTSIM_REDIS_CLI_EXE could not be used"
             ) from e
 
     @property

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -40,19 +40,19 @@ from ..utils.helpers import expand_exe_path
 # These values can be set through environment variables to
 # override the default behavior of SmartSim.
 #
-# RAI_PATH
+# SMARTSIM_RAI_PATH
 #   - Path to the RAI shared library
 #   - Default: /smartsim/smartsim/_core/lib/redisai.so
 #
-# REDIS_CONF
+# SMARTSIM_REDIS_CONF
 #   - Path to the redis.conf file
 #   - Default: /SmartSim/smartsim/_core/config/redis.conf
 #
-# REDIS_PATH
+# SMARTSIM_REDIS_PATH
 #   - Path to the redis-server executable
 #   - Default: /SmartSim/smartsim/_core/bin/redis-server
 #
-# REDIS_CLI_PATH
+# SMARTSIM_REDIS_CLI_PATH
 #   - Path to the redis-cli executable
 #   - Default: /SmartSim/smartsim/_core/bin/redis-cli
 #
@@ -105,20 +105,20 @@ class Config:
     @property
     def redisai(self) -> str:
         rai_path = self.lib_path / "redisai.so"
-        redisai = Path(os.environ.get("RAI_PATH", rai_path)).resolve()
+        redisai = Path(os.environ.get("SMARTSIM_RAI_PATH", rai_path)).resolve()
         if not redisai.is_file():
             raise SSConfigError(
                 "RedisAI dependency not found. Build with `smart` cli "
-                "or specify RAI_PATH"
+                "or specify SMARTSIM_RAI_PATH"
             )
         return str(redisai)
 
     @property
     def database_conf(self) -> str:
-        conf = Path(os.environ.get("REDIS_CONF", self.conf_path)).resolve()
+        conf = Path(os.environ.get("SMARTSIM_REDIS_CONF", self.conf_path)).resolve()
         if not conf.is_file():
             raise SSConfigError(
-                "Database configuration file at REDIS_CONF could not be found"
+                "Database configuration file at SMARTSIM_REDIS_CONF could not be found"
             )
         return str(conf)
 
@@ -126,24 +126,28 @@ class Config:
     def database_exe(self) -> str:
         try:
             database_exe = next(self.bin_path.glob("*-server"))
-            database = Path(os.environ.get("REDIS_PATH", database_exe)).resolve()
+            database = Path(
+                os.environ.get("SMARTSIM_REDIS_PATH", database_exe)
+            ).resolve()
             exe = expand_exe_path(str(database))
             return exe
         except (TypeError, FileNotFoundError) as e:
             raise SSConfigError(
-                "Specified database binary at REDIS_PATH could not be used"
+                "Specified database binary at SMARTSIM_REDIS_PATH could not be used"
             ) from e
 
     @property
     def database_cli(self) -> str:
         try:
             redis_cli_exe = next(self.bin_path.glob("*-cli"))
-            redis_cli = Path(os.environ.get("REDIS_CLI_PATH", redis_cli_exe)).resolve()
+            redis_cli = Path(
+                os.environ.get("SMARTSIM_REDIS_CLI_PATH", redis_cli_exe)
+            ).resolve()
             exe = expand_exe_path(str(redis_cli))
             return exe
         except (TypeError, FileNotFoundError) as e:
             raise SSConfigError(
-                "Specified Redis binary at REDIS_CLI_PATH could not be used"
+                "Specified Redis binary at SMARTSIM_REDIS_CLI_PATH could not be used"
             ) from e
 
     @property
@@ -163,7 +167,7 @@ class Config:
     def dragon_server_path(self) -> t.Optional[str]:
         return os.getenv(
             "SMARTSIM_DRAGON_SERVER_PATH",
-            os.getenv("SMARTSIM_DRAGON_SERVER_PATH_EXP", None),
+            os.getenv("_SMARTSIM_DRAGON_SERVER_PATH_EXP", None),
         )
 
     @property

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -133,7 +133,8 @@ class Config:
             return exe
         except (TypeError, FileNotFoundError) as e:
             raise SSConfigError(
-                "Specified database binary at SMARTSIM_REDIS_SERVER_EXE could not be used"
+                "Specified database binary at SMARTSIM_REDIS_SERVER_EXE "
+                "could not be used"
             ) from e
 
     @property

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -221,7 +221,7 @@ def _installed(base_path: Path, backend: str) -> bool:
     """
     backend_key = f"redisai_{backend}"
     backend_path = base_path / backend_key / f"{backend_key}.so"
-    backend_so = Path(os.environ.get("RAI_PATH", backend_path)).resolve()
+    backend_so = Path(os.environ.get("SMARTSIM_RAI_PATH", backend_path)).resolve()
 
     return backend_so.is_file()
 

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -221,7 +221,7 @@ def _installed(base_path: Path, backend: str) -> bool:
     """
     backend_key = f"redisai_{backend}"
     backend_path = base_path / backend_key / f"{backend_key}.so"
-    backend_so = Path(os.environ.get("SMARTSIM_RAI_PATH", backend_path)).resolve()
+    backend_so = Path(os.environ.get("SMARTSIM_RAI_LIB", backend_path)).resolve()
 
     return backend_so.is_file()
 

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -265,8 +265,8 @@ class Orchestrator(EntityList[DBNode]):
             raise SSConfigError(
                 "SmartSim not installed with pre-built extensions (Redis)\n"
                 "Use the `smart` cli tool to install needed extensions\n"
-                "or set REDIS_PATH and REDIS_CLI_PATH in your environment\n"
-                "See documentation for more information"
+                "or set SMARTSIM_REDIS_PATH and SMARTSIM_REDIS_CLI_PATH "
+                "in your environment\nSee documentation for more information"
             ) from e
 
         if self.launcher != "local":

--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -265,7 +265,7 @@ class Orchestrator(EntityList[DBNode]):
             raise SSConfigError(
                 "SmartSim not installed with pre-built extensions (Redis)\n"
                 "Use the `smart` cli tool to install needed extensions\n"
-                "or set SMARTSIM_REDIS_PATH and SMARTSIM_REDIS_CLI_PATH "
+                "or set SMARTSIM_REDIS_SERVER_EXE and SMARTSIM_REDIS_CLI_EXE "
                 "in your environment\nSee documentation for more information"
             ) from e
 

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -178,7 +178,7 @@ class Experiment:
     def _set_dragon_server_path(self) -> None:
         """Set path for dragon server through environment varialbes"""
         if not "SMARTSIM_DRAGON_SERVER_PATH" in environ:
-            environ["SMARTSIM_DRAGON_SERVER_PATH_EXP"] = osp.join(
+            environ["_SMARTSIM_DRAGON_SERVER_PATH_EXP"] = osp.join(
                 self.exp_path, CONFIG.dragon_default_subdir
             )
 

--- a/tests/on_wlm/test_dragon.py
+++ b/tests/on_wlm/test_dragon.py
@@ -56,7 +56,7 @@ def test_dragon_global_path(global_dragon_teardown, wlmutils, test_dir, monkeypa
 
 def test_dragon_exp_path(global_dragon_teardown, wlmutils, test_dir, monkeypatch):
     monkeypatch.delenv("SMARTSIM_DRAGON_SERVER_PATH", raising=False)
-    monkeypatch.delenv("SMARTSIM_DRAGON_SERVER_PATH_EXP", raising=False)
+    monkeypatch.delenv("_SMARTSIM_DRAGON_SERVER_PATH_EXP", raising=False)
     exp: Experiment = Experiment(
         "test_dragon_connection",
         exp_path=test_dir,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,9 +66,9 @@ def get_redisai_env(
     """
     env = os.environ.copy()
     if rai_path is not None:
-        env["RAI_PATH"] = rai_path
+        env["SMARTSIM_RAI_PATH"] = rai_path
     else:
-        env.pop("RAI_PATH", None)
+        env.pop("SMARTSIM_RAI_PATH", None)
 
     if lib_path is not None:
         env["SMARTSIM_DEP_INSTALL_PATH"] = lib_path
@@ -85,7 +85,7 @@ def make_file(filepath: str) -> None:
 
 
 def test_redisai_invalid_rai_path(test_dir, monkeypatch):
-    """An invalid RAI_PATH and valid SMARTSIM_DEP_INSTALL_PATH should fail"""
+    """An invalid SMARTSIM_RAI_PATH and valid SMARTSIM_DEP_INSTALL_PATH should fail"""
 
     rai_file_path = os.path.join(test_dir, "lib", "mock-redisai.so")
     make_file(os.path.join(test_dir, "lib", "redisai.so"))
@@ -94,7 +94,7 @@ def test_redisai_invalid_rai_path(test_dir, monkeypatch):
 
     config = Config()
 
-    # Fail when no file exists @ RAI_PATH
+    # Fail when no file exists @ SMARTSIM_RAI_PATH
     with pytest.raises(SSConfigError) as ex:
         _ = config.redisai
 
@@ -102,7 +102,7 @@ def test_redisai_invalid_rai_path(test_dir, monkeypatch):
 
 
 def test_redisai_valid_rai_path(test_dir, monkeypatch):
-    """A valid RAI_PATH should override valid SMARTSIM_DEP_INSTALL_PATH and succeed"""
+    """A valid SMARTSIM_RAI_PATH should override valid SMARTSIM_DEP_INSTALL_PATH and succeed"""
 
     rai_file_path = os.path.join(test_dir, "lib", "mock-redisai.so")
     make_file(rai_file_path)
@@ -117,7 +117,7 @@ def test_redisai_valid_rai_path(test_dir, monkeypatch):
 
 
 def test_redisai_invalid_lib_path(test_dir, monkeypatch):
-    """Invalid RAI_PATH and invalid SMARTSIM_DEP_INSTALL_PATH should fail"""
+    """Invalid SMARTSIM_RAI_PATH and invalid SMARTSIM_DEP_INSTALL_PATH should fail"""
 
     rai_file_path = f"{test_dir}/railib/redisai.so"
 
@@ -133,7 +133,7 @@ def test_redisai_invalid_lib_path(test_dir, monkeypatch):
 
 
 def test_redisai_valid_lib_path(test_dir, monkeypatch):
-    """Valid RAI_PATH and invalid SMARTSIM_DEP_INSTALL_PATH should succeed"""
+    """Valid SMARTSIM_RAI_PATH and invalid SMARTSIM_DEP_INSTALL_PATH should succeed"""
 
     rai_file_path = os.path.join(test_dir, "lib", "mock-redisai.so")
     make_file(rai_file_path)
@@ -147,7 +147,7 @@ def test_redisai_valid_lib_path(test_dir, monkeypatch):
 
 
 def test_redisai_valid_lib_path_null_rai(test_dir, monkeypatch):
-    """Missing RAI_PATH and valid SMARTSIM_DEP_INSTALL_PATH should succeed"""
+    """Missing SMARTSIM_RAI_PATH and valid SMARTSIM_DEP_INSTALL_PATH should succeed"""
 
     rai_file_path: t.Optional[str] = None
     lib_file_path = os.path.join(test_dir, "lib", "redisai.so")
@@ -166,11 +166,11 @@ def test_redis_conf():
     assert Path(config.database_conf).is_file()
     assert isinstance(config.database_conf, str)
 
-    os.environ["REDIS_CONF"] = "not/a/path"
+    os.environ["SMARTSIM_REDIS_CONF"] = "not/a/path"
     config = Config()
     with pytest.raises(SSConfigError):
         config.database_conf
-    os.environ.pop("REDIS_CONF")
+    os.environ.pop("SMARTSIM_REDIS_CONF")
 
 
 def test_redis_exe():
@@ -178,11 +178,11 @@ def test_redis_exe():
     assert Path(config.database_exe).is_file()
     assert isinstance(config.database_exe, str)
 
-    os.environ["REDIS_PATH"] = "not/a/path"
+    os.environ["SMARTSIM_REDIS_PATH"] = "not/a/path"
     config = Config()
     with pytest.raises(SSConfigError):
         config.database_exe
-    os.environ.pop("REDIS_PATH")
+    os.environ.pop("SMARTSIM_REDIS_PATH")
 
 
 def test_redis_cli():
@@ -190,11 +190,11 @@ def test_redis_cli():
     assert Path(config.redisai).is_file()
     assert isinstance(config.redisai, str)
 
-    os.environ["REDIS_CLI_PATH"] = "not/a/path"
+    os.environ["SMARTSIM_REDIS_CLI_PATH"] = "not/a/path"
     config = Config()
     with pytest.raises(SSConfigError):
         config.database_cli
-    os.environ.pop("REDIS_CLI_PATH")
+    os.environ.pop("SMARTSIM_REDIS_CLI_PATH")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,9 +66,9 @@ def get_redisai_env(
     """
     env = os.environ.copy()
     if rai_path is not None:
-        env["SMARTSIM_RAI_PATH"] = rai_path
+        env["SMARTSIM_RAI_LIB"] = rai_path
     else:
-        env.pop("SMARTSIM_RAI_PATH", None)
+        env.pop("SMARTSIM_RAI_LIB", None)
 
     if lib_path is not None:
         env["SMARTSIM_DEP_INSTALL_PATH"] = lib_path
@@ -85,7 +85,7 @@ def make_file(filepath: str) -> None:
 
 
 def test_redisai_invalid_rai_path(test_dir, monkeypatch):
-    """An invalid SMARTSIM_RAI_PATH and valid SMARTSIM_DEP_INSTALL_PATH should fail"""
+    """An invalid SMARTSIM_RAI_LIB and valid SMARTSIM_DEP_INSTALL_PATH should fail"""
 
     rai_file_path = os.path.join(test_dir, "lib", "mock-redisai.so")
     make_file(os.path.join(test_dir, "lib", "redisai.so"))
@@ -94,7 +94,7 @@ def test_redisai_invalid_rai_path(test_dir, monkeypatch):
 
     config = Config()
 
-    # Fail when no file exists @ SMARTSIM_RAI_PATH
+    # Fail when no file exists @ SMARTSIM_RAI_LIB
     with pytest.raises(SSConfigError) as ex:
         _ = config.redisai
 
@@ -102,7 +102,7 @@ def test_redisai_invalid_rai_path(test_dir, monkeypatch):
 
 
 def test_redisai_valid_rai_path(test_dir, monkeypatch):
-    """A valid SMARTSIM_RAI_PATH should override valid SMARTSIM_DEP_INSTALL_PATH and succeed"""
+    """A valid SMARTSIM_RAI_LIB should override valid SMARTSIM_DEP_INSTALL_PATH and succeed"""
 
     rai_file_path = os.path.join(test_dir, "lib", "mock-redisai.so")
     make_file(rai_file_path)
@@ -117,7 +117,7 @@ def test_redisai_valid_rai_path(test_dir, monkeypatch):
 
 
 def test_redisai_invalid_lib_path(test_dir, monkeypatch):
-    """Invalid SMARTSIM_RAI_PATH and invalid SMARTSIM_DEP_INSTALL_PATH should fail"""
+    """Invalid SMARTSIM_RAI_LIB and invalid SMARTSIM_DEP_INSTALL_PATH should fail"""
 
     rai_file_path = f"{test_dir}/railib/redisai.so"
 
@@ -133,7 +133,7 @@ def test_redisai_invalid_lib_path(test_dir, monkeypatch):
 
 
 def test_redisai_valid_lib_path(test_dir, monkeypatch):
-    """Valid SMARTSIM_RAI_PATH and invalid SMARTSIM_DEP_INSTALL_PATH should succeed"""
+    """Valid SMARTSIM_RAI_LIB and invalid SMARTSIM_DEP_INSTALL_PATH should succeed"""
 
     rai_file_path = os.path.join(test_dir, "lib", "mock-redisai.so")
     make_file(rai_file_path)
@@ -147,7 +147,7 @@ def test_redisai_valid_lib_path(test_dir, monkeypatch):
 
 
 def test_redisai_valid_lib_path_null_rai(test_dir, monkeypatch):
-    """Missing SMARTSIM_RAI_PATH and valid SMARTSIM_DEP_INSTALL_PATH should succeed"""
+    """Missing SMARTSIM_RAI_LIB and valid SMARTSIM_DEP_INSTALL_PATH should succeed"""
 
     rai_file_path: t.Optional[str] = None
     lib_file_path = os.path.join(test_dir, "lib", "redisai.so")
@@ -178,11 +178,11 @@ def test_redis_exe():
     assert Path(config.database_exe).is_file()
     assert isinstance(config.database_exe, str)
 
-    os.environ["SMARTSIM_REDIS_PATH"] = "not/a/path"
+    os.environ["SMARTSIM_REDIS_SERVER_EXE"] = "not/a/path"
     config = Config()
     with pytest.raises(SSConfigError):
         config.database_exe
-    os.environ.pop("SMARTSIM_REDIS_PATH")
+    os.environ.pop("SMARTSIM_REDIS_SERVER_EXE")
 
 
 def test_redis_cli():
@@ -190,11 +190,11 @@ def test_redis_cli():
     assert Path(config.redisai).is_file()
     assert isinstance(config.redisai, str)
 
-    os.environ["SMARTSIM_REDIS_CLI_PATH"] = "not/a/path"
+    os.environ["SMARTSIM_REDIS_CLI_EXE"] = "not/a/path"
     config = Config()
     with pytest.raises(SSConfigError):
         config.database_cli
-    os.environ.pop("SMARTSIM_REDIS_CLI_PATH")
+    os.environ.pop("SMARTSIM_REDIS_CLI_EXE")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR updates environment variable names with the new convention. 

`SMARTSIM_DRAGON_SERVER_PATH_EXP` -> `_SMARTSIM_DRAGON_SERVER_PATH_EXP` 
`RAI_PATH` -> `SMARTSIM_RAI_LIB`
`REDIS_PATH` -> `SMARTSIM_REDIS_SERVER_EXE`
`REDIS_CLI_PATH` -> `SMARTSIM_REDIS_CLI_EXE`
`REDIS_CONF` -> `SMARTSIM_REDIS_CONF` 