### PR TITLE
Remove pydantic dependency from MLI code

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@ Jump to:
 
 Description
 
+- Remove pydantic dependency from MLI code
 - Reduce a copy by using torch.from_numpy instead of torch.tensor
 - Enable dynamic feature store selection
 - Fix dragon package installation bug

--- a/smartsim/_core/mli/infrastructure/storage/featurestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/featurestore.py
@@ -27,19 +27,20 @@
 import typing as t
 from abc import ABC, abstractmethod
 
-from pydantic import BaseModel, Field
+from dataclasses import dataclass
+
 
 from smartsim.log import get_logger
 
 logger = get_logger(__name__)
 
-
-class FeatureStoreKey(BaseModel):
+@dataclass
+class FeatureStoreKey:
     """A key,descriptor pair enabling retrieval of an item from a feature store"""
 
-    key: str = Field(min_length=1)
+    key: str
     """The unique key of an item in a feature store"""
-    descriptor: str = Field(min_length=1)
+    descriptor: str
     """The unique identifier of the feature store containing the key"""
 
 

--- a/smartsim/_core/mli/infrastructure/storage/featurestore.py
+++ b/smartsim/_core/mli/infrastructure/storage/featurestore.py
@@ -26,15 +26,14 @@
 
 import typing as t
 from abc import ABC, abstractmethod
-
 from dataclasses import dataclass
-
 
 from smartsim.log import get_logger
 
 logger = get_logger(__name__)
 
-@dataclass
+
+@dataclass(frozen=True)
 class FeatureStoreKey:
     """A key,descriptor pair enabling retrieval of an item from a feature store"""
 
@@ -42,6 +41,16 @@ class FeatureStoreKey:
     """The unique key of an item in a feature store"""
     descriptor: str
     """The unique identifier of the feature store containing the key"""
+
+    def __post_init__(self) -> None:
+        """Ensure the key and descriptor have at least one character
+
+        :raises ValueError: if key or descriptor are empty strings
+        """
+        if len(self.key) < 1:
+            raise ValueError("Key must have at least one character.")
+        if len(self.descriptor) < 1:
+            raise ValueError("Descriptor must have at least one character.")
 
 
 class FeatureStore(ABC):

--- a/tests/mli/test_core_machine_learning_worker.py
+++ b/tests/mli/test_core_machine_learning_worker.py
@@ -350,3 +350,15 @@ def test_place_outputs() -> None:
 
     for i in range(3):
         assert feature_store[keys[i].key] == data[i]
+
+
+@pytest.mark.parametrize(
+    "key, descriptor",
+    [
+        pytest.param("", "desc", id="invalid key"),
+        pytest.param("key", "", id="invalid descriptor"),
+    ],
+)
+def test_invalid_featurestorekey(key, descriptor) -> None:
+    with pytest.raises(ValueError):
+        fsk = FeatureStoreKey(key, descriptor)


### PR DESCRIPTION
We only used pydantic BaseModels in `FeatureStoreKey`, so I converted that into a dataclass and used `_post_init_` to validate that the key and descriptor are not empty strings. I also made the dataclass frozen.