### PR TITLE
fix init reordering bug

### DIFF
--- a/smartsim/_core/launcher/dragon/dragonBackend.py
+++ b/smartsim/_core/launcher/dragon/dragonBackend.py
@@ -157,7 +157,6 @@ class DragonBackend:
         self._step_ids = (f"{create_short_id_str()}-{id}" for id in itertools.count())
         """Incremental ID to assign to new steps prior to execution"""
 
-        self._initialize_hosts()
         self._queued_steps: "collections.OrderedDict[str, DragonRunRequest]" = (
             collections.OrderedDict()
         )
@@ -188,11 +187,7 @@ class DragonBackend:
             else 5
         )
         """Time in seconds needed to server to complete shutdown"""
-
-        self._view = DragonBackendView(self)
-        logger.debug(self._view.host_desc)
         self._infra_ddict: t.Optional[dragon_ddict.DDict] = None
-        self._prioritizer = NodePrioritizer(self._nodes, self._queue_lock)
 
         self._nodes: t.List["dragon_machine.Node"] = []
         """Node capability information for hosts in the allocation"""
@@ -204,6 +199,11 @@ class DragonBackend:
         """List of gpu-count by node"""
         self._allocated_hosts: t.Dict[str, t.Set[str]] = {}
         """Mapping with hostnames as keys and a set of running step IDs as the value"""
+
+        self._initialize_hosts()
+        self._view = DragonBackendView(self)
+        logger.debug(self._view.host_desc)
+        self._prioritizer = NodePrioritizer(self._nodes, self._queue_lock)
 
     @property
     def hosts(self) -> list[str]:

--- a/smartsim/_core/launcher/dragon/pqueue.py
+++ b/smartsim/_core/launcher/dragon/pqueue.py
@@ -143,9 +143,6 @@ class _TrackedNode:
         :param tracking_id: a unique task identifier executing on the node
         to remove
         :raises ValueError: if tracking_id is already assigned to this node"""
-        if tracking_id and tracking_id not in self.assigned_tasks:
-            raise ValueError("Attempted removal of untracked item")
-
         self._num_refs = max(self._num_refs - 1, 0)
         if tracking_id:
             self._assigned_tasks = self._assigned_tasks - {tracking_id}
@@ -460,8 +457,5 @@ class NodePrioritizer:
         :param hosts: a list of hostnames used to filter the available nodes
         :returns: Collection of reserved nodes
         :raises ValueError: if the hosts parameter is an empty list"""
-        if hosts is not None and not hosts:
-            raise ValueError("No hostnames provided")
-
         heap = self._create_sub_heap(hosts, filter_on)
         return self._get_next_n_available_nodes(num_items, heap, tracking_id)

--- a/tests/test_dragon_run_request.py
+++ b/tests/test_dragon_run_request.py
@@ -761,5 +761,3 @@ def test_can_honor_hosts_1_hosts_requested(monkeypatch: pytest.MonkeyPatch) -> N
 
     # confirm the failure is indicated
     assert can_honor, error_msg
-    # # confirm failure message indicates number of nodes requested as cause
-    # assert error_msg is None, error_msg

--- a/tests/test_dragon_run_request.py
+++ b/tests/test_dragon_run_request.py
@@ -635,8 +635,7 @@ def test_view(monkeypatch: pytest.MonkeyPatch) -> None:
     hosts = dragon_backend.hosts
     dragon_backend._prioritizer.increment(hosts[0])
 
-    expected_msg = textwrap.dedent(
-        f"""\
+    expected_msg = textwrap.dedent(f"""\
         Dragon server backend update
         | Host   |  Status  |
         |--------|----------|
@@ -649,8 +648,7 @@ def test_view(monkeypatch: pytest.MonkeyPatch) -> None:
         | del999-2 | Cancelled    | {hosts[1]}         |       -9       |      1      |
         | c101vz-3 | Completed    | {hosts[1]},{hosts[2]} |       0        |      2      |
         | 0ghjk1-4 | Failed       | {hosts[2]}         |       -1       |      1      |
-        | ljace0-5 | NeverStarted |                 |                |      0      |"""
-    )
+        | ljace0-5 | NeverStarted |                 |                |      0      |""")
 
     # get rid of white space to make the comparison easier
     actual_msg = dragon_backend.status_message.replace(" ", "")

--- a/tests/test_node_prioritizer.py
+++ b/tests/test_node_prioritizer.py
@@ -457,9 +457,9 @@ def test_node_prioritizer_multi_increment_subheap_assigned() -> None:
     assert len(all_tracking_info) == 0
 
 
-def test_node_prioritizer_empty_subheap_next_w_hosts() -> None:
+def test_node_prioritizer_empty_subheap_next_w_no_hosts() -> None:
     """Verify that retrieving multiple nodes via `next_n` API does
-    not allow an empty host list"""
+    with an empty host list uses the entire available host list"""
 
     num_cpu_nodes, num_gpu_nodes = 8, 0
     cpu_hosts, gpu_hosts = mock_node_hosts(num_cpu_nodes, num_gpu_nodes)
@@ -476,15 +476,15 @@ def test_node_prioritizer_empty_subheap_next_w_hosts() -> None:
 
     # request n == {num_requested} nodes from set of 3 available
     num_requested = 1
-    with pytest.raises(ValueError) as ex:
-        p.next(hosts=hostnames)
+    node = p.next(hosts=hostnames)
+    assert node
 
-    assert "No hostnames provided" == ex.value.args[0]
+    # assert "No hostnames provided" == ex.value.args[0]
 
 
 def test_node_prioritizer_empty_subheap_next_n_w_hosts() -> None:
     """Verify that retrieving multiple nodes via `next_n` API does
-    not allow an empty host list"""
+    not blow up with an empty host list"""
 
     num_cpu_nodes, num_gpu_nodes = 8, 0
     cpu_hosts, gpu_hosts = mock_node_hosts(num_cpu_nodes, num_gpu_nodes)
@@ -501,10 +501,8 @@ def test_node_prioritizer_empty_subheap_next_n_w_hosts() -> None:
 
     # request n == {num_requested} nodes from set of 3 available
     num_requested = 1
-    with pytest.raises(ValueError) as ex:
-        p.next_n(num_requested, hosts=hostnames)
-
-    assert "No hostnames provided" == ex.value.args[0]
+    node = p.next_n(num_requested, hosts=hostnames)
+    assert node is not None
 
 
 @pytest.mark.parametrize("num_requested", [-100, -1, 0])


### PR DESCRIPTION
Fix 3 bugs:
1. reordering the init sequence in the dragon backend resulted in an un-set collection being used
2. fix tests that should have been updated to compare set contents instead of individual items
3. remove newly added validation on empty host lists that broke existing tests