### PR TITLE
Pin watchdog version to prevent mypy errors

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -15,6 +15,7 @@ To be released at some future point in time
 
 Description
 
+- Pin watchdog to 4.x
 - Update codecov to 4.5.0
 - Remove build of Redis from setup.py
 - Mitigate dependency installation issues
@@ -30,6 +31,9 @@ Description
 
 Detailed Notes
 
+- Pin watchdog to 4.x because v5 introduces new types and requires
+  updates to the type-checking
+  ([SmartSim-PR690](https://github.com/CrayLabs/SmartSim/pull/690))
 - Update codecov to 4.5.0 to mitigate GitHub action failure
   ([SmartSim-PR657](https://github.com/CrayLabs/SmartSim/pull/657))
 - The builder module was included in setup.py to allow us to ship the

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ setup(
         "filelock>=3.4.2",
         "protobuf~=3.20",
         "jinja2>=3.1.2",
-        "watchdog>=4.0.0",
+        "watchdog>4,<5",
         "pydantic==1.10.14",
         "pyzmq>=25.1.2",
         "pygithub>=2.3.0",


### PR DESCRIPTION
The release of watchdog v5 introduced new types which caused further errors with mypy. To mitigate these errors for now, we pin the watchdog version to 4.x and will resolve these errors in the future.