### PR TITLE
Remove Problematic Type Union

### DIFF
--- a/smartsim/_core/shell/shellLauncher.py
+++ b/smartsim/_core/shell/shellLauncher.py
@@ -57,7 +57,7 @@ class ShellLauncherCommand(t.NamedTuple):
     path: pathlib.Path
     stdout: io.TextIOWrapper | int
     stderr: io.TextIOWrapper | int
-    command_tuple: tuple[str, tuple[str, ...]] | t.Sequence[str]
+    command_tuple: t.Sequence[str]
 
 
 def make_shell_format_fn(


### PR DESCRIPTION
In the shell launcher, an unintended and unused type union sunk into the ``ShellLauncherCommand`` type for the ``command_tuple`` type, allowing the attr to be of type ``Sequence[str]`` or ``tuple[str, tuple[str, ...]]``. The former works as expected, but the latter would error at runtime when sent to the ``ShellLauncher`` when opening a subprocess.

```py
class ShellLauncher:
    ...
    def start(self, shell_command: ShellLauncherCommand) -> LaunchedJobID:
        ...
        exe, *rest = shell_command.command_tuple
        #     ^^^^ Mypy thinks this is `list[str] | list[tuple[str]]`
        expanded_exe = helpers.expand_exe_path(exe)
        # pylint: disable-next=consider-using-with
        self._launched[id_] = sp.Popen(
            (expanded_exe, *rest),
       #    ^^^^^^^^^^^^^^^^^^^^^
       #    And inadvertently casts this to `tuple[Any]` which errors
       #    at runtime
            cwd=shell_command.path,
            env={k: v for k, v in shell_command.env.items() if v is not None},
            stdout=shell_command.stdout,
            stderr=shell_command.stderr,
        )
        ...
```

Because this type was not being used, it can simply be removed from the union.