### PR TITLE
parameterize dragon install for CI/CD

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -71,6 +71,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py_v }}
+        env:
+          GH_DRAGON_TOKEN: ${{ secrets.DRAGON_TOKEN }}
 
       - name: Install build-essentials for Ubuntu
         if: contains( matrix.os, 'ubuntu' )
@@ -116,9 +118,11 @@ jobs:
         run: smart build --device cpu --onnx -v
 
       - name: Install ML Runtimes with Smart (with pt, tf, dragon, and onnx support)
+        with:
+          DRAGON_TOKEN: ${{ secrets.DRAGON_TOKEN }}
         if: (contains( matrix.os, 'ubuntu' ) || contains( matrix.os, 'macos-12')) && ( matrix.subset == 'dragon' )
         run: |
-          smart build --device cpu --onnx --dragon -v
+          GH_TOKEN="$DRAGON_TOKEN" smart build --device cpu --onnx -v --dragon-repo dragonhpc/dragon-nightly --dragon-version 0.10
           SP=$(python -c 'import site; print(site.getsitepackages()[0])')/smartsim/_core/config/dragon/.env
           LLP=$(cat $SP | grep LD_LIBRARY_PATH | awk '{split($0, array, "="); print array[2]}')
           echo "LD_LIBRARY_PATH=$LLP:$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -65,14 +65,13 @@ jobs:
 
     env:
       SMARTSIM_REDISAI: ${{ matrix.rai }}
+      DRAGON_TOKEN: ${{ secrets.DRAGON_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py_v }}
-        env:
-          GH_DRAGON_TOKEN: ${{ secrets.DRAGON_TOKEN }}
 
       - name: Install build-essentials for Ubuntu
         if: contains( matrix.os, 'ubuntu' )
@@ -118,11 +117,9 @@ jobs:
         run: smart build --device cpu --onnx -v
 
       - name: Install ML Runtimes with Smart (with pt, tf, dragon, and onnx support)
-        with:
-          DRAGON_TOKEN: ${{ secrets.DRAGON_TOKEN }}
         if: (contains( matrix.os, 'ubuntu' ) || contains( matrix.os, 'macos-12')) && ( matrix.subset == 'dragon' )
         run: |
-          GH_TOKEN="$DRAGON_TOKEN" smart build --device cpu --onnx -v --dragon-repo dragonhpc/dragon-nightly --dragon-version 0.10
+          GH_TOKEN=$DRAGON_TOKEN smart build --device cpu --onnx -v --dragon-repo dragonhpc/dragon-nightly --dragon-version 0.10
           SP=$(python -c 'import site; print(site.getsitepackages()[0])')/smartsim/_core/config/dragon/.env
           LLP=$(cat $SP | grep LD_LIBRARY_PATH | awk '{split($0, array, "="); print array[2]}')
           echo "LD_LIBRARY_PATH=$LLP:$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@ Jump to:
 
 Description
 
+- Parameterize installation of dragon package with `smart build`
 - Update docstrings
 - Implement asynchronous notifications for shared data
 - Filenames conform to snake case

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -33,7 +33,12 @@ from pathlib import Path
 
 from tabulate import tabulate
 
-from smartsim._core._cli.scripts.dragon_install import install_dragon
+from smartsim._core._cli.scripts.dragon_install import (
+    DEFAULT_DRAGON_REPO,
+    DEFAULT_DRAGON_VERSION,
+    DragonInstallRequest,
+    install_dragon,
+)
 from smartsim._core._cli.utils import SMART_LOGGER_FORMAT, color_bool, pip
 from smartsim._core._install import builder
 from smartsim._core._install.buildenv import (
@@ -380,6 +385,8 @@ def execute(
     keydb = args.keydb
     device = Device(args.device.lower())
     is_dragon_requested = args.dragon
+    dragon_repo = args.dragon_repo
+    dragon_version = args.dragon_version
     # torch and tf build by default
     pt = not args.no_pt  # pylint: disable=invalid-name
     tf = not args.no_tf  # pylint: disable=invalid-name
@@ -409,9 +416,17 @@ def execute(
         version_names = list(vers.keys())
         print(tabulate(vers, headers=version_names, tablefmt="github"), "\n")
 
-    if is_dragon_requested:
-        install_to = CONFIG.core_path / ".dragon"
-        return_code = install_dragon(install_to)
+    if is_dragon_requested or dragon_repo or dragon_version:
+        try:
+            request = DragonInstallRequest(
+                CONFIG.core_path / ".dragon",
+                dragon_repo,
+                dragon_version,
+            )
+            return_code = install_dragon(request)
+        except ValueError as ex:
+            return_code = 2
+            logger.error(" ".join(ex.args))
 
         if return_code == 0:
             logger.info("Dragon installation complete")
@@ -482,6 +497,21 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         default=False,
         help="Install the dragon runtime",
+    )
+    parser.add_argument(
+        "--dragon-repo",
+        default=None,
+        type=str,
+        help=(
+            "Specify a git repo containing dragon release assets "
+            f"(e.g. {DEFAULT_DRAGON_REPO})"
+        ),
+    )
+    parser.add_argument(
+        "--dragon-version",
+        default=None,
+        type=str,
+        help=f"Specify the dragon version to install (e.g. {DEFAULT_DRAGON_VERSION})",
     )
     parser.add_argument(
         "--only_python_packages",

--- a/smartsim/_core/_cli/scripts/dragon_install.py
+++ b/smartsim/_core/_cli/scripts/dragon_install.py
@@ -1,15 +1,19 @@
 import os
 import pathlib
+import re
 import shutil
 import sys
 import typing as t
-from urllib.request import urlretrieve
+from urllib.request import Request, urlopen
 
 from github import Github
+from github.Auth import Token
+from github.GitRelease import GitRelease
 from github.GitReleaseAsset import GitReleaseAsset
+from github.Repository import Repository
 
 from smartsim._core._cli.utils import pip
-from smartsim._core._install.builder import WebTGZ
+from smartsim._core._install.builder import _WebTGZ
 from smartsim._core.config import CONFIG
 from smartsim._core.utils.helpers import check_platform, is_crayex_platform
 from smartsim.error.errors import SmartSimCLIActionCancelled
@@ -17,8 +21,78 @@ from smartsim.log import get_logger
 
 logger = get_logger(__name__)
 
+DEFAULT_DRAGON_REPO = "DragonHPC/dragon"
+DEFAULT_DRAGON_VERSION = "0.9"
+DEFAULT_DRAGON_VERSION_TAG = f"v{DEFAULT_DRAGON_VERSION}"
+_GH_TOKEN = "GH_TOKEN"
 
-def create_dotenv(dragon_root_dir: pathlib.Path) -> None:
+
+class DragonInstallRequest:
+    """Encapsulates a request to install the dragon package"""
+
+    def __init__(
+        self,
+        working_dir: pathlib.Path,
+        repo_name: t.Optional[str] = None,
+        version: t.Optional[str] = None,
+    ) -> None:
+        """Initialize an install request.
+
+        :param working_dir: A path to store temporary files used during installation
+        :param repo_name: The name of a repository to install from, e.g. DragonHPC/dragon
+        :param version: The version to install, e.g. v0.10
+        """
+
+        self.working_dir = working_dir
+        """A path to store temporary files used during installation"""
+
+        self.repo_name = repo_name or DEFAULT_DRAGON_REPO
+        """The name of a repository to install from, e.g. DragonHPC/dragon"""
+
+        self.pkg_version = version or DEFAULT_DRAGON_VERSION
+        """The version to install, e.g. 0.10"""
+
+        self._check()
+
+    def _check(self) -> None:
+        """Perform validation of this instance
+
+        :raises: ValueError if any value fails validation"""
+        if not self.repo_name or len(self.repo_name.split("/")) != 2:
+            raise ValueError(
+                f"Invalid dragon repository name. Example: `dragonhpc/dragon`"
+            )
+
+        # version must match standard dragon tag & filename format `vX.YZ`
+        match = re.match(r"^\d\.\d+$", self.pkg_version)
+        if not self.pkg_version or not match:
+            raise ValueError("Invalid dragon version. Examples: `0.9, 0.91, 0.10`")
+
+        # attempting to retrieve from a non-default repository requires GH_TOKEN
+        if self.repo_name.lower() != DEFAULT_DRAGON_REPO.lower() and not self.raw_token:
+            raise ValueError(
+                f"An access token must be available to access {self.repo_name}. "
+                f"Set the `{_GH_TOKEN}` env var to pass your access token."
+            )
+
+    @property
+    def raw_token(self) -> t.Optional[str]:
+        """Returns the raw access token from the environment, if available"""
+        return os.environ.get(_GH_TOKEN, None)
+
+
+def get_auth_token(request: DragonInstallRequest) -> t.Optional[Token]:
+    """Create a Github.Auth.Token if an access token can be found
+    in the environment
+
+    :param request: the installation request
+    :returns: an auth token if one can be built, otherwise `None`"""
+    if gh_token := request.raw_token:
+        return Token(gh_token)
+    return None
+
+
+def create_dotenv(dragon_root_dir: pathlib.Path, dragon_version: str) -> None:
     """Create a .env file with required environment variables for the Dragon runtime"""
     dragon_root = str(dragon_root_dir)
     dragon_inc_dir = str(dragon_root_dir / "include")
@@ -30,7 +104,7 @@ def create_dotenv(dragon_root_dir: pathlib.Path) -> None:
         "DRAGON_ROOT_DIR": dragon_root,  # note: same as base_dir
         "DRAGON_INCLUDE_DIR": dragon_inc_dir,
         "DRAGON_LIB_DIR": dragon_lib_dir,
-        "DRAGON_VERSION": dragon_pin(),
+        "DRAGON_VERSION": dragon_version,
         "PATH": dragon_bin_dir,
         "LD_LIBRARY_PATH": dragon_lib_dir,
     }
@@ -48,12 +122,6 @@ def python_version() -> str:
     """Return a formatted string used to filter release assets
     for the current python version"""
     return f"py{sys.version_info.major}.{sys.version_info.minor}"
-
-
-def dragon_pin() -> str:
-    """Return a string indicating the pinned major/minor version of the dragon
-    package to install"""
-    return "0.9"
 
 
 def _platform_filter(asset_name: str) -> bool:
@@ -77,39 +145,70 @@ def _version_filter(asset_name: str) -> bool:
     return python_version() in asset_name
 
 
-def _pin_filter(asset_name: str) -> bool:
+def _pin_filter(asset_name: str, dragon_version: str) -> bool:
     """Return true if the supplied value contains a dragon version pin match
 
     :param asset_name: A value to inspect for keywords indicating a dragon version
     :returns: True if supplied value is correct for current dragon version"""
-    return f"dragon-{dragon_pin()}" in asset_name
+    return f"dragon-{dragon_version}" in asset_name
 
 
-def _get_release_assets() -> t.Collection[GitReleaseAsset]:
+def _get_all_releases(dragon_repo: Repository) -> t.Collection[GitRelease]:
+    """Retrieve all available releases for the configured dragon repository
+
+    :returns: A list of GitRelease"""
+    all_releases = [release for release in list(dragon_repo.get_releases())]
+    return all_releases
+
+
+def _get_release_assets(request: DragonInstallRequest) -> t.Collection[GitReleaseAsset]:
     """Retrieve a collection of available assets for all releases that satisfy
     the dragon version pin
 
+    :param git_repo: The name of the git repository to search for assets, e.g. "DragonHPC/dragon"
     :returns: A collection of release assets"""
-    git = Github()
-
-    dragon_repo = git.get_repo("DragonHPC/dragon")
+    auth = get_auth_token(request)
+    git = Github(auth=auth)
+    dragon_repo = git.get_repo(request.repo_name)
 
     if dragon_repo is None:
         raise SmartSimCLIActionCancelled("Unable to locate dragon repo")
 
-    # find any releases matching our pinned version requirement
-    tags = [tag for tag in dragon_repo.get_tags() if dragon_pin() in tag.name]
-    # repo.get_latest_release fails if only pre-release results are returned
-    pin_releases = list(dragon_repo.get_release(tag.name) for tag in tags)
-    releases = sorted(pin_releases, key=lambda r: r.published_at, reverse=True)
+    all_releases = sorted(
+        _get_all_releases(dragon_repo), key=lambda r: r.published_at, reverse=True
+    )
 
-    # take the most recent release for the given pin
-    assets = releases[0].assets
+    # filter the list of releases to include only the target version
+    releases = [
+        release
+        for release in all_releases
+        if request.pkg_version in release.title or release.tag_name
+    ]
+
+    releases = sorted(releases, key=lambda r: r.published_at, reverse=True)
+
+    if not releases:
+        release_titles = ", ".join(release.title for release in all_releases)
+        raise SmartSimCLIActionCancelled(
+            f"Unable to find a release for dragon version {request.pkg_version}. "
+            f"Available releases: {release_titles}"
+        )
+
+    # install the latest release of the target version (including pre-release)
+    release = releases[0]
+    assets = list(release.get_assets())
+
+    if not assets:
+        raise SmartSimCLIActionCancelled(
+            f"Unable to find assets for dragon release {release.title}"
+        )
 
     return assets
 
 
-def filter_assets(assets: t.Collection[GitReleaseAsset]) -> t.Optional[GitReleaseAsset]:
+def filter_assets(
+    request: DragonInstallRequest, assets: t.Collection[GitReleaseAsset]
+) -> t.Optional[GitReleaseAsset]:
     """Filter the available release assets so that HSTA agents are used
     when run on a Cray EX platform
 
@@ -118,26 +217,42 @@ def filter_assets(assets: t.Collection[GitReleaseAsset]) -> t.Optional[GitReleas
     # Expect cray & non-cray assets that require a filter, e.g.
     # 'dragon-0.8-py3.9.4.1-bafaa887f.tar.gz',
     # 'dragon-0.8-py3.9.4.1-CRAYEX-ac132fe95.tar.gz'
-    asset = next(
-        (
-            asset
-            for asset in assets
-            if _version_filter(asset.name)
-            and _platform_filter(asset.name)
-            and _pin_filter(asset.name)
-        ),
-        None,
+    all_assets = [asset.name for asset in assets]
+
+    assets = list(
+        asset
+        for asset in assets
+        if _version_filter(asset.name) and _pin_filter(asset.name, request.pkg_version)
     )
+
+    if len(assets) == 0:
+        available = "\n\t".join(all_assets)
+        logger.warning(
+            f"Please specify a dragon version (e.g. {DEFAULT_DRAGON_VERSION}) "
+            f"of an asset available in the repository:\n\t{available}"
+        )
+        return None
+
+    asset: t.Optional[GitReleaseAsset] = None
+
+    # Apply platform filter if we have multiple matches for python/dragon version
+    if len(assets) > 0:
+        asset = next((asset for asset in assets if _platform_filter(asset.name)), None)
+
+    if not asset:
+        asset = assets[0]
+        logger.warning(f"Platform-specific package not found. Using {asset.name}")
+
     return asset
 
 
-def retrieve_asset_info() -> GitReleaseAsset:
+def retrieve_asset_info(request: DragonInstallRequest) -> GitReleaseAsset:
     """Find a release asset that meets all necessary filtering criteria
 
-    :param dragon_pin: identify the dragon version to install (e.g. dragon-0.8)
+    :param git_repo: The name of the git repository to search for assets, e.g. "DragonHPC/dragon"
     :returns: A GitHub release asset"""
-    assets = _get_release_assets()
-    asset = filter_assets(assets)
+    assets = _get_release_assets(request)
+    asset = filter_assets(request, assets)
 
     platform_result = check_platform()
     if not platform_result.is_cray:
@@ -152,40 +267,56 @@ def retrieve_asset_info() -> GitReleaseAsset:
     return asset
 
 
-def retrieve_asset(working_dir: pathlib.Path, asset: GitReleaseAsset) -> pathlib.Path:
+def retrieve_asset(
+    request: DragonInstallRequest, asset: GitReleaseAsset
+) -> pathlib.Path:
     """Retrieve the physical file associated to a given GitHub release asset
 
     :param working_dir: location in file system where assets should be written
     :param asset: GitHub release asset to retrieve
     :returns: path to the directory containing the extracted release asset"""
-    download_dir = working_dir / str(asset.id)
+    download_dir = request.working_dir / str(asset.id)
 
     # if we've previously downloaded the release and still have
     # wheels laying around, use that cached version instead
-    if download_dir.exists() or list(download_dir.rglob("*.whl")):
-        return download_dir
+    cleanup(download_dir)
 
     download_dir.mkdir(parents=True, exist_ok=True)
 
     # grab a copy of the complete asset
     asset_path = download_dir / str(asset.name)
-    download_url = asset.browser_download_url
+
+    # use the asset URL instead of the browser_download_url to enable
+    # using auth for private repositories
+    headers: t.Dict[str, str] = {"Accept": "application/octet-stream"}
+
+    if request.raw_token:
+        headers["Authorization"] = f"Bearer {request.raw_token}"
 
     try:
-        urlretrieve(download_url, str(asset_path))
-        logger.debug(f"Retrieved asset {asset.name} from {download_url}")
+        # a github asset endpoint causes a redirect. the first request
+        # receives a pre-signed URL to the asset to pass on to WebTGZ
+        dl_request = Request(asset.url, headers=headers)
+        response = urlopen(dl_request)
+        presigned_url = response.url
+
+        logger.debug(f"Retrieved asset {asset.name} metadata from {asset.url}")
     except Exception:
-        logger.exception(f"Unable to download asset from: {download_url}")
+        logger.exception(f"Unable to download {asset.name} from: {asset.url}")
+        presigned_url = asset.url
 
     # extract the asset
-    archive = WebTGZ(download_url)
-    archive.extract(download_dir)
+    try:
+        archive = _WebTGZ(presigned_url, headers=headers)
+        archive.extract(asset_path)
+        logger.debug(f"Extracted {asset.name} to {download_dir}")
+    except Exception as ex:
+        logger.exception("oops")
 
-    logger.debug(f"Extracted {download_url} to {download_dir}")
     return download_dir
 
 
-def install_package(asset_dir: pathlib.Path) -> int:
+def install_package(request: DragonInstallRequest, asset_dir: pathlib.Path) -> int:
     """Install the package found in `asset_dir` into the current python environment
 
     :param asset_dir: path to a decompressed archive contents for a release asset"""
@@ -194,12 +325,12 @@ def install_package(asset_dir: pathlib.Path) -> int:
         logger.error(f"No wheel(s) found for package in {asset_dir}")
         return 1
 
-    create_dotenv(found_wheels[0].parent)
+    create_dotenv(found_wheels[0].parent, request.pkg_version)
 
     try:
         wheels = list(map(str, found_wheels))
-        logger.info("Installing packages:\n%s", "\n".join(wheels))
-
+        pkg_list = "\n\t".join(wheels)
+        logger.debug(f"Installing packages:\n\t{pkg_list}")
         pip("install", *wheels)
     except Exception:
         logger.error(f"Unable to install from {asset_dir}")
@@ -214,36 +345,57 @@ def cleanup(
     """Delete the downloaded asset and any files extracted during installation
 
     :param archive_path: path to a downloaded archive for a release asset"""
-    if archive_path:
-        archive_path.unlink(missing_ok=True)
-        logger.debug(f"Deleted archive: {archive_path}")
+    if not archive_path:
+        return
+
+    if archive_path.exists() and archive_path.is_file():
+        archive_path.unlink()
+        archive_path = archive_path.parent
+
+    if archive_path.exists() and archive_path.is_dir():
+        shutil.rmtree(archive_path, ignore_errors=True)
+        logger.debug(f"Deleted temporary files in: {archive_path}")
 
 
-def install_dragon(extraction_dir: t.Union[str, os.PathLike[str]]) -> int:
+def install_dragon(request: DragonInstallRequest) -> int:
     """Retrieve a dragon runtime appropriate for the current platform
     and install to the current python environment
+
     :param extraction_dir: path for download and extraction of assets
+    :param git_repo: The name of the git repository to search for assets, e.g. "DragonHPC/dragon"
     :returns: Integer return code, 0 for success, non-zero on failures"""
     if sys.platform == "darwin":
         logger.debug(f"Dragon not supported on platform: {sys.platform}")
         return 1
 
-    extraction_dir = pathlib.Path(extraction_dir)
-    filename: t.Optional[pathlib.Path] = None
     asset_dir: t.Optional[pathlib.Path] = None
 
     try:
-        asset_info = retrieve_asset_info()
-        asset_dir = retrieve_asset(extraction_dir, asset_info)
+        asset_info = retrieve_asset_info(request)
+        if asset_info is not None:
+            asset_dir = retrieve_asset(request, asset_info)
+            return install_package(request, asset_dir)
 
-        return install_package(asset_dir)
+    except SmartSimCLIActionCancelled as ex:
+        logger.warning(*ex.args)
     except Exception as ex:
-        logger.error("Unable to install dragon runtime", exc_info=ex)
+        logger.error("Unable to install dragon runtime", exc_info=True)
     finally:
-        cleanup(filename)
+        cleanup(asset_dir)
 
     return 2
 
 
 if __name__ == "__main__":
-    sys.exit(install_dragon(CONFIG.core_path / ".dragon"))
+    # path for download and extraction of assets
+    extraction_dir = CONFIG.core_path / ".dragon"
+    dragon_repo = DEFAULT_DRAGON_REPO
+    dragon_version = DEFAULT_DRAGON_VERSION
+
+    request = DragonInstallRequest(
+        extraction_dir,
+        dragon_repo,
+        dragon_version,
+    )
+
+    sys.exit(install_dragon(request))

--- a/smartsim/_core/_install/builder.py
+++ b/smartsim/_core/_install/builder.py
@@ -40,13 +40,13 @@ import sys
 import tarfile
 import tempfile
 import typing as t
-import urllib.request
 import zipfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 from shutil import which
 from subprocess import SubprocessError
+from urllib.request import build_opener, install_opener, urlretrieve
 
 # NOTE: This will be imported by setup.py and hence no smartsim related
 # items should be imported into this file.
@@ -795,48 +795,87 @@ class _DLPackRepository(_WebGitRepository, _RAIBuildDependency):
 
 
 class _WebArchive(_WebLocation):
+    """Used to download a remote resource"""
+
+    def __init__(self, headers: t.Optional[t.Dict[str, str]] = None) -> None:
+        """Initialize the instance"""
+        self._headers: t.Dict[str, str] = headers or {}
+
     @property
     def name(self) -> str:
-        _, name = self.url.rsplit("/", 1)
+        """Return the resource name identified by the URL."""
+        # omit the querystring to find the resource name
+        addressparts = self.url.split("?", maxsplit=1)
+        address = addressparts[0]
+        _, name = address.rsplit("/", 1)
         return name
 
     def download(self, target: _PathLike) -> Path:
+        """Retrieve the remote file
+
+        :param target: The desired target path for writing the downloaded file
+        :returns: The path to the downloaded file"""
         target = Path(target)
         if target.is_dir():
             target = target / self.name
-        file, _ = urllib.request.urlretrieve(self.url, target)
-        return Path(file).resolve()
+
+        if hasattr(self, "_headers") and self._headers:
+            opener = build_opener()
+            opener.addheaders = list(self._headers.items())
+            install_opener(opener)
+
+        urlretrieve(self.url, target)
+        return Path(target).resolve()
 
 
 class _ExtractableWebArchive(_WebArchive, ABC):
+    """Abstract base class for implementing download and
+    extraction of a remote archive file"""
+
     @abstractmethod
-    def _extract_download(self, download_path: Path, target: _PathLike) -> None: ...
+    def _extract_download(self, download_path: Path, target: _PathLike) -> None:
+        """Called during file handling to perform format-specific extraction
+        operations. Must be overridden in child classes"""
 
     def extract(self, target: _PathLike) -> None:
+        """Extract the downloaded file into the desired target location"""
         with tempfile.TemporaryDirectory() as tmp_dir:
             arch_path = self.download(tmp_dir)
             self._extract_download(arch_path, target)
 
 
 class _WebTGZ(_ExtractableWebArchive):
+    """Performs download and extraction of a remote archive file
+    in the `.tar.gz` format."""
+
+    def __init__(self, url: str, headers: t.Optional[t.Dict[str, str]] = None) -> None:
+        """Initialize the instance
+
+        :param url: URL pointing to a .tar.gz file
+        :param headers: Additional headers required to download the file"""
+        super().__init__(headers)
+
+        self._url = url
+
+    @property
+    def url(self) -> str:
+        """Returns the url that was downloaded"""
+        return self._url
+
     def _extract_download(self, download_path: Path, target: _PathLike) -> None:
+        """Called during file handling to perform extraction of `.tar.gz` files"""
         with tarfile.open(download_path, "r") as tgz_file:
             tgz_file.extractall(target)
 
 
 class _WebZip(_ExtractableWebArchive):
+    """Performs download and extraction of a remote archive file
+    in the `.zip` format."""
+
     def _extract_download(self, download_path: Path, target: _PathLike) -> None:
+        """Called during file handling to perform extraction of `.zip` files"""
         with zipfile.ZipFile(download_path, "r") as zip_file:
             zip_file.extractall(target)
-
-
-class WebTGZ(_WebTGZ):
-    def __init__(self, url: str) -> None:
-        self._url = url
-
-    @property
-    def url(self) -> str:
-        return self._url
 
 
 @dataclass(frozen=True)

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -296,10 +296,6 @@ class Config:
         default_path = Path.home() / ".smartsim" / "keys"
         return os.environ.get("SMARTSIM_KEY_PATH", str(default_path))
 
-    @property
-    def dragon_pin(self) -> str:
-        return "0.9"
-
 
 @lru_cache(maxsize=128, typed=False)
 def get_config() -> Config:

--- a/tests/test_dragon_installer.py
+++ b/tests/test_dragon_installer.py
@@ -31,12 +31,16 @@ import typing as t
 from collections import namedtuple
 
 import pytest
+from github.GitRelease import GitRelease
 from github.GitReleaseAsset import GitReleaseAsset
 from github.Requester import Requester
 
 import smartsim
 import smartsim._core.utils.helpers as helpers
 from smartsim._core._cli.scripts.dragon_install import (
+    DEFAULT_DRAGON_REPO,
+    DEFAULT_DRAGON_VERSION,
+    DragonInstallRequest,
     cleanup,
     create_dotenv,
     install_dragon,
@@ -44,7 +48,7 @@ from smartsim._core._cli.scripts.dragon_install import (
     retrieve_asset,
     retrieve_asset_info,
 )
-from smartsim._core._install.builder import WebTGZ
+from smartsim._core._install.builder import _WebTGZ
 from smartsim.error.errors import SmartSimCLIActionCancelled
 
 # The tests in this file belong to the group_a group
@@ -136,6 +140,35 @@ def test_assets(monkeypatch: pytest.MonkeyPatch) -> t.Dict[str, GitReleaseAsset]
     return assets
 
 
+@pytest.fixture
+def test_releases(monkeypatch: pytest.MonkeyPatch) -> t.Dict[str, GitRelease]:
+    requester = Requester(
+        auth=None,
+        base_url="https://github.com",
+        user_agent="mozilla",
+        per_page=10,
+        verify=False,
+        timeout=1,
+        retry=1,
+        pool_size=1,
+    )
+    headers = {"mock-header": "mock-value"}
+    attributes = {"title": "mock-title"}
+    completed = True
+
+    releases: t.List[GitRelease] = []
+
+    for python_version in ["py3.9", "py3.10", "py3.11"]:
+        for dragon_version in ["dragon-0.8", "dragon-0.9", "dragon-0.10"]:
+            attributes = {
+                "title": f"{python_version}-{dragon_version}-release",
+                "tag_name": f"v{dragon_version}-weekly",
+            }
+            releases.append(GitRelease(requester, headers, attributes, completed))
+
+    return releases
+
+
 def test_cleanup_no_op(archive_path: pathlib.Path) -> None:
     """Ensure that the cleanup method doesn't bomb when called with
     missing archive path; simulate a failed download"""
@@ -156,62 +189,6 @@ def test_cleanup_archive_exists(test_archive: pathlib.Path) -> None:
     assert not test_archive.exists()
 
 
-def test_retrieve_cached(
-    test_dir: str,
-    # archive_path: pathlib.Path,
-    test_archive: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Verify that a previously retrieved asset archive is re-used and the
-    release asset retrieval is not attempted"""
-
-    asset_id = 123
-
-    def mock_webtgz_extract(self_, target_) -> None:
-        mock_extraction_dir = pathlib.Path(target_)
-        with tarfile.TarFile.open(test_archive) as tar:
-            tar.extractall(mock_extraction_dir)
-
-    # we'll use the mock extract to create the files that would normally be downloaded
-    expected_output_dir = test_archive.parent / str(asset_id)
-    mock_webtgz_extract(None, expected_output_dir)
-
-    # get modification time of directory holding the "downloaded" archive
-    ts1 = expected_output_dir.stat().st_ctime
-
-    requester = Requester(
-        auth=None,
-        base_url="https://github.com",
-        user_agent="mozilla",
-        per_page=10,
-        verify=False,
-        timeout=1,
-        retry=1,
-        pool_size=1,
-    )
-    headers = {"mock-header": "mock-value"}
-    attributes = {"mock-attr": "mock-attr-value"}
-    completed = True
-
-    asset = GitReleaseAsset(requester, headers, attributes, completed)
-
-    # ensure mocked asset has values that we use...
-    monkeypatch.setattr(asset, "_browser_download_url", _git_attr(value="http://foo"))
-    monkeypatch.setattr(asset, "_name", _git_attr(value=mock_archive_name))
-    monkeypatch.setattr(asset, "_id", _git_attr(value=asset_id))
-
-    # show that retrieving an asset w/a different ID results in ignoring
-    # other wheels from prior downloads in the parent directory of the asset
-    asset_path = retrieve_asset(test_archive.parent, asset)
-    ts2 = asset_path.stat().st_ctime
-
-    # NOTE: the file should be written to a subdir based on the asset ID
-    assert (
-        asset_path == expected_output_dir
-    )  # shows that the expected path matches the output path
-    assert ts1 == ts2  # show that the file wasn't changed...
-
-
 def test_retrieve_updated(
     test_archive: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -222,7 +199,7 @@ def test_retrieve_updated(
     old_asset_id = 100
     asset_id = 123
 
-    def mock_webtgz_extract(self_, target_) -> None:
+    def mock__WebTGZ_extract(self_, target_) -> None:
         mock_extraction_dir = pathlib.Path(target_)
         with tarfile.TarFile.open(test_archive) as tar:
             tar.extractall(mock_extraction_dir)
@@ -230,7 +207,7 @@ def test_retrieve_updated(
     # we'll use the mock extract to create the files that would normally be downloaded
     expected_output_dir = test_archive.parent / str(asset_id)
     old_output_dir = test_archive.parent / str(old_asset_id)
-    mock_webtgz_extract(None, old_output_dir)
+    mock__WebTGZ_extract(None, old_output_dir)
 
     requester = Requester(
         auth=None,
@@ -253,13 +230,14 @@ def test_retrieve_updated(
     monkeypatch.setattr(asset, "_name", _git_attr(value=mock_archive_name))
     monkeypatch.setattr(asset, "_id", _git_attr(value=asset_id))
     monkeypatch.setattr(
-        WebTGZ,
+        _WebTGZ,
         "extract",
-        lambda s_, t_: mock_webtgz_extract(s_, expected_output_dir),
+        lambda s_, t_: mock__WebTGZ_extract(s_, expected_output_dir),
     )  # mock the retrieval of the updated archive
 
     # tell it to retrieve. it should return the path to the new download, not the old one
-    asset_path = retrieve_asset(test_archive.parent, asset)
+    request = DragonInstallRequest(test_archive.parent)
+    asset_path = retrieve_asset(request, asset)
 
     # sanity check we don't have the same paths
     assert old_output_dir != expected_output_dir
@@ -298,11 +276,13 @@ def test_retrieve_updated(
 )
 def test_retrieve_asset_info(
     test_assets: t.Collection[GitReleaseAsset],
+    test_releases: t.Collection[GitRelease],
     monkeypatch: pytest.MonkeyPatch,
     dragon_pin: str,
     pyv: str,
     is_found: bool,
     is_crayex: bool,
+    test_dir: str,
 ) -> None:
     """Verify that an information is retrieved correctly based on the python
     version, platform (e.g. CrayEX, !CrayEx), and target dragon pin"""
@@ -318,20 +298,23 @@ def test_retrieve_asset_info(
             "is_crayex_platform",
             lambda: is_crayex,
         )
+        # avoid hitting github API
         ctx.setattr(
             smartsim._core._cli.scripts.dragon_install,
-            "dragon_pin",
-            lambda: dragon_pin,
+            "_get_all_releases",
+            lambda x: test_releases,
         )
         # avoid hitting github API
         ctx.setattr(
             smartsim._core._cli.scripts.dragon_install,
             "_get_release_assets",
-            lambda: test_assets,
+            lambda x: test_assets,
         )
 
+        request = DragonInstallRequest(test_dir, version=dragon_pin)
+
         if is_found:
-            chosen_asset = retrieve_asset_info()
+            chosen_asset = retrieve_asset_info(request)
 
             assert chosen_asset
             assert pyv in chosen_asset.name
@@ -343,7 +326,7 @@ def test_retrieve_asset_info(
                 assert "crayex" not in chosen_asset.name.lower()
         else:
             with pytest.raises(SmartSimCLIActionCancelled):
-                retrieve_asset_info()
+                retrieve_asset_info(request)
 
 
 def test_check_for_utility_missing(test_dir: str) -> None:
@@ -441,11 +424,12 @@ def test_is_cray_ex(
         assert is_cray == platform_result
 
 
-def test_install_package_no_wheel(extraction_dir: pathlib.Path):
+def test_install_package_no_wheel(test_dir: str, extraction_dir: pathlib.Path):
     """Verify that a missing wheel does not blow up and has a failure retcode"""
     exp_path = extraction_dir
+    request = DragonInstallRequest(test_dir)
 
-    result = install_package(exp_path)
+    result = install_package(request, exp_path)
     assert result != 0
 
 
@@ -454,7 +438,9 @@ def test_install_macos(monkeypatch: pytest.MonkeyPatch, extraction_dir: pathlib.
     with monkeypatch.context() as ctx:
         ctx.setattr(sys, "platform", "darwin")
 
-        result = install_dragon(extraction_dir)
+        request = DragonInstallRequest(extraction_dir)
+
+        result = install_dragon(request)
         assert result == 1
 
 
@@ -471,7 +457,7 @@ def test_create_dotenv(monkeypatch: pytest.MonkeyPatch, test_dir: str):
         # ensure no .env exists before trying to create it.
         assert not exp_env_path.exists()
 
-        create_dotenv(mock_dragon_root)
+        create_dotenv(mock_dragon_root, DEFAULT_DRAGON_VERSION)
 
         # ensure the .env is created as side-effect of create_dotenv
         assert exp_env_path.exists()
@@ -493,7 +479,7 @@ def test_create_dotenv_existing_dir(monkeypatch: pytest.MonkeyPatch, test_dir: s
         # ensure no .env exists before trying to create it.
         assert not exp_env_path.exists()
 
-        create_dotenv(mock_dragon_root)
+        create_dotenv(mock_dragon_root, DEFAULT_DRAGON_VERSION)
 
         # ensure the .env is created as side-effect of create_dotenv
         assert exp_env_path.exists()
@@ -518,7 +504,7 @@ def test_create_dotenv_existing_dotenv(monkeypatch: pytest.MonkeyPatch, test_dir
         # ensure .env exists so we can update it
         assert exp_env_path.exists()
 
-        create_dotenv(mock_dragon_root)
+        create_dotenv(mock_dragon_root, DEFAULT_DRAGON_VERSION)
 
         # ensure the .env is created as side-effect of create_dotenv
         assert exp_env_path.exists()
@@ -540,7 +526,7 @@ def test_create_dotenv_format(monkeypatch: pytest.MonkeyPatch, test_dir: str):
     with monkeypatch.context() as ctx:
         ctx.setattr(smartsim._core.config.CONFIG, "conf_dir", test_path)
 
-        create_dotenv(mock_dragon_root)
+        create_dotenv(mock_dragon_root, DEFAULT_DRAGON_VERSION)
 
         # ensure the .env is created as side-effect of create_dotenv
         content = exp_env_path.read_text(encoding="utf-8")

--- a/tests/test_dragon_launcher.py
+++ b/tests/test_dragon_launcher.py
@@ -37,7 +37,10 @@ import pytest
 import zmq
 
 import smartsim._core.config
-from smartsim._core._cli.scripts.dragon_install import create_dotenv
+from smartsim._core._cli.scripts.dragon_install import (
+    DEFAULT_DRAGON_VERSION,
+    create_dotenv,
+)
 from smartsim._core.config.config import get_config
 from smartsim._core.launcher.dragon.dragonLauncher import (
     DragonConnector,
@@ -494,7 +497,7 @@ def test_load_env_env_file_created(monkeypatch: pytest.MonkeyPatch, test_dir: st
 
     with monkeypatch.context() as ctx:
         ctx.setattr(smartsim._core.config.CONFIG, "conf_dir", test_path)
-        create_dotenv(mock_dragon_root)
+        create_dotenv(mock_dragon_root, DEFAULT_DRAGON_VERSION)
         dragon_conf = smartsim._core.config.CONFIG.dragon_dotenv
 
         # verify config does exist
@@ -517,7 +520,7 @@ def test_load_env_cached_env(monkeypatch: pytest.MonkeyPatch, test_dir: str):
 
     with monkeypatch.context() as ctx:
         ctx.setattr(smartsim._core.config.CONFIG, "conf_dir", test_path)
-        create_dotenv(mock_dragon_root)
+        create_dotenv(mock_dragon_root, DEFAULT_DRAGON_VERSION)
 
         # load config w/launcher
         connector = DragonConnector()
@@ -541,7 +544,7 @@ def test_merge_env(monkeypatch: pytest.MonkeyPatch, test_dir: str):
 
     with monkeypatch.context() as ctx:
         ctx.setattr(smartsim._core.config.CONFIG, "conf_dir", test_path)
-        create_dotenv(mock_dragon_root)
+        create_dotenv(mock_dragon_root, DEFAULT_DRAGON_VERSION)
 
         # load config w/launcher
         connector = DragonConnector()


### PR DESCRIPTION
Parameterize the `smart build --dragon` command to enable specification of a fork/repository and package version

- add parameter `--dragon-repo`
- add parameter `--dragon-version`

Sample usage:

- Get latest version from private fork

  `GH_TOKEN=xxxxx smart build --dragon-repo ankona/dragonfork`

- Get specific version from private fork

  `GH_TOKEN=xxxxx smart build --dragon-repo ankona/dragonfork --dragon-version 0.10`

- Get specific version from public fork

  - `GH_TOKEN=xxxxx smart build --dragon-repo dragonhpc/dragon --dragon-version 0.10`
  - `GH_TOKEN=xxxxx smart build --dragon-version 0.10`
  - `smart build --dragon-repo dragonhpc/dragon --dragon-version 0.10`
  - `smart build --dragon-version 0.10`


## manual test results

1. OK - `smart build --dragon`

```
  [1] % smart build --dragon
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] DEBUG Retrieved asset metadata: GitReleaseAsset(url="https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358")
  [SmartSim] DEBUG Retrieved asset dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz metadata from https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358
  [SmartSim] DEBUG Extracted dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz to /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] DEBUG Installing packages:
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/dragon-0.9-cp311-cp311-linux_x86_64.whl
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/pycapnp-2.0.0-cp311-cp311-linux_x86_64.whl
  [SmartSim] DEBUG Deleted temporary files in: /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] INFO Dragon installation complete
  [SmartSim] INFO Redis build complete!
```

2. OK_FAIL - `smart build --dragon-repo dragonhpc/dragon-nightly`

```
  [1] % smart build --dragon-repo dragonhpc/dragon-nightly
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] ERROR An access token must be available to access dragonhpc/dragon-nightly. Set the `GH_TOKEN` env var to pass your access token.
  [SmartSim] WARNING Dragon installation failed
  [SmartSim] INFO Redis build complete!
```

3. OK_FAIL - `smart build --dragon-repo dragonhpc/dragon-nightly --dragon-version 0.9`
  - no gh_token supplied to connect to private repo, no version 0.9 in that repo

```
  [130] % smart build --dragon-repo dragonhpc/dragon-nightly --dragon-version 0.9 
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] ERROR An access token must be available to access dragonhpc/dragon-nightly. Set the `GH_TOKEN` env var to pass your access token.
  [SmartSim] WARNING Dragon installation failed
  [SmartSim] INFO Redis build complete!
```

3. OK_FAIL - `GH_TOKEN=xxx smart build --dragon-repo dragonhpc/dragon-nightly --dragon-version 0.9`
  - no version 0.9 in that repo

```
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] WARNING Please specify a dragon version (e.g. 0.9) of an asset available in the repository:
          dragon-0.10-py3.10.10-ff4c77a60.tar.gz
          dragon-0.10-py3.11.5-ff4c77a60.tar.gz
          dragon-0.10-py3.9.4.1-ff4c77a60.tar.gz
          dragondocs-0.10-ff4c77a60.tar.gz
  [SmartSim] WARNING No dragon runtime asset available to install
  [SmartSim] WARNING Dragon installation failed
  [SmartSim] INFO Redis build complete!
```

4. OK FAIL - `smart build --dragon-repo dragonhpc/dragon-nightly --dragon-version 0.10`
  - no gh_token supplied to connect to private repo

```
  [1] % smart build --dragon-repo dragonhpc/dragon-nightly --dragon-version 0.10
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] ERROR An access token must be available to access dragonhpc/dragon-nightly. Set the `GH_TOKEN` env var to pass your access token.
  [SmartSim] WARNING Dragon installation failed
  [SmartSim] INFO Redis build complete!
```

5. OK - `GH_TOKEN=xxx  smart build --dragon-repo dragonhpc/dragon-nightly --dragon-version 0.10`

```
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] WARNING Platform-specific package not found. Using dragon-0.10-py3.11.5-ff4c77a60.tar.gz
  [SmartSim] DEBUG Retrieved asset metadata: GitReleaseAsset(url="https://api.github.com/repos/DragonHPC/dragon-nightly/releases/assets/190659388")
  [SmartSim] DEBUG Retrieved asset dragon-0.10-py3.11.5-ff4c77a60.tar.gz metadata from https://api.github.com/repos/DragonHPC/dragon-nightly/releases/assets/190659388
  [SmartSim] DEBUG Extracted dragon-0.10-py3.11.5-ff4c77a60.tar.gz to /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/190659388
  [SmartSim] DEBUG Installing packages:
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/190659388/dragon-0.10-py3.11.5-ff4c77a60.tar.gz/dragon-0.10/pycapnp-2.0.0-cp311-cp311-linux_x86_64.whl
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/190659388/dragon-0.10-py3.11.5-ff4c77a60.tar.gz/dragon-0.10/dragon-0.10-cp311-cp311-linux_x86_64.whl
  [SmartSim] DEBUG Deleted temporary files in: /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/190659388
  [SmartSim] INFO Dragon installation complete
  [SmartSim] INFO Redis build complete!
```

5. OK_FAIL - `smart build --dragon-version 0.10`
  - no v0.10 in that repo

```
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] WARNING Please specify a dragon version (e.g. 0.9) of an asset available in the repository:
          dragon-0.9-py3.10.10-CRAYEX-ce895d2de.tar.gz
          dragon-0.9-py3.10.10-ec3fc0f8a.tar.gz
          dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz
          dragon-0.9-py3.11.5-ec3fc0f8a.tar.gz
          dragon-0.9-py3.9.4.1-CRAYEX-ce895d2de.tar.gz
          dragon-0.9-py3.9.4.1-ec3fc0f8a.tar.gz
  [SmartSim] WARNING No dragon runtime asset available to install
  [SmartSim] WARNING Dragon installation failed
  [SmartSim] INFO Redis build complete!
```

6. OK - `smart build --dragon-version 0.9`

```
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] DEBUG Retrieved asset metadata: GitReleaseAsset(url="https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358")
  [SmartSim] DEBUG Retrieved asset dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz metadata from https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358
  [SmartSim] DEBUG Extracted dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz to /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] DEBUG Installing packages:
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/dragon-0.9-cp311-cp311-linux_x86_64.whl
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/pycapnp-2.0.0-cp311-cp311-linux_x86_64.whl
  [SmartSim] DEBUG Deleted temporary files in: /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] INFO Dragon installation complete
  [SmartSim] INFO Redis build complete!
```

7. OK - `export GH_TOKEN=xxx smart build --dragon-version 0.9`

```
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] DEBUG Retrieved asset metadata: GitReleaseAsset(url="https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358")
  [SmartSim] DEBUG Retrieved asset dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz metadata from https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358
  [SmartSim] DEBUG Extracted dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz to /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] DEBUG Installing packages:
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/dragon-0.9-cp311-cp311-linux_x86_64.whl
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/pycapnp-2.0.0-cp311-cp311-linux_x86_64.whl
  [SmartSim] DEBUG Deleted temporary files in: /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] INFO Dragon installation complete
  [SmartSim] INFO Redis build complete!
```

8. OK - `smart build --dragon-repo dragonhpc/dragon`
  - handle lower case fine!

```
  [1] % smart build --dragon-repo dragonhpc/dragon
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] DEBUG Retrieved asset metadata: GitReleaseAsset(url="https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358")
  [SmartSim] DEBUG Retrieved asset dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz metadata from https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358
  [SmartSim] DEBUG Extracted dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz to /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] DEBUG Installing packages:
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/dragon-0.9-cp311-cp311-linux_x86_64.whl
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/pycapnp-2.0.0-cp311-cp311-linux_x86_64.whl
  [SmartSim] DEBUG Deleted temporary files in: /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] INFO Dragon installation complete
  [SmartSim] INFO Redis build complete!
```

9. OK - `GH_TOKEN=xxx smart build --dragon-repo dragonhpc/dragon`
  - token not required for public, but works:

```
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] DEBUG Retrieved asset metadata: GitReleaseAsset(url="https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358")
  [SmartSim] DEBUG Retrieved asset dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz metadata from https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358
  [SmartSim] DEBUG Extracted dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz to /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] DEBUG Installing packages:
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/dragon-0.9-cp311-cp311-linux_x86_64.whl
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/pycapnp-2.0.0-cp311-cp311-linux_x86_64.whl
  [SmartSim] DEBUG Deleted temporary files in: /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] INFO Dragon installation complete
  [SmartSim] INFO Redis build complete!
```

8. OK - `smart build --dragon-repo dragonhpc/dragon --dragon-version 0.9`

```
  [1] % smart build --dragon-repo dragonhpc/dragon --dragon-version 0.9 
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] DEBUG Retrieved asset metadata: GitReleaseAsset(url="https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358")
  [SmartSim] DEBUG Retrieved asset dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz metadata from https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358
  [SmartSim] DEBUG Extracted dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz to /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] DEBUG Installing packages:
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/dragon-0.9-cp311-cp311-linux_x86_64.whl
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/pycapnp-2.0.0-cp311-cp311-linux_x86_64.whl
  [SmartSim] DEBUG Deleted temporary files in: /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] INFO Dragon installation complete
  [SmartSim] INFO Redis build complete!
```

9. OK - `GH_TOKEN=xxx  smart build --dragon-repo dragonhpc/dragon --dragon-version 0.9`

```
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] DEBUG Retrieved asset metadata: GitReleaseAsset(url="https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358")
  [SmartSim] DEBUG Retrieved asset dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz metadata from https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358
  [SmartSim] DEBUG Extracted dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz to /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] DEBUG Installing packages:
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/dragon-0.9-cp311-cp311-linux_x86_64.whl
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/pycapnp-2.0.0-cp311-cp311-linux_x86_64.whl
  [SmartSim] DEBUG Deleted temporary files in: /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] INFO Dragon installation complete
  [SmartSim] INFO Redis build complete!
```

10. OK - 1. `smart build --dragon --dragon-version 0.9`

```
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] DEBUG Retrieved asset metadata: GitReleaseAsset(url="https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358")
  [SmartSim] DEBUG Retrieved asset dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz metadata from https://api.github.com/repos/DragonHPC/dragon/releases/assets/165524358
  [SmartSim] DEBUG Extracted dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz to /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] DEBUG Installing packages:
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/dragon-0.9-cp311-cp311-linux_x86_64.whl
          /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358/dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz/dragon-0.9/pycapnp-2.0.0-cp311-cp311-linux_x86_64.whl
  [SmartSim] DEBUG Deleted temporary files in: /lus/bnchlu1/mcbridch/code/ss/smartsim/_core/.dragon/165524358
  [SmartSim] INFO Dragon installation complete
  [SmartSim] INFO Redis build complete!
```

11. OK_FAIL - 1. `smart build --dragon --dragon-version 0.10`

```
  [1] % smart build --dragon --dragon-version 0.10
  [SmartSim] INFO Running SmartSim build process...
  [SmartSim] INFO Checking requested versions...
  [SmartSim] DEBUG Checking for build tools...
  [SmartSim] WARNING Please specify a dragon version (e.g. 0.9) of an asset available in the repository:
          dragon-0.9-py3.10.10-CRAYEX-ce895d2de.tar.gz
          dragon-0.9-py3.10.10-ec3fc0f8a.tar.gz
          dragon-0.9-py3.11.5-CRAYEX-ce895d2de.tar.gz
          dragon-0.9-py3.11.5-ec3fc0f8a.tar.gz
          dragon-0.9-py3.9.4.1-CRAYEX-ce895d2de.tar.gz
          dragon-0.9-py3.9.4.1-ec3fc0f8a.tar.gz
  [SmartSim] WARNING No dragon runtime asset available to install
  [SmartSim] WARNING Dragon installation failed
  [SmartSim] INFO Redis build complete!

```

12. OK - `smart build -h`

```
  --dragon-repo DRAGON_REPO
                        Specify a git repo containing dragon release assets (e.g. DragonHPC/dragon)
  --dragon-version DRAGON_VERSION
                        Specify the dragon version to install (e.g. 0.9)
```