### PR TITLE
Change 'conda activate' to 'source activate' for Frontier

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -15,6 +15,7 @@ To be released at some future point in time
 
 Description
 
+- Refine Frontier documentation for proper use of miniforge3
 - Refactor to the RedisAI build to allow more flexibility in versions
   and sources of ML backends
 - Add Dockerfiles with GPU support
@@ -39,6 +40,11 @@ Description
 
 Detailed Notes
 
+- On Frontier, the recommended way to activate conda environments is
+  to go through source activate. This also means that ``conda init``
+  is not needed. The instructions for Frontier have been updated to
+  reflect this.
+  ([SmartSim-PR719](https://github.com/CrayLabs/SmartSim/pull/719))
 - The RedisAIBuilder class was completely overhauled to allow users to
   express a wider range of support for hardware/software stacks. This
   will be extended to support ROCm, CUDA-11, and CUDA-12.

--- a/doc/installation_instructions/platform/frontier.rst
+++ b/doc/installation_instructions/platform/frontier.rst
@@ -40,17 +40,7 @@ these instructions, being sure to set the following variables
 
    export SCRATCH=/lustre/orion/$PROJECT_NAME/scratch/$USER/
    conda create -n smartsim python=3.11
-   conda activate smartsim
-
-**Step 1 (Optional):** If this is your first time using miniforge on
-Frontier you may also have to execute the following before being able
-to activate the ``smartsim`` environment
-
-.. code:: bash
-
-   conda init
-   source ~/.bashrc
-   conda activate smartsim
+   source activate smartsim
 
 **Step 2:** Build the SmartRedis C++ and Fortran libraries:
 
@@ -103,7 +93,7 @@ build, and some variables should be set to optimize performance:
 .. code:: bash
 
    module load PrgEnv-gnu miniforge3 rocm/6.1.3
-   conda activate smartsim
+   source activate smartsim
 
    # Optimizations for inference
    export SCRATCH=/lustre/orion/$PROJECT_NAME/scratch/$USER/


### PR DESCRIPTION
On Frontier, the recommended way to activate conda environments is
to go through source activate. This also means that ``conda init``
is not needed. The instructions for Frontier have been updated to 
reflect this.