### PR TITLE
Update release action to remove CI Build Wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,108 +32,61 @@ on:
   release:
     types: [published]
 
-
-env:
-  HOMEBREW_NO_ANALYTICS: "ON" # Make Homebrew installation a little quicker
-  HOMEBREW_NO_AUTO_UPDATE: "ON"
-  HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
-  HOMEBREW_NO_GITHUB_API: "ON"
-  HOMEBREW_NO_INSTALL_CLEANUP: "ON"
-  CIBW_SKIP: "pp* *i686*" # skip building for PyPy
-  CIBW_ARCHS_MACOS: x86_64
-  CIBW_ARCHS_LINUX: x86_64  # ppc64le # uncomment to enable powerPC build
-  CIBW_ENVIRONMENT_MACOS: PATH="$(brew --prefix)/opt/make/libexec/gnubin:$PATH"
-  MACOSX_DEPLOYMENT_TARGET: "10.09"
-
-
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-22.04, macos-12]
-
+  build_dists:
+    name: Build Distributions
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel>=2.12.3
-
-      - name: Install build-essentials
-        if: contains(matrix.os, 'ubuntu')
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
-          sudo apt-get install -y build-essential
-          sudo apt-get install -y wget
-
-      - name: Install GNU make for MacOS
-        if: contains(matrix.os, 'macos')
-        run: brew install make || true
-
-      - name: list target wheels
-        run: |
-          python -m cibuildwheel . --print-build-identifiers
-
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_ENVIRONMENT_MACOS: PATH="$(brew --prefix)/opt/make/libexec/gnubin:$PATH"
-          MACOSX_DEPLOYMENT_TARGET: "10.09"
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
-
-
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        name: Install Python
         with:
           python-version: '3.9'
 
-      - name: Build sdist
+      - name: Install build
+        run: python -m pip install 'build>=1.2.2,<2'
+
+      - name: Install build-essentials
         run: |
-          python -m pip install cmake>=3.13
-          python setup.py sdist
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y build-essential wget
+
+      - name: Build Distributions
+        run: python -m build .
 
       - uses: actions/upload-artifact@v3
         with:
-          path: dist/*.tar.gz
+          name: distributables
+          path: ./dist/*
 
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
+    needs: [build_dists]
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: artifact
+          name: distributables
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI }}
-          #repository_url: https://test.pypi.org/legacy/
-
+          # repository-url: https://test.pypi.org/legacy/
 
   createPullRequest:
-    runs-on: ubuntu-latest
+    needs: [upload_pypi]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Create pull request
         run: |
-          gh pr create -B develop -H master --title 'Merge master into develop' --body 'This PR brings develop up to date with master for release.'
+          gh pr create -B develop \
+                       -H master \
+                       --title 'Merge master into develop' \
+                       --body 'This PR brings develop up to date with master for release.'
         env:
             GH_TOKEN: ${{ github.token }}

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -11,7 +11,7 @@ Jump to:
 
 ### 0.8.0
 
-Released on 25 September, 2024
+Released on 27 September, 2024
 
 Description
 
@@ -52,8 +52,12 @@ Detailed Notes
 - Versions for each of these packages are no longer specified in an
   internal class. Instead a default set of JSON files specifies the
   sources and versions. Users can specify their own custom specifications
-  at smart build time
+  at smart build time.
   ([SmartSim-PR669](https://github.com/CrayLabs/SmartSim/pull/669))
+- Because all build configuration has been moved to static files and all
+  backends are compiled during `smart build`, SmartSim can now be shipped as a
+  pure python wheel.
+  ([SmartSim-PR728](https://github.com/CrayLabs/SmartSim/pull/728))
 - Two new Dockerfiles are now provided (one each for 11.8 and 12.1) that
   can be used to build a container to run the tutorials. No HPC support
   should be expected at this time


### PR DESCRIPTION
Removes the use of CI Build Wheel now that SmartSim is a pure python package.