### PR TITLE
Add patch to Tensorflow backend for GCC 14 compatibility

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,6 +9,24 @@ Jump to:
 
 ## SmartSim
 
+### develop
+
+To be released at some point in the future
+
+Description
+
+- Implement workaround for Tensorflow that allows RedisAI to build with GCC-14
+
+Detailed Notes
+
+- In libtensorflow, the input argument to TF_SessionRun seems to be mistyped to
+  TF_Output instead of TF_Input. These two types differ only in name. GCC-14
+  catches this and throws an error, even though earlier versions allow this. To
+  solve this problem, patches are applied to the Tensorflow backend in RedisAI.
+  Future versions of Tensorflow may fix this problem, but for now this seems to be
+  the best workaround.
+  ([SmartSim-PR738](https://github.com/CrayLabs/SmartSim/pull/738))
+
 ### 0.8.0
 
 Released on 27 September, 2024

--- a/smartsim/_core/_install/configs/mlpackages/DarwinARM64CPU.json
+++ b/smartsim/_core/_install/configs/mlpackages/DarwinARM64CPU.json
@@ -28,6 +28,18 @@
                     "source_file": "src/backends/libtorch_c/CMakeLists.txt",
                     "regex": "set_property\\(TARGET\\storch_c\\sPROPERTY\\sCXX_STANDARD\\s(98|11|14)\\)",
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input inputs",
+                    "replacement": "TF_Output inputs"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input port",
+                    "replacement": "TF_Output port"
                 }
             ]
         },

--- a/smartsim/_core/_install/configs/mlpackages/DarwinX64CPU.json
+++ b/smartsim/_core/_install/configs/mlpackages/DarwinX64CPU.json
@@ -28,6 +28,18 @@
                     "source_file": "src/backends/libtorch_c/CMakeLists.txt",
                     "regex": "set_property\\(TARGET\\storch_c\\sPROPERTY\\sCXX_STANDARD\\s(98|11|14)\\)",
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input inputs",
+                    "replacement": "TF_Output inputs"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input port",
+                    "replacement": "TF_Output port"
                 }
             ]
         },

--- a/smartsim/_core/_install/configs/mlpackages/LinuxX64CPU.json
+++ b/smartsim/_core/_install/configs/mlpackages/LinuxX64CPU.json
@@ -28,6 +28,18 @@
                     "source_file": "src/backends/libtorch_c/CMakeLists.txt",
                     "regex": "set_property\\(TARGET\\storch_c\\sPROPERTY\\sCXX_STANDARD\\s(98|11|14)\\)",
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input inputs",
+                    "replacement": "TF_Output inputs"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input port",
+                    "replacement": "TF_Output port"
                 }
             ]
         },

--- a/smartsim/_core/_install/configs/mlpackages/LinuxX64CUDA11.json
+++ b/smartsim/_core/_install/configs/mlpackages/LinuxX64CUDA11.json
@@ -28,6 +28,18 @@
                     "source_file": "src/backends/libtorch_c/CMakeLists.txt",
                     "regex": "set_property\\(TARGET\\storch_c\\sPROPERTY\\sCXX_STANDARD\\s(98|11|14)\\)",
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input inputs",
+                    "replacement": "TF_Output inputs"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input port",
+                    "replacement": "TF_Output port"
                 }
             ]
         },

--- a/smartsim/_core/_install/configs/mlpackages/LinuxX64CUDA12.json
+++ b/smartsim/_core/_install/configs/mlpackages/LinuxX64CUDA12.json
@@ -28,6 +28,18 @@
                     "source_file": "src/backends/libtorch_c/CMakeLists.txt",
                     "regex": "set_property\\(TARGET\\storch_c\\sPROPERTY\\sCXX_STANDARD\\s(98|11|14)\\)",
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input inputs",
+                    "replacement": "TF_Output inputs"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input port",
+                    "replacement": "TF_Output port"
                 }
             ]
         },

--- a/smartsim/_core/_install/configs/mlpackages/LinuxX64ROCM6.json
+++ b/smartsim/_core/_install/configs/mlpackages/LinuxX64ROCM6.json
@@ -40,6 +40,18 @@
                     "source_file": "../package/libtorch/share/cmake/Caffe2/Caffe2Targets.cmake",
                     "regex": "/opt/rocm",
                     "replacement": "$ENV{ROCM_PATH}"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input inputs",
+                    "replacement": "TF_Output inputs"
+                },
+                {
+                    "description": "Fix the type in a Tensorflow function signature",
+                    "source_file": "src/backends/tensorflow.c",
+                    "regex": "TF_Input port",
+                    "replacement": "TF_Output port"
                 }
             ]
         }


### PR DESCRIPTION
In libtensorflow, the `input` argument to `TF_SessionRun` seems to be mistyped to `TF_Output` instead of `TF_Input`. These two types differ only in name. GCC-14 catches this and throws an error, even though earlier versions allow this. To solve this problem, patches are applied to the Tensorflow backend in RedisAI. Future versions of Tensorflow may fix this problem, but for now this seems to be the best workaround.