### PR TITLE
`Experiment.start` Returns Records

### DIFF
--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -65,11 +65,13 @@ _NestedJobSequenceType: TypeAlias = "t.Sequence[Job | _NestedJobSequenceType]"
 
 def unpack(value: _NestedJobSequenceType) -> t.Generator[Job, None, None]:
     """Unpack any iterable input in order to obtain a
-    single sequence of values
+    single sequence of values.
 
     :param value: Sequence containing elements of type Job or other
-    sequences that are also of type _NestedJobSequenceType
-    :return: flattened list of Jobs"""
+        sequences that are also of type `_NestedJobSequenceType`.
+    :raises TypeError: If the value is not a nested sequence of jobs.
+    :return: A flattened list of `Jobs`.
+    """
     from smartsim.launchable.job import Job
 
     for item in value:

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -161,11 +161,10 @@ class Experiment:
         """Execute a collection of `Job` instances.
 
         :param jobs: A collection of other job instances to start
-        :raises TypeError: If jobs provided are not the correct type
         :raises ValueError: No Jobs were provided.
-        :returns: A sequence of ids with order corresponding to the sequence of
-            jobs that can be used to query or alter the status of that
-            particular execution of the job.
+        :returns: A sequence of records with order corresponding to the
+            sequence of jobs that can be used to query or alter the status of
+            that particular execution of the job.
         """
 
         if not jobs:
@@ -232,12 +231,12 @@ class Experiment:
         )
 
     def get_status(self, *records: Record) -> tuple[JobStatus | InvalidJobStatus, ...]:
-        """Get the status of jobs launched through the `Experiment` from their
-        launched job id returned when calling `Experiment.start`.
+        """Get the status of jobs launched through the `Experiment` from the
+        record returned when calling `Experiment.start`.
 
-        The `Experiment` will map the launched ID back to the launcher that
-        started the job and request a status update. The order of the returned
-        statuses exactly matches the order of the launched job ids.
+        The `Experiment` will map the launched id of the record back to the
+        launcher that started the job and request a status update. The order of
+        the returned statuses exactly matches the order of the records.
 
         If the `Experiment` cannot find any launcher that started the job
         associated with the launched job id, then a
@@ -450,7 +449,7 @@ class Experiment:
         """
         if not records:
             raise ValueError("No records provided")
-        if not all(isinstance(reocrd, Record) for reocrd in records):
+        if not all(isinstance(record, Record) for record in records):
             raise TypeError("record argument was not of type Record")
         ids = tuple(record.launched_id for record in records)
         by_launcher = self._launch_history.group_by_launcher(set(ids), unknown_ok=True)

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -42,7 +42,7 @@ from smartsim._core.control import preview_renderer
 from smartsim._core.control.launch_history import LaunchHistory as _LaunchHistory
 from smartsim._core.utils import helpers as _helpers
 from smartsim.error import errors
-from smartsim.launchable.job import Job
+from smartsim.launchable.job import Job, Record
 from smartsim.status import TERMINAL_STATUSES, InvalidJobStatus, JobStatus
 
 from ._core import Generator, Manifest
@@ -52,7 +52,6 @@ from .error import SmartSimError
 from .log import ctx_exp_path, get_logger, method_contextualizer
 
 if t.TYPE_CHECKING:
-    from smartsim.launchable.job import Job
     from smartsim.types import LaunchedJobID
 
 logger = get_logger(__name__)
@@ -158,14 +157,7 @@ class Experiment:
         experiment
         """
 
-    def _set_dragon_server_path(self) -> None:
-        """Set path for dragon server through environment varialbes"""
-        if not "SMARTSIM_DRAGON_SERVER_PATH" in environ:
-            environ["_SMARTSIM_DRAGON_SERVER_PATH_EXP"] = osp.join(
-                self.exp_path, CONFIG.dragon_default_subdir
-            )
-
-    def start(self, *jobs: Job | t.Sequence[Job]) -> tuple[LaunchedJobID, ...]:
+    def start(self, *jobs: Job | t.Sequence[Job]) -> tuple[Record, ...]:
         """Execute a collection of `Job` instances.
 
         :param jobs: A collection of other job instances to start
@@ -179,12 +171,11 @@ class Experiment:
         if not jobs:
             raise ValueError("No jobs provided to start")
 
-        # Create the run id
         jobs_ = list(_helpers.unpack(jobs))
-
         run_id = datetime.datetime.now().replace(microsecond=0).isoformat()
-        root = pathlib.Path(self.exp_path, run_id.replace(":", "."))
-        return self._dispatch(Generator(root), dispatch.DEFAULT_DISPATCHER, *jobs_)
+        root = pathlib.Path(self.exp_path, run_id)
+        ids = self._dispatch(Generator(root), dispatch.DEFAULT_DISPATCHER, *jobs_)
+        return tuple(Record(id_, job) for id_, job in zip(ids, jobs_))
 
     def _dispatch(
         self,
@@ -240,9 +231,7 @@ class Experiment:
             execute_dispatch(generator, job, idx) for idx, job in enumerate(jobs, 1)
         )
 
-    def get_status(
-        self, *ids: LaunchedJobID
-    ) -> tuple[JobStatus | InvalidJobStatus, ...]:
+    def get_status(self, *records: Record) -> tuple[JobStatus | InvalidJobStatus, ...]:
         """Get the status of jobs launched through the `Experiment` from their
         launched job id returned when calling `Experiment.start`.
 
@@ -259,16 +248,17 @@ class Experiment:
         launched job ids issued by user defined launcher are not sufficiently
         unique.
 
-        :param ids: A sequence of launched job ids issued by the experiment.
+        :param records: A sequence of records issued by the experiment.
         :raises TypeError: If ids provided are not the correct type
         :raises ValueError: No IDs were provided.
         :returns: A tuple of statuses with order respective of the order of the
             calling arguments.
         """
-        if not ids:
-            raise ValueError("No job ids provided to get status")
-        if not all(isinstance(id, str) for id in ids):
-            raise TypeError("ids argument was not of type LaunchedJobID")
+        if not records:
+            raise ValueError("No records provided to get status")
+        if not all(isinstance(record, Record) for record in records):
+            raise TypeError("record argument was not of type Record")
+        ids = tuple(record.launched_id for record in records)
 
         to_query = self._launch_history.group_by_launcher(
             set(ids), unknown_ok=True
@@ -279,39 +269,38 @@ class Experiment:
         return tuple(stats)
 
     def wait(
-        self, *ids: LaunchedJobID, timeout: float | None = None, verbose: bool = True
+        self, *records: Record, timeout: float | None = None, verbose: bool = True
     ) -> None:
         """Block execution until all of the provided launched jobs, represented
         by an ID, have entered a terminal status.
 
-        :param ids: The ids of the launched jobs to wait for.
+        :param records: The records of the launched jobs to wait for.
         :param timeout: The max time to wait for all of the launched jobs to end.
         :param verbose: Whether found statuses should be displayed in the console.
         :raises TypeError: If IDs provided are not the correct type
         :raises ValueError: No IDs were provided.
         """
-        if ids:
-            if not all(isinstance(id, str) for id in ids):
-                raise TypeError("ids argument was not of type LaunchedJobID")
-        else:
-            raise ValueError("No job ids to wait on provided")
+        if not records:
+            raise ValueError("No records to wait on provided")
+        if not all(isinstance(record, Record) for record in records):
+            raise TypeError("record argument was not of type Record")
         self._poll_for_statuses(
-            ids, TERMINAL_STATUSES, timeout=timeout, verbose=verbose
+            records, TERMINAL_STATUSES, timeout=timeout, verbose=verbose
         )
 
     def _poll_for_statuses(
         self,
-        ids: t.Sequence[LaunchedJobID],
+        records: t.Sequence[Record],
         statuses: t.Collection[JobStatus],
         timeout: float | None = None,
         interval: float = 5.0,
         verbose: bool = True,
-    ) -> dict[LaunchedJobID, JobStatus | InvalidJobStatus]:
+    ) -> dict[Record, JobStatus | InvalidJobStatus]:
         """Poll the experiment's launchers for the statuses of the launched
         jobs with the provided ids, until the status of the changes to one of
         the provided statuses.
 
-        :param ids: The ids of the launched jobs to wait for.
+        :param records: The records of the launched jobs to wait for.
         :param statuses: A collection of statuses to poll for.
         :param timeout: The minimum amount of time to spend polling all jobs to
             reach one of the supplied statuses. If not supplied or `None`, the
@@ -327,12 +316,10 @@ class Experiment:
         log = logger.info if verbose else lambda *_, **__: None
         method_timeout = _interval.SynchronousTimeInterval(timeout)
         iter_timeout = _interval.SynchronousTimeInterval(interval)
-        final: dict[LaunchedJobID, JobStatus | InvalidJobStatus] = {}
+        final: dict[Record, JobStatus | InvalidJobStatus] = {}
 
-        def is_finished(
-            id_: LaunchedJobID, status: JobStatus | InvalidJobStatus
-        ) -> bool:
-            job_title = f"Job({id_}): "
+        def is_finished(record: Record, status: JobStatus | InvalidJobStatus) -> bool:
+            job_title = f"Job({record.launched_id}, {record.job.name}): "
             if done := status in terminal:
                 log(f"{job_title}Finished with status '{status.value}'")
             else:
@@ -341,22 +328,22 @@ class Experiment:
 
         if iter_timeout.infinite:
             raise ValueError("Polling interval cannot be infinite")
-        while ids and not method_timeout.expired:
+        while records and not method_timeout.expired:
             iter_timeout = iter_timeout.new_interval()
-            stats = zip(ids, self.get_status(*ids))
+            stats = zip(records, self.get_status(*records))
             is_done = _helpers.group_by(_helpers.pack_params(is_finished), stats)
             final |= dict(is_done.get(True, ()))
-            ids = tuple(id_ for id_, _ in is_done.get(False, ()))
-            if ids:
+            records = tuple(rec for rec, _ in is_done.get(False, ()))
+            if records:
                 (
                     iter_timeout
                     if iter_timeout.remaining < method_timeout.remaining
                     else method_timeout
                 ).block()
-        if ids:
+        if records:
             raise TimeoutError(
-                f"Job ID(s) {', '.join(map(str, ids))} failed to reach "
-                "terminal status before timeout"
+                f"Job ID(s) {', '.join(rec.launched_id for rec in records)} "
+                "failed to reach terminal status before timeout"
             )
         return final
 
@@ -452,20 +439,20 @@ class Experiment:
             disable_numparse=True,
         )
 
-    def stop(self, *ids: LaunchedJobID) -> tuple[JobStatus | InvalidJobStatus, ...]:
+    def stop(self, *records: Record) -> tuple[JobStatus | InvalidJobStatus, ...]:
         """Cancel the execution of a previously launched job.
 
-        :param ids: The ids of the launched jobs to stop.
+        :param records: The records of the launched jobs to stop.
         :raises TypeError: If ids provided are not the correct type
         :raises ValueError: No job ids were provided.
         :returns: A tuple of job statuses upon cancellation with order
             respective of the order of the calling arguments.
         """
-        if ids:
-            if not all(isinstance(id, str) for id in ids):
-                raise TypeError("ids argument was not of type LaunchedJobID")
-        else:
-            raise ValueError("No job ids provided")
+        if not records:
+            raise ValueError("No records provided")
+        if not all(isinstance(reocrd, Record) for reocrd in records):
+            raise TypeError("record argument was not of type Record")
+        ids = tuple(record.launched_id for record in records)
         by_launcher = self._launch_history.group_by_launcher(set(ids), unknown_ok=True)
         id_to_stop_stat = (
             launcher.stop_jobs(*launched).items()

--- a/smartsim/experiment.py
+++ b/smartsim/experiment.py
@@ -234,9 +234,9 @@ class Experiment:
         """Get the status of jobs launched through the `Experiment` from the
         record returned when calling `Experiment.start`.
 
-        The `Experiment` will map the launched id of the record back to the
+        The `Experiment` will map the record id of the record back to the
         launcher that started the job and request a status update. The order of
-        the returned statuses exactly matches the order of the records.
+        the returned statuses matches the order of the records.
 
         If the `Experiment` cannot find any launcher that started the job
         associated with the launched job id, then a
@@ -448,9 +448,9 @@ class Experiment:
             respective of the order of the calling arguments.
         """
         if not records:
-            raise ValueError("No records provided")
+            raise ValueError("No records provided. No jobs will be stopped.")
         if not all(isinstance(record, Record) for record in records):
-            raise TypeError("record argument was not of type Record")
+            raise TypeError("Record argument was not of type `Record`.")
         ids = tuple(record.launched_id for record in records)
         by_launcher = self._launch_history.group_by_launcher(set(ids), unknown_ok=True)
         id_to_stop_stat = (

--- a/smartsim/launchable/job.py
+++ b/smartsim/launchable/job.py
@@ -39,6 +39,7 @@ logger = get_logger(__name__)
 
 if t.TYPE_CHECKING:
     from smartsim.entity.entity import SmartSimEntity
+    from smartsim.types import LaunchedJobID
 
 
 @t.final
@@ -158,3 +159,35 @@ class Job(BaseJob):
         string = f"SmartSim Entity: {self.entity}\n"
         string += f"Launch Settings: {self.launch_settings}"
         return string
+
+
+@t.final
+class Record:
+    """A record a job that was launched and launch ID assigned to the
+    launching.
+    """
+
+    def __init__(self, launch_id: LaunchedJobID, job: Job) -> None:
+        """Initialize a new record of a launched job
+
+        :param launch_id: A unique identifier for the launch of the job.
+        :param job: The job that was launched.
+        """
+        self._id = launch_id
+        self._job = deepcopy(job)
+
+    @property
+    def launched_id(self) -> LaunchedJobID:
+        """The unique identifier for the launched job.
+
+        :returns: A unique identifier for the launched job.
+        """
+        return self._id
+
+    @property
+    def job(self) -> Job:
+        """A deep copy of the job that was launched.
+
+        :returns: A deep copy of the launched job.
+        """
+        return deepcopy(self._job)

--- a/smartsim/launchable/job.py
+++ b/smartsim/launchable/job.py
@@ -163,8 +163,8 @@ class Job(BaseJob):
 
 @t.final
 class Record:
-    """A record a job that was launched and launch ID assigned to the
-    launching.
+    """A Record object to track a launched job along with its assigned
+    launch ID.
     """
 
     def __init__(self, launch_id: LaunchedJobID, job: Job) -> None:

--- a/smartsim/launchable/job.py
+++ b/smartsim/launchable/job.py
@@ -26,6 +26,7 @@
 
 from __future__ import annotations
 
+import textwrap
 import typing as t
 from copy import deepcopy
 
@@ -191,3 +192,12 @@ class Record:
         :returns: A deep copy of the launched job.
         """
         return deepcopy(self._job)
+
+    def __str__(self) -> str:
+        return textwrap.dedent(f"""\
+            Launch Record:
+                Launched Job ID:
+                    {self.launched_id}
+                Laucnehd Job:
+            {textwrap.indent(str(self._job), "        ")}
+            """)

--- a/smartsim/launchable/job.py
+++ b/smartsim/launchable/job.py
@@ -164,8 +164,8 @@ class Job(BaseJob):
 
 @t.final
 class Record:
-    """A Record object to track a launched job along with its assigned
-    launch ID.
+    """An object composed of a unique identifier for a launched job, and a copy
+    of the job that was launched.
     """
 
     def __init__(self, launch_id: LaunchedJobID, job: Job) -> None:
@@ -198,6 +198,6 @@ class Record:
             Launch Record:
                 Launched Job ID:
                     {self.launched_id}
-                Laucnehd Job:
+                Launched Job:
             {textwrap.indent(str(self._job), "        ")}
             """)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -709,7 +709,7 @@ def test_type_wait_parameter(test_dir):
 
 def test_type_stop_parameter(test_dir):
     exp = Experiment(name="exp_name", exp_path=test_dir)
-    with pytest.raises(TypeError, match="record argument was not of type Record"):
+    with pytest.raises(TypeError, match="Record argument was not of type `Record`"):
         exp.stop(2)
 
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -1,0 +1,64 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2024, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import itertools
+
+import pytest
+
+from smartsim._core.utils.helpers import expand_exe_path
+from smartsim._core.utils.launcher import create_job_id
+from smartsim.entity.application import Application
+from smartsim.launchable.job import Job, Record
+from smartsim.settings.launch_settings import LaunchSettings
+
+pytestmark = pytest.mark.group_a
+
+
+def test_cannot_mutate_record_job():
+    app = Application("my-test-app", "echo", ["spam", "eggs"])
+    settings = LaunchSettings("local")
+    job = Job(app, settings)
+
+    id_ = create_job_id()
+    record = Record(id_, job)
+    assert record.launched_id == id_
+    assert all(
+        x is not y for x, y in itertools.combinations([job, record.job, record._job], 2)
+    )
+
+    app.name = "Modified orignal app name"
+    job.name = "Modified original job name"
+    record.job.name = "Modified reference to job off record name"
+    record.job.name = "Modified reference to app to job off record name"
+    assert record.job.name == record.job.entity.name == "my-test-app"
+
+    record.job.entity.exe = "sleep"
+    app.exe_args = ["120"]
+    assert [record.job.entity.exe] + record.job.entity.exe_args == [
+        expand_exe_path("echo"),
+        "spam",
+        "eggs",
+    ]


### PR DESCRIPTION
Basic implementation of a `Record` class to keep track of launched jobs. Convert `Experiment.start` return `Record`s and all other methods to accept records.