### PR TITLE
Symlink-fix

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@ Jump to:
 
 Description
 
+- Fix symlink operation
 - Fix dragon build logging bug
 - Merge core refactor into MLI feature branch
 - Implement asynchronous notifications for shared data

--- a/smartsim/_core/generation/operations/operations.py
+++ b/smartsim/_core/generation/operations/operations.py
@@ -135,17 +135,16 @@ class SymlinkOperation(GenerationProtocol):
         :return: Symlink Command
         """
         normalized_path = os.path.normpath(self.src)
-        parent_dir = os.path.dirname(normalized_path)
         final_dest = _create_dest_path(context.job_run_path, self.dest)
-        new_dest = os.path.join(final_dest, parent_dir)
+
         return Command(
             [
                 sys.executable,
                 "-m",
                 entry_point_path,
                 symlink_cmd,
-                str(self.src),
-                new_dest,
+                str(normalized_path),
+                final_dest,
             ]
         )
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -192,10 +192,8 @@ def test_symlink_operation_format(
     assert symlink_cmd in exec.command
 
     normalized_path = os.path.normpath(mock_src)
-    parent_dir = os.path.dirname(normalized_path)
     final_dest = _create_dest_path(generation_context.job_run_path, mock_dest)
-    new_dest = os.path.join(final_dest, parent_dir)
-    assert new_dest in exec.command
+    assert final_dest in exec.command
 
 
 def test_init_configure_operation(mock_src: str, mock_dest: str):


### PR DESCRIPTION
This PR is an attempt to fix an unexpected behavior encountered when using `SymlinkOperation`, where files were symlinked to their own directory.

I might have mis-interpreted what was going on with the code, though.

