### PR TITLE
Drop Unused `sympy` Import

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -21,6 +21,7 @@ Description
 - Terminate LSF and LSB support
 - Implement workaround for Tensorflow that allows RedisAI to build with GCC-14
 - Add instructions for installing SmartSim on PML's Scylla
+- Drop unsued development dependencies
 - Fix typos in documentation
 
 Detailed Notes
@@ -85,6 +86,8 @@ Detailed Notes
   Future versions of Tensorflow may fix this problem, but for now this seems to be
   the best workaround.
   ([SmartSim-PR738](https://github.com/CrayLabs/SmartSim/pull/738))
+- Removes an undocumented and unused dependency from the testing suite.
+  ([SmartSim-PR792](https://github.com/CrayLabs/SmartSim/pull/792))
 
 
 ### 0.8.0

--- a/tests/utils/test_security.py
+++ b/tests/utils/test_security.py
@@ -29,7 +29,6 @@ import pathlib
 import stat
 
 import pytest
-from sympy import public
 
 from smartsim._core.config.config import get_config
 from smartsim._core.utils.security import KeyManager, _KeyLocator, _KeyPermissions


### PR DESCRIPTION
Looks like this import was added to this test file and is not used. Dropping because it's not listed in the test requirements, does not look like its used, and was causing me some problems when attempting to run tests locally.