### PR TITLE
Fix patch for rocm6.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ htmlcov
 smartsim.egg-info
 tests/test_output
 .DS_Store
+build
 
 # Dependencies
 smartsim/_core/.third-party

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -11,6 +11,7 @@ To be released at some point in the future
 
 Description
 
+- Update install patch for PyTorch 2.7.1+rocm6.3
 - Modernize typing syntax to Python 3.10+ standards
 - Removed telemetry functionality, LaunchedManifest tracking
   classes, and SmartDashboard integration
@@ -26,6 +27,9 @@ Description
 
 Detailed Notes
 
+- Updated the post-install patch which is applied to the Caffe2/PyTorch
+  CMakeFind module.
+  ([SmartSim-PR793](https://github.com/CrayLabs/SmartSim/pull/793))
 - Modernized typing syntax to use Python 3.10+ standards, replacing
   `Union[X, Y]` with `X | Y`, `Optional[X]` with `X | None`, and generic
   collections (`List[X]` → `list[X]`, `Dict[X, Y]` → `dict[X, Y]`, etc.).

--- a/smartsim/_core/_install/configs/mlpackages/LinuxX64ROCM6.json
+++ b/smartsim/_core/_install/configs/mlpackages/LinuxX64ROCM6.json
@@ -33,7 +33,7 @@
                     "description": "Fix LoadHIP.cmake regex to match tabs in ROCm version header",
                     "source_file": "../package/libtorch/share/cmake/Caffe2/public/LoadHIP.cmake",
                     "regex": "\\[ \\]\\+",
-                    "replacement": "[ \\t]+"
+                    "replacement": "[ \\\\t]+"
                 },
                 {
                     "description": "Replace `/opt/rocm` with `$ENV{ROCM_PATH}`",

--- a/smartsim/_core/_install/configs/mlpackages/LinuxX64ROCM6.json
+++ b/smartsim/_core/_install/configs/mlpackages/LinuxX64ROCM6.json
@@ -30,10 +30,10 @@
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
                 },
                 {
-                    "description": "Fix Regex, Load HIP",
+                    "description": "Fix LoadHIP.cmake regex to match tabs in ROCm version header",
                     "source_file": "../package/libtorch/share/cmake/Caffe2/public/LoadHIP.cmake",
-                    "regex": ".*string.*",
-                    "replacement": ""
+                    "regex": "\\[ \\]\\+",
+                    "replacement": "[ \\t]+"
                 },
                 {
                     "description": "Replace `/opt/rocm` with `$ENV{ROCM_PATH}`",


### PR DESCRIPTION
The header for ROCM 6.3.4 is not compatible with PyTorch 2.7.1 regex. Additionally, an old patch is not useful anymore and has been removed.