### PR TITLE
Miscellaneous test fixes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -747,7 +747,9 @@ def _cleanup_db(name: str) -> None:
     global database_registry
     db = database_registry[name]
     if db and db.is_active():
-        exp = Experiment("cleanup")
+        cleanup_dir = str(pathlib.Path(test_output_root) / "cleanup")
+        os.makedirs(cleanup_dir, exist_ok=True)
+        exp = Experiment("cleanup", cleanup_dir)
         try:
             db = exp.reconnect_orchestrator(db.checkpoint_file)
             exp.stop(db)

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -11,6 +11,7 @@ To be released at some point in the future
 
 Description
 
+- Miscellaneous test fixes
 - Update install patch for PyTorch 2.7.1+rocm6.3
 - Modernize typing syntax to Python 3.10+ standards
 - Removed telemetry functionality, LaunchedManifest tracking
@@ -27,6 +28,10 @@ Description
 
 Detailed Notes
 
+- Updated tests which would create experiment in root directory, patched
+  tests which would not work on some Slurm systems, added an environment variable
+  to control how long to wait for Redis server to be available.
+  ([SmartSim-PR794](https://github.com/CrayLabs/SmartSim/pull/794))
 - Updated the post-install patch which is applied to the Caffe2/PyTorch
   CMakeFind module.
   ([SmartSim-PR793](https://github.com/CrayLabs/SmartSim/pull/793))

--- a/smartsim/_core/config/config.py
+++ b/smartsim/_core/config/config.py
@@ -195,6 +195,10 @@ class Config:
         return os.getenv("SMARTSIM_DRAGON_TRANSPORT", "hsta")
 
     @property
+    def redis_cli_timeout(self) -> int:
+        return int(os.getenv("SMARTSIM_REDIS_TIMEOUT", "10"))
+
+    @property
     def log_level(self) -> str:
         return os.environ.get("SMARTSIM_LOG_LEVEL", "info")
 

--- a/smartsim/_core/utils/redis.py
+++ b/smartsim/_core/utils/redis.py
@@ -225,7 +225,7 @@ def shutdown_db_node(host_ip: str, port: int) -> tuple[int, str, str]:  # cov-wl
     """
     redis_cli = CONFIG.database_cli
     cmd = [redis_cli, "-h", host_ip, "-p", str(port), "shutdown"]
-    returncode, out, err = execute_cmd(cmd, proc_input="yes", shell=False, timeout=10)
+    returncode, out, err = execute_cmd(cmd, proc_input="yes", shell=False, timeout=CONFIG.redis_cli_timeout)
 
     if returncode != 0:
         logger.error(out)

--- a/smartsim/_core/utils/redis.py
+++ b/smartsim/_core/utils/redis.py
@@ -225,7 +225,9 @@ def shutdown_db_node(host_ip: str, port: int) -> tuple[int, str, str]:  # cov-wl
     """
     redis_cli = CONFIG.database_cli
     cmd = [redis_cli, "-h", host_ip, "-p", str(port), "shutdown"]
-    returncode, out, err = execute_cmd(cmd, proc_input="yes", shell=False, timeout=CONFIG.redis_cli_timeout)
+    returncode, out, err = execute_cmd(
+        cmd, proc_input="yes", shell=False, timeout=CONFIG.redis_cli_timeout
+    )
 
     if returncode != 0:
         logger.error(out)

--- a/smartsim/_core/utils/security.py
+++ b/smartsim/_core/utils/security.py
@@ -195,11 +195,15 @@ class KeyManager:
                 permission = _KeyPermissions.PUBLIC_DIR
                 logger.debug(f"Creating key dir: {locator.public_dir}, {permission}")
                 locator.public_dir.mkdir(parents=True, mode=permission)
+                # Explicitly chmod to override umask and inherited bits (e.g. setgid)
+                locator.public_dir.chmod(permission)
 
             if not locator.private_dir.exists():
                 permission = _KeyPermissions.PRIVATE_DIR
                 logger.debug(f"Creating key dir: {locator.private_dir}, {permission}")
                 locator.private_dir.mkdir(parents=True, mode=permission)
+                # Explicitly chmod to override umask and inherited bits (e.g. setgid)
+                locator.private_dir.chmod(permission)
 
     @classmethod
     def _load_keypair(cls, locator: _KeyLocator, in_context: bool) -> KeyPair:

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -39,6 +39,9 @@ from smartsim.status import SmartSimStatus
 
 logger = get_logger(__name__)
 
+# Disable CPU pinning on Slurm systems where default CPUs (0,1,...) may not be available
+slurm_pinning_override = {"custom_pinning": []} if pytest.test_launcher == "slurm" else {}
+
 should_run_tf = True
 should_run_pt = True
 
@@ -393,7 +396,7 @@ def test_colocated_db_model_tf(fileutils, test_dir, wlmutils, mlutils):
     # Create colocated Model
     colo_model = exp.create_model("colocated_model", colo_settings)
     colo_model.colocate_db_tcp(
-        port=test_port, db_cpus=1, debug=True, ifname=test_interface
+        port=test_port, db_cpus=1, debug=True, ifname=test_interface, **slurm_pinning_override
     )
 
     # Create and save ML model to filesystem
@@ -465,7 +468,7 @@ def test_colocated_db_model_pytorch(fileutils, test_dir, wlmutils, mlutils):
     # Create colocated SmartSim Model
     colo_model = exp.create_model("colocated_model", colo_settings)
     colo_model.colocate_db_tcp(
-        port=test_port, db_cpus=1, debug=True, ifname=test_interface
+        port=test_port, db_cpus=1, debug=True, ifname=test_interface, **slurm_pinning_override
     )
 
     # Create and save ML model to filesystem
@@ -532,7 +535,7 @@ def test_colocated_db_model_ensemble(fileutils, test_dir, wlmutils, mlutils):
     # Create a third model with a colocated database
     colo_model = exp.create_model("colocated_model", colo_settings)
     colo_model.colocate_db_tcp(
-        port=test_port, db_cpus=1, debug=True, ifname=test_interface
+        port=test_port, db_cpus=1, debug=True, ifname=test_interface, **slurm_pinning_override
     )
 
     # Create and save the ML models to the filesystem
@@ -542,7 +545,7 @@ def test_colocated_db_model_ensemble(fileutils, test_dir, wlmutils, mlutils):
     # Colocate a database with the ensemble with two ensemble members
     for i, entity in enumerate(colo_ensemble):
         entity.colocate_db_tcp(
-            port=test_port + i + 1, db_cpus=1, debug=True, ifname=test_interface
+            port=test_port + i + 1, db_cpus=1, debug=True, ifname=test_interface, **slurm_pinning_override
         )
         # Add ML model to each ensemble member individual to test that they
         # do not conflict with models add to the Ensemble object
@@ -652,7 +655,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, test_dir, wlmutils, ml
     # Colocate a database with the first ensemble members
     for i, entity in enumerate(colo_ensemble):
         entity.colocate_db_tcp(
-            port=test_port + i, db_cpus=1, debug=True, ifname=test_interface
+            port=test_port + i, db_cpus=1, debug=True, ifname=test_interface, **slurm_pinning_override
         )
         # Add ML models to each ensemble member to make sure they
         # do not conflict with other ML models
@@ -677,6 +680,7 @@ def test_colocated_db_model_ensemble_reordered(fileutils, test_dir, wlmutils, ml
         db_cpus=1,
         debug=True,
         ifname=test_interface,
+        **slurm_pinning_override,
     )
     # Add a ML model to the new ensemble member
     colo_model.add_ml_model(

--- a/tests/backends/test_dbmodel.py
+++ b/tests/backends/test_dbmodel.py
@@ -40,7 +40,9 @@ from smartsim.status import SmartSimStatus
 logger = get_logger(__name__)
 
 # Disable CPU pinning on Slurm systems where default CPUs (0,1,...) may not be available
-slurm_pinning_override = {"custom_pinning": []} if pytest.test_launcher == "slurm" else {}
+slurm_pinning_override = (
+    {"custom_pinning": []} if pytest.test_launcher == "slurm" else {}
+)
 
 should_run_tf = True
 should_run_pt = True
@@ -396,7 +398,11 @@ def test_colocated_db_model_tf(fileutils, test_dir, wlmutils, mlutils):
     # Create colocated Model
     colo_model = exp.create_model("colocated_model", colo_settings)
     colo_model.colocate_db_tcp(
-        port=test_port, db_cpus=1, debug=True, ifname=test_interface, **slurm_pinning_override
+        port=test_port,
+        db_cpus=1,
+        debug=True,
+        ifname=test_interface,
+        **slurm_pinning_override,
     )
 
     # Create and save ML model to filesystem
@@ -468,7 +474,11 @@ def test_colocated_db_model_pytorch(fileutils, test_dir, wlmutils, mlutils):
     # Create colocated SmartSim Model
     colo_model = exp.create_model("colocated_model", colo_settings)
     colo_model.colocate_db_tcp(
-        port=test_port, db_cpus=1, debug=True, ifname=test_interface, **slurm_pinning_override
+        port=test_port,
+        db_cpus=1,
+        debug=True,
+        ifname=test_interface,
+        **slurm_pinning_override,
     )
 
     # Create and save ML model to filesystem
@@ -535,7 +545,11 @@ def test_colocated_db_model_ensemble(fileutils, test_dir, wlmutils, mlutils):
     # Create a third model with a colocated database
     colo_model = exp.create_model("colocated_model", colo_settings)
     colo_model.colocate_db_tcp(
-        port=test_port, db_cpus=1, debug=True, ifname=test_interface, **slurm_pinning_override
+        port=test_port,
+        db_cpus=1,
+        debug=True,
+        ifname=test_interface,
+        **slurm_pinning_override,
     )
 
     # Create and save the ML models to the filesystem
@@ -545,7 +559,11 @@ def test_colocated_db_model_ensemble(fileutils, test_dir, wlmutils, mlutils):
     # Colocate a database with the ensemble with two ensemble members
     for i, entity in enumerate(colo_ensemble):
         entity.colocate_db_tcp(
-            port=test_port + i + 1, db_cpus=1, debug=True, ifname=test_interface, **slurm_pinning_override
+            port=test_port + i + 1,
+            db_cpus=1,
+            debug=True,
+            ifname=test_interface,
+            **slurm_pinning_override,
         )
         # Add ML model to each ensemble member individual to test that they
         # do not conflict with models add to the Ensemble object
@@ -655,7 +673,11 @@ def test_colocated_db_model_ensemble_reordered(fileutils, test_dir, wlmutils, ml
     # Colocate a database with the first ensemble members
     for i, entity in enumerate(colo_ensemble):
         entity.colocate_db_tcp(
-            port=test_port + i, db_cpus=1, debug=True, ifname=test_interface, **slurm_pinning_override
+            port=test_port + i,
+            db_cpus=1,
+            debug=True,
+            ifname=test_interface,
+            **slurm_pinning_override,
         )
         # Add ML models to each ensemble member to make sure they
         # do not conflict with other ML models

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -235,7 +235,10 @@ def test_colocated_db_script(fileutils, test_dir, wlmutils, mlutils):
     # Create model with colocated database
     colo_model = exp.create_model("colocated_model", colo_settings)
     colo_model.colocate_db_tcp(
-        port=test_port, db_cpus=1, debug=True, ifname=test_interface,
+        port=test_port,
+        db_cpus=1,
+        debug=True,
+        ifname=test_interface,
         custom_pinning=[] if test_launcher == "slurm" else None,
     )
 

--- a/tests/backends/test_dbscript.py
+++ b/tests/backends/test_dbscript.py
@@ -235,7 +235,8 @@ def test_colocated_db_script(fileutils, test_dir, wlmutils, mlutils):
     # Create model with colocated database
     colo_model = exp.create_model("colocated_model", colo_settings)
     colo_model.colocate_db_tcp(
-        port=test_port, db_cpus=1, debug=True, ifname=test_interface
+        port=test_port, db_cpus=1, debug=True, ifname=test_interface,
+        custom_pinning=[] if test_launcher == "slurm" else None,
     )
 
     # Create string for script creation
@@ -318,6 +319,7 @@ def test_colocated_db_script_ensemble(fileutils, test_dir, wlmutils, mlutils):
             db_cpus=1,
             debug=True,
             ifname=test_interface,
+            custom_pinning=[] if test_launcher == "slurm" else None,
         )
 
         entity.add_script(
@@ -334,6 +336,7 @@ def test_colocated_db_script_ensemble(fileutils, test_dir, wlmutils, mlutils):
         db_cpus=1,
         debug=True,
         ifname=test_interface,
+        custom_pinning=[] if test_launcher == "slurm" else None,
     )
 
     # Add a script to the non-ensemble model
@@ -427,6 +430,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, test_dir, wlmutils, m
             db_cpus=1,
             debug=True,
             ifname=test_interface,
+            custom_pinning=[] if test_launcher == "slurm" else None,
         )
 
         entity.add_script(
@@ -443,6 +447,7 @@ def test_colocated_db_script_ensemble_reordered(fileutils, test_dir, wlmutils, m
         db_cpus=1,
         debug=True,
         ifname=test_interface,
+        custom_pinning=[] if test_launcher == "slurm" else None,
     )
 
     # Add the non-ensemble SmartSim Model to the Ensemble
@@ -503,6 +508,7 @@ def test_db_script_errors(fileutils, test_dir, wlmutils, mlutils):
         db_cpus=1,
         debug=True,
         ifname=test_interface,
+        custom_pinning=[] if test_launcher == "slurm" else None,
     )
 
     # Check that an error is raised for adding in-memory
@@ -529,6 +535,7 @@ def test_db_script_errors(fileutils, test_dir, wlmutils, mlutils):
             db_cpus=1,
             debug=True,
             ifname=test_interface,
+            custom_pinning=[] if test_launcher == "slurm" else None,
         )
 
     # Check that an exception is raised when adding an in-memory
@@ -567,6 +574,7 @@ def test_db_script_errors(fileutils, test_dir, wlmutils, mlutils):
                 db_cpus=1,
                 debug=True,
                 ifname=test_interface,
+                custom_pinning=[] if test_launcher == "slurm" else None,
             )
 
     # Check that an error is raised when trying to add

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -49,7 +49,7 @@ if launcher not in pytest.wlm_options:
 @pytest.mark.skipif(
     launcher == "slurm",
     reason="Default CPU pinning assumes CPUs 0..N are available, which is not "
-           "guaranteed on SLURM with cgroup restrictions",
+    "guaranteed on SLURM with cgroup restrictions",
 )
 @pytest.mark.parametrize("db_type", supported_dbs)
 def test_launch_colocated_model_defaults(fileutils, test_dir, coloutils, db_type):
@@ -104,7 +104,7 @@ def test_colocated_model_disable_pinning(fileutils, test_dir, coloutils, db_type
 @pytest.mark.skipif(
     launcher == "slurm",
     reason="Default CPU pinning assumes CPUs 0..N are available, which is not "
-           "guaranteed on SLURM with cgroup restrictions",
+    "guaranteed on SLURM with cgroup restrictions",
 )
 @pytest.mark.parametrize("db_type", supported_dbs)
 def test_colocated_model_pinning_auto_2cpu(fileutils, test_dir, coloutils, db_type):

--- a/tests/on_wlm/test_colocated_model.py
+++ b/tests/on_wlm/test_colocated_model.py
@@ -46,6 +46,11 @@ if launcher not in pytest.wlm_options:
     pytestmark = pytest.mark.skip(reason="Not testing WLM integrations")
 
 
+@pytest.mark.skipif(
+    launcher == "slurm",
+    reason="Default CPU pinning assumes CPUs 0..N are available, which is not "
+           "guaranteed on SLURM with cgroup restrictions",
+)
 @pytest.mark.parametrize("db_type", supported_dbs)
 def test_launch_colocated_model_defaults(fileutils, test_dir, coloutils, db_type):
     """Test the launch of a model with a colocated database and local launcher"""
@@ -96,6 +101,11 @@ def test_colocated_model_disable_pinning(fileutils, test_dir, coloutils, db_type
     ), f"Statuses: {statuses}"
 
 
+@pytest.mark.skipif(
+    launcher == "slurm",
+    reason="Default CPU pinning assumes CPUs 0..N are available, which is not "
+           "guaranteed on SLURM with cgroup restrictions",
+)
 @pytest.mark.parametrize("db_type", supported_dbs)
 def test_colocated_model_pinning_auto_2cpu(fileutils, test_dir, coloutils, db_type):
     exp = Experiment(

--- a/tests/on_wlm/test_preview_wlm.py
+++ b/tests/on_wlm/test_preview_wlm.py
@@ -93,6 +93,8 @@ def test_preview_wlm_run_commands_cluster_orc_model(
         "debug": True,
         "db_identifier": "testdb_colo",
     }
+    if wlmutils.get_test_launcher() == "slurm":
+        db_args["custom_pinning"] = []
 
     # Create model with colocated database
     smartsim_model = coloutils.setup_test_colo(
@@ -371,7 +373,7 @@ def test_preview_ensemble_db_script(wlmutils, test_dir):
     """
     # Initialize the Experiment and set the launcher to auto
     test_launcher = wlmutils.get_test_launcher()
-    exp = Experiment("getting-started", launcher=test_launcher)
+    exp = Experiment("getting-started", test_dir, launcher=test_launcher)
 
     orch = exp.create_database(db_identifier="test_db1")
     orch_2 = exp.create_database(db_identifier="test_db2", db_nodes=3)

--- a/tests/on_wlm/test_simple_entity_launch.py
+++ b/tests/on_wlm/test_simple_entity_launch.py
@@ -75,6 +75,7 @@ def test_multinode_app(mpi_app_path, test_dir, wlmutils):
 
     settings = exp.create_run_settings(str(mpi_app_path), [])
     settings.set_nodes(3)
+    settings.set_tasks(3)
 
     model = exp.create_model("mpi_app", run_settings=settings)
     exp.generate(model)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+from collections import defaultdict
 import logging
 import os
 import pathlib
@@ -697,6 +698,7 @@ def test_cli_full_site_execute(capsys, monkeypatch):
 
 def test_cli_full_build_execute(capsys, monkeypatch):
     """Ensure that the execute method of build is called"""
+
     exp_retval = 0
     exp_output = "mocked-execute-build utility"
 
@@ -704,10 +706,25 @@ def test_cli_full_build_execute(capsys, monkeypatch):
         print(exp_output)
         return exp_retval
 
-    # mock out the internal get_db_path method so we don't actually do file system ops
+    def mock_noop(*args, **kwargs):
+        pass
+
+    # mock out the internal methods so we don't actually do file system ops or installs
     monkeypatch.setattr(smartsim._core._cli.build, "tabulate", mock_operation)
     monkeypatch.setattr(smartsim._core._cli.build, "build_database", mock_operation)
     monkeypatch.setattr(smartsim._core._cli.build, "build_redis_ai", mock_operation)
+    # Return empty package collection to prevent pip_install calls
+    monkeypatch.setattr(
+        smartsim._core._cli.build,
+        "load_platform_configs",
+        lambda *a, **kw: defaultdict(dict),
+    )
+    monkeypatch.setattr(
+        smartsim._core._cli.build, "installed_redisai_backends", lambda: []
+    )
+    monkeypatch.setattr(
+        smartsim._core._cli.build, "check_ml_python_packages", mock_noop
+    )
 
     command = "build"
     cfg = MenuItemConfig(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,11 +25,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
-from collections import defaultdict
 import logging
 import os
 import pathlib
 import typing as t
+from collections import defaultdict
 from contextlib import contextmanager
 
 import pytest

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -298,8 +298,8 @@ def test_key_prefixing():
     assert e.query_key_prefixing() == True
 
 
-def test_ensemble_type():
-    exp = Experiment("name")
+def test_ensemble_type(test_dir):
+    exp = Experiment("name", test_dir)
     ens_settings = RunSettings("python")
     ensemble = exp.create_ensemble("name", replicas=4, run_settings=ens_settings)
     assert ensemble.type == "Ensemble"

--- a/tests/test_entitylist.py
+++ b/tests/test_entitylist.py
@@ -42,11 +42,11 @@ def test_entity_list_init():
         ent_list = EntityList("list", getcwd(), perm_strat="all_perm")
 
 
-def test_entity_list_getitem():
+def test_entity_list_getitem(test_dir):
     """EntityList.__getitem__ is overridden in Ensemble, so we had to pass an instance of Ensemble
     to EntityList.__getitem__ in order to add test coverage to EntityList.__getitem__
     """
-    exp = Experiment("name")
+    exp = Experiment("name", test_dir)
     ens_settings = RunSettings("python")
     ensemble = exp.create_ensemble("name", replicas=4, run_settings=ens_settings)
     assert ensemble.__getitem__("name_3") == ensemble["name_3"]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -86,9 +86,9 @@ def test_type_exp_path() -> None:
         exp = Experiment("test", ["this-is-a-list-dummy"])
 
 
-def test_stop_type() -> None:
+def test_stop_type(test_dir) -> None:
     """Wrong argument type given to stop"""
-    exp = Experiment("name")
+    exp = Experiment("name", test_dir)
     with pytest.raises(TypeError):
         exp.stop("model")
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -58,7 +58,7 @@ def get_gen_file(fileutils, filename):
 
 
 def test_ensemble(fileutils, test_dir):
-    exp = Experiment("gen-test", launcher="local")
+    exp = Experiment("gen-test", test_dir, launcher="local")
 
     gen = Generator(test_dir)
     params = {"THERMO": [10, 20, 30], "STEPS": [10, 20, 30]}
@@ -75,7 +75,7 @@ def test_ensemble(fileutils, test_dir):
 
 
 def test_ensemble_overwrite(fileutils, test_dir):
-    exp = Experiment("gen-test-overwrite", launcher="local")
+    exp = Experiment("gen-test-overwrite", test_dir, launcher="local")
 
     gen = Generator(test_dir, overwrite=True)
 
@@ -98,7 +98,7 @@ def test_ensemble_overwrite(fileutils, test_dir):
 
 
 def test_ensemble_overwrite_error(fileutils, test_dir):
-    exp = Experiment("gen-test-overwrite-error", launcher="local")
+    exp = Experiment("gen-test-overwrite-error", test_dir, launcher="local")
 
     gen = Generator(test_dir)
 
@@ -306,7 +306,7 @@ def test_config_dir(fileutils, test_dir):
     """Test the generation and configuration of models with
     tagged files that are directories with subdirectories and files
     """
-    exp = Experiment("config-dir", launcher="local")
+    exp = Experiment("config-dir", test_dir, launcher="local")
 
     gen = Generator(test_dir)
 
@@ -339,31 +339,31 @@ def test_config_dir(fileutils, test_dir):
     _check_generated(3, 1, 3)
 
 
-def test_no_gen_if_file_not_exist(fileutils):
+def test_no_gen_if_file_not_exist(fileutils, test_dir):
     """Test that generation of file with non-existant config
     raises a FileNotFound exception
     """
-    exp = Experiment("file-not-found", launcher="local")
+    exp = Experiment("file-not-found", test_dir, launcher="local")
     ensemble = exp.create_ensemble("test", params={"P": [0, 1]}, run_settings=rs)
     config = get_gen_file(fileutils, "path_not_exist")
     with pytest.raises(FileNotFoundError):
         ensemble.attach_generator_files(to_configure=config)
 
 
-def test_no_gen_if_symlink_to_dir(fileutils):
+def test_no_gen_if_symlink_to_dir(fileutils, test_dir):
     """Test that when configuring a directory containing a symlink
     a ValueError exception is raised to prevent circular file
     structure configuration
     """
-    exp = Experiment("circular-config-files", launcher="local")
+    exp = Experiment("circular-config-files", test_dir, launcher="local")
     ensemble = exp.create_ensemble("test", params={"P": [0, 1]}, run_settings=rs)
     config = get_gen_file(fileutils, "circular_config")
     with pytest.raises(ValueError):
         ensemble.attach_generator_files(to_configure=config)
 
 
-def test_no_file_overwrite():
-    exp = Experiment("test_no_file_overwrite", launcher="local")
+def test_no_file_overwrite(test_dir):
+    exp = Experiment("test_no_file_overwrite", test_dir, launcher="local")
     ensemble = exp.create_ensemble("test", params={"P": [0, 1]}, run_settings=rs)
     with pytest.raises(ValueError):
         ensemble.attach_generator_files(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -41,8 +41,8 @@ from smartsim.settings.mpiSettings import _BaseMPISettings
 pytestmark = pytest.mark.slow_tests
 
 
-def test_register_incoming_entity_preexists():
-    exp = Experiment("experiment", launcher="local")
+def test_register_incoming_entity_preexists(test_dir):
+    exp = Experiment("experiment", test_dir, launcher="local")
     rs = RunSettings("python", exe_args="sleep.py")
     ensemble = exp.create_ensemble(name="ensemble", replicas=1, run_settings=rs)
     m = exp.create_model("model", run_settings=rs)
@@ -52,16 +52,16 @@ def test_register_incoming_entity_preexists():
         m.register_incoming_entity(ensemble["ensemble_0"])
 
 
-def test_disable_key_prefixing():
-    exp = Experiment("experiment", launcher="local")
+def test_disable_key_prefixing(test_dir):
+    exp = Experiment("experiment", test_dir, launcher="local")
     rs = RunSettings("python", exe_args="sleep.py")
     m = exp.create_model("model", run_settings=rs)
     m.disable_key_prefixing()
     assert m.query_key_prefixing() == False
 
 
-def test_catch_colo_mpmd_model():
-    exp = Experiment("experiment", launcher="local")
+def test_catch_colo_mpmd_model(test_dir):
+    exp = Experiment("experiment", test_dir, launcher="local")
     rs = _BaseMPISettings("python", exe_args="sleep.py", fail_if_missing_exec=False)
 
     # make it an mpmd model
@@ -75,8 +75,8 @@ def test_catch_colo_mpmd_model():
         model.colocate_db()
 
 
-def test_attach_batch_settings_to_model():
-    exp = Experiment("experiment", launcher="slurm")
+def test_attach_batch_settings_to_model(test_dir):
+    exp = Experiment("experiment", test_dir, launcher="slurm")
     bs = SbatchSettings()
     rs = SrunSettings("python", exe_args="sleep.py")
 

--- a/tests/test_multidb.py
+++ b/tests/test_multidb.py
@@ -104,6 +104,8 @@ def test_db_identifier_standard_then_colo_error(
         "debug": True,
         "db_identifier": "testdb_colo",
     }
+    if wlmutils.get_test_launcher() == "slurm":
+        db_args["custom_pinning"] = []
 
     smartsim_model = coloutils.setup_test_colo(
         fileutils, db_type, exp, test_script, db_args, on_wlm=on_wlm
@@ -160,6 +162,8 @@ def test_db_identifier_colo_then_standard(
         "debug": True,
         "db_identifier": "testdb_colo",
     }
+    if wlmutils.get_test_launcher() == "slurm":
+        db_args["custom_pinning"] = []
 
     smartsim_model = coloutils.setup_test_colo(
         fileutils,
@@ -332,6 +336,8 @@ def test_multidb_colo_once(fileutils, test_dir, wlmutils, coloutils, db_type):
         "debug": True,
         "db_identifier": "testdb_colo",
     }
+    if wlmutils.get_test_launcher() == "slurm":
+        db_args["custom_pinning"] = []
     # Create model with colocated database
 
     smartsim_model = coloutils.setup_test_colo(
@@ -379,6 +385,8 @@ def test_multidb_standard_then_colo(fileutils, test_dir, wlmutils, coloutils, db
         "debug": True,
         "db_identifier": "testdb_colo",
     }
+    if wlmutils.get_test_launcher() == "slurm":
+        db_args["custom_pinning"] = []
     # Create model with colocated database
     smartsim_model = coloutils.setup_test_colo(
         fileutils,
@@ -420,6 +428,8 @@ def test_multidb_colo_then_standard(fileutils, test_dir, wlmutils, coloutils, db
         "debug": True,
         "db_identifier": "testdb_colo",
     }
+    if wlmutils.get_test_launcher() == "slurm":
+        db_args["custom_pinning"] = []
 
     # Create model with colocated database
     smartsim_model = coloutils.setup_test_colo(
@@ -477,6 +487,8 @@ def test_launch_cluster_orc_single_dbid(
         "debug": True,
         "db_identifier": "testdb_colo",
     }
+    if wlmutils.get_test_launcher() == "slurm":
+        db_args["custom_pinning"] = []
 
     # Create model with colocated database
     smartsim_model = coloutils.setup_test_colo(

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1301,7 +1301,7 @@ def test_preview_db_script(wlmutils, test_dir):
     test_launcher = wlmutils.get_test_launcher()
     # Initialize the Experiment and set the launcher to auto
 
-    exp = Experiment("getting-started", launcher=test_launcher)
+    exp = Experiment("getting-started", test_dir, launcher=test_launcher)
 
     # Initialize a RunSettings object
     model_settings = exp.create_run_settings(exe="python", exe_args="params.py")


### PR DESCRIPTION
This PR adds miscellaneous fixes to tests, preventing files from spilling in the root directory, allowing better control of Redis retries, and also preventing issues when Slurm would not assign CPU 0, 1, ... to the run, resulting in issues with cgroup. This last one is the most fragile of all fixes and it could be ignored - or improved.

I won't be able to follow what will happen with this PR, I'll leave it up to the team.