### PR TITLE
fix: treat path=None as getcwd() in Model, Ensemble, and Orchestrator

### DIFF
--- a/smartsim/database/orchestrator.py
+++ b/smartsim/database/orchestrator.py
@@ -229,7 +229,7 @@ class Orchestrator(EntityList[DBNode]):
 
         super().__init__(
             name=db_identifier,
-            path=str(path),
+            path=path if path is not None else getcwd(),
             port=port,
             interface=interface,
             db_nodes=db_nodes,

--- a/smartsim/entity/ensemble.py
+++ b/smartsim/entity/ensemble.py
@@ -96,7 +96,7 @@ class Ensemble(EntityList[Model]):
         self.run_settings = run_settings
         self.replicas: str
 
-        super().__init__(name, str(path), perm_strat=perm_strat, **kwargs)
+        super().__init__(name, path if path is not None else getcwd(), perm_strat=perm_strat, **kwargs)
 
     @property
     def models(self) -> Collection[Model]:

--- a/smartsim/entity/model.py
+++ b/smartsim/entity/model.py
@@ -91,7 +91,7 @@ class Model(SmartSimEntity):
         :param batch_settings: Launcher settings for running the individual
                                model as a batch job
         """
-        super().__init__(name, str(path), run_settings)
+        super().__init__(name, path if path is not None else getcwd(), run_settings)
         self.params = _parse_model_parameters(params)
         self.params_as_args = params_as_args
         self.incoming_entities: list[SmartSimEntity] = []

--- a/tests/test_entity_path_none.py
+++ b/tests/test_entity_path_none.py
@@ -1,0 +1,104 @@
+# BSD 2-Clause License
+#
+# Copyright (c) 2021-2025, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Regression tests for CrayLabs/SmartSim#556.
+
+When path=None is passed to Model, Ensemble, or Orchestrator, the .path
+attribute must be the current working directory — never the string 'None'.
+"""
+
+from os import getcwd
+
+import pytest
+
+from smartsim.entity import Ensemble, Model
+from smartsim.settings import RunSettings
+from smartsim.settings.base import BatchSettings
+
+
+def test_model_path_none_defaults_to_cwd():
+    """Model(path=None) must set .path to getcwd(), not 'None'."""
+    rs = RunSettings("echo", ["hello"])
+    m = Model("test-model", {}, rs, path=None)
+    assert m.path != "None", "path must not be the string 'None'"
+    assert m.path == getcwd()
+
+
+def test_model_explicit_path_unchanged():
+    """Passing an explicit path string must be stored as-is."""
+    rs = RunSettings("echo", ["hello"])
+    m = Model("test-model", {}, rs, path="/tmp/my-experiment")
+    assert m.path == "/tmp/my-experiment"
+
+
+def test_ensemble_path_none_defaults_to_cwd():
+    """Ensemble(path=None) must set .path to getcwd(), not 'None'.
+
+    A batch-only ensemble (no run_settings, no params) is used so the
+    constructor does not attempt to spawn Model members, keeping the test
+    free of HPC-specific launcher dependencies.
+    """
+
+    class _StubBatchSettings(BatchSettings):
+        """Minimal BatchSettings subclass that requires no external commands."""
+
+        def set_walltime(self, walltime: str) -> None:  # type: ignore[override]
+            pass
+
+        def set_nodes(self, num_nodes: int) -> None:
+            pass
+
+        def set_hostlist(self, host_list):
+            pass
+
+        def format_batch_args(self):
+            return []
+
+    bs = _StubBatchSettings()
+    ens = Ensemble("test-ens", {}, path=None, batch_settings=bs)
+    assert ens.path != "None", "path must not be the string 'None'"
+    assert ens.path == getcwd()
+
+
+def test_ensemble_explicit_path_unchanged():
+    """Passing an explicit path string to Ensemble must be stored as-is."""
+
+    class _StubBatchSettings(BatchSettings):
+        def set_walltime(self, walltime: str) -> None:  # type: ignore[override]
+            pass
+
+        def set_nodes(self, num_nodes: int) -> None:
+            pass
+
+        def set_hostlist(self, host_list):
+            pass
+
+        def format_batch_args(self):
+            return []
+
+    bs = _StubBatchSettings()
+    ens = Ensemble("test-ens", {}, path="/tmp/my-ensemble", batch_settings=bs)
+    assert ens.path == "/tmp/my-ensemble"


### PR DESCRIPTION
## What

Replace `str(path)` with `path if path is not None else getcwd()` in the `__init__` of `Model`, `Ensemble`, and `Orchestrator`, so that passing `path=None` defaults to the current working directory rather than storing the literal string `"None"`.

## Why

Fixes #556.

When a caller passes `path=None` explicitly (or relies on the default), `str(None)` evaluates to `"None"`, which is stored as `self.path`. Any subsequent file I/O (e.g. writing output files, resolving configuration paths) fails because `"None"` is not a valid filesystem path. Since `getcwd` is already imported in all three files, the fix requires no new imports.

## How

At each of the three call sites that forwarded `path` to `super().__init__()`, replace:

```python
str(path)
```

with:

```python
path if path is not None else getcwd()
```

The affected lines are:
- `smartsim/entity/model.py` — `Model.__init__` → `super().__init__`
- `smartsim/entity/ensemble.py` — `Ensemble.__init__` → `super().__init__`
- `smartsim/database/orchestrator.py` — `Orchestrator.__init__` → `super().__init__`

No changes were made to the base class (`SmartSimEntity`) or any other file.

## Scope

- **Included:** fix for `Model`, `Ensemble`, and `Orchestrator`; regression tests for `Model` and `Ensemble`
- **NOT included:** a regression test for `Orchestrator` — the constructor checks for Redis binaries at import time, which requires the full SmartSim extension stack. The fix is applied and the logic is identical to the other two classes; a test could be added once the CI environment provides those binaries.

## Verification

- [ ] `tests/test_entity_path_none.py::test_model_path_none_defaults_to_cwd` — passes after fix, fails on unpatched code
- [ ] `tests/test_entity_path_none.py::test_model_explicit_path_unchanged` — passes in both cases (regression guard)
- [ ] `tests/test_entity_path_none.py::test_ensemble_path_none_defaults_to_cwd` — passes after fix, fails on unpatched code
- [ ] `tests/test_entity_path_none.py::test_ensemble_explicit_path_unchanged` — passes in both cases (regression guard)

Manual check (no SmartSim install needed for the logic itself):
```python
from os import getcwd
path = None
result = path if path is not None else getcwd()
assert result == getcwd()   # True — never "None"
```

## AI Disclosure

AI tools were used to assist with identifying the fix sites and drafting the test file. All changes were manually reviewed for correctness before submission.