### PR TITLE
Bump Numpy Version Cap

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -20,6 +20,7 @@ Description
 - Python 3.12 is now supported; where available, installed TensorFlow version
   is now 2.16.2, PyTorch is 2.7.1.
 - Drop Python 3.9 support
+- Add Numpy 2.0 support
 - Terminate LSF and LSB support
 - Implement workaround for Tensorflow that allows RedisAI to build with GCC-14
 - Add instructions for installing SmartSim on PML's Scylla
@@ -104,6 +105,9 @@ Detailed Notes
   ([SmartSim-PR792](https://github.com/CrayLabs/SmartSim/pull/792))
 - Address potential type errors in SmartSim.
   ([SmartSim-PR798](https://github.com/CrayLabs/SmartSim/pull/798))
+- Removes an Numpy upper bound in the SmartSim dependency list now that
+  SmartRedis and supported ML backends support Numpy 2.0.
+  ([SmartSim-PR803](https://github.com/CrayLabs/SmartSim/pull/803))
 
 
 ### 0.8.0

--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,7 @@ setup(
         "pydantic>2",
         "pyzmq>=25.1.2",
         "pygithub>=2.3.0",
-        "numpy<2",
+        "numpy<3.0.0",
         "smartredis>=0.6,<0.7",
     ],
     zip_safe=False,

--- a/tests/test_controller_metadata_usage.py
+++ b/tests/test_controller_metadata_usage.py
@@ -15,6 +15,7 @@ from smartsim.settings import RunSettings
 
 pytestmark = pytest.mark.group_b
 
+
 class _DummyStep:
     def __init__(self, metadata_dir: pathlib.Path, entity_name: str) -> None:
         self.name = f"{entity_name}-step"

--- a/tests/test_controller_metadata_usage.py
+++ b/tests/test_controller_metadata_usage.py
@@ -13,6 +13,7 @@ from smartsim._core.control.manifest import Manifest
 from smartsim.entity import Model
 from smartsim.settings import RunSettings
 
+pytestmark = pytest.mark.group_b
 
 class _DummyStep:
     def __init__(self, metadata_dir: pathlib.Path, entity_name: str) -> None:
@@ -42,7 +43,7 @@ def test_controller_uses_run_prefixed_metadata_dir(tmp_path, monkeypatch):
         return _DummyStep(metadata_dir, entity.name)
 
     monkeypatch.setattr(controller, "_create_job_step", fake_create_job_step)
-    monkeypatch.setattr(controller, "_launch_step", lambda step, entity: None)
+    monkeypatch.setattr(controller, "_launch_step", lambda step, entity, monitor: None)
     monkeypatch.setattr(
         controller, "symlink_output_files", lambda *args, **kwargs: None
     )


### PR DESCRIPTION
Update numpy version cap to allow for numpy 2.0 support, adds tests to CI that were previously being ignored.

Fixes #796 