### PR TITLE
Update TensorFlow Versions and Patches

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -18,7 +18,7 @@ Description
   classes, and SmartDashboard integration
 - Update copyright headers from 2021-2024 to 2021-2025 across the entire codebase
 - Python 3.12 is now supported; where available, installed TensorFlow version
-  is now 2.16.2, PyTorch is 2.7.1.
+  is now 2.18.1, PyTorch is 2.7.1.
 - Drop Python 3.9 support
 - Add Numpy 2.0 support
 - Terminate LSF and LSB support
@@ -76,10 +76,12 @@ Detailed Notes
   tests, Docker files, shell scripts, and other supporting files to reflect the
   new year.
   ([SmartSim-PR790](https://github.com/CrayLabs/SmartSim/pull/790))
-- Python 3.12 is now supported. TensorFlow 2.16.2 and PyTorch 2.7.1 library
-  files are installed as part of `smart build` process when available. On Mac,
-  ONNX runtime 1.22.0 is now installed, together with ONNX 1.16.
+- Python 3.12 is now supported. TensorFlow 2.18.1 (except on x86 MacOS where
+  the highest suported version is 2.16.2) and PyTorch 2.7.1 library files are
+  installed as part of `smart build` process when available. On Mac, ONNX
+  runtime 1.22.0 is now installed, together with ONNX 1.16.
   ([SmartSim-PR785](https://github.com/CrayLabs/SmartSim/pull/785))
+  ([SmartSim-PR805](https://github.com/CrayLabs/SmartSim/pull/805))
 - Python 3.9 will not be supported anymore, the last stable version of SmartSim
   with support for Python 3.9 will be 0.8.
   ([SmartSim-PR781](https://github.com/CrayLabs/SmartSim/pull/781))

--- a/smartsim/_core/_install/configs/mlpackages/DarwinARM64CPU.json
+++ b/smartsim/_core/_install/configs/mlpackages/DarwinARM64CPU.json
@@ -28,7 +28,18 @@
                     "source_file": "src/backends/libtorch_c/CMakeLists.txt",
                     "regex": "set_property\\(TARGET\\storch_c\\sPROPERTY\\sCXX_STANDARD\\s(98|11|14)\\)",
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
-                },
+                }
+            ]
+        },
+        {
+            "name": "libtensorflow",
+            "version": "2.18.1",
+            "pip_index": "",
+            "python_packages": [
+                "tensorflow==2.18.1"
+            ],
+            "lib_source": "https://storage.googleapis.com/tensorflow/versions/2.18.1/libtensorflow-cpu-darwin-arm64.tar.gz",
+            "rai_patches": [
                 {
                     "description": "Fix the type in a Tensorflow function signature",
                     "source_file": "src/backends/tensorflow.c",
@@ -42,15 +53,6 @@
                     "replacement": "TF_Output port"
                 }
             ]
-        },
-        {
-            "name": "libtensorflow",
-            "version": "2.18.0",
-            "pip_index": "",
-            "python_packages": [
-                "tensorflow==2.18.1"
-            ],
-            "lib_source": "https://storage.googleapis.com/tensorflow/versions/2.18.0/libtensorflow-cpu-darwin-arm64.tar.gz"
         },
         {
             "name": "onnxruntime",

--- a/smartsim/_core/_install/configs/mlpackages/DarwinX64CPU.json
+++ b/smartsim/_core/_install/configs/mlpackages/DarwinX64CPU.json
@@ -28,7 +28,18 @@
                     "source_file": "src/backends/libtorch_c/CMakeLists.txt",
                     "regex": "set_property\\(TARGET\\storch_c\\sPROPERTY\\sCXX_STANDARD\\s(98|11|14)\\)",
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
-                },
+                }
+            ]
+        },
+        {
+            "name": "libtensorflow",
+            "version": "2.16.2",
+            "pip_index": "",
+            "python_packages": [
+                "tensorflow==2.16.2"
+            ],
+            "lib_source": "https://storage.googleapis.com/tensorflow/versions/2.16.2/libtensorflow-cpu-darwin-x86_64.tar.gz",
+            "rai_patches": [
                 {
                     "description": "Fix the type in a Tensorflow function signature",
                     "source_file": "src/backends/tensorflow.c",
@@ -42,15 +53,6 @@
                     "replacement": "TF_Output port"
                 }
             ]
-        },
-        {
-            "name": "libtensorflow",
-            "version": "2.16.2",
-            "pip_index": "",
-            "python_packages": [
-                "tensorflow==2.16.2"
-            ],
-            "lib_source": "https://storage.googleapis.com/tensorflow/versions/2.16.2/libtensorflow-cpu-darwin-x86_64.tar.gz"
         },
         {
             "name": "onnxruntime",

--- a/smartsim/_core/_install/configs/mlpackages/LinuxX64CPU.json
+++ b/smartsim/_core/_install/configs/mlpackages/LinuxX64CPU.json
@@ -28,7 +28,18 @@
                     "source_file": "src/backends/libtorch_c/CMakeLists.txt",
                     "regex": "set_property\\(TARGET\\storch_c\\sPROPERTY\\sCXX_STANDARD\\s(98|11|14)\\)",
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
-                },
+                }
+            ]
+        },
+        {
+            "name": "libtensorflow",
+            "version": "2.18.1",
+            "pip_index": "",
+            "python_packages": [
+                "tensorflow==2.18.1"
+            ],
+            "lib_source": "https://storage.googleapis.com/tensorflow/versions/2.18.1/libtensorflow-cpu-linux-x86_64.tar.gz",
+            "rai_patches": [
                 {
                     "description": "Fix the type in a Tensorflow function signature",
                     "source_file": "src/backends/tensorflow.c",
@@ -42,15 +53,6 @@
                     "replacement": "TF_Output port"
                 }
             ]
-        },
-        {
-            "name": "libtensorflow",
-            "version": "2.16.2",
-            "pip_index": "",
-            "python_packages": [
-                "tensorflow==2.16.2"
-            ],
-            "lib_source": "https://storage.googleapis.com/tensorflow/versions/2.16.2/libtensorflow-cpu-linux-x86_64.tar.gz"
         },
         {
             "name": "onnxruntime",

--- a/smartsim/_core/_install/configs/mlpackages/LinuxX64CUDA11.json
+++ b/smartsim/_core/_install/configs/mlpackages/LinuxX64CUDA11.json
@@ -28,7 +28,18 @@
                     "source_file": "src/backends/libtorch_c/CMakeLists.txt",
                     "regex": "set_property\\(TARGET\\storch_c\\sPROPERTY\\sCXX_STANDARD\\s(98|11|14)\\)",
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
-                },
+                }
+            ]
+        },
+        {
+            "name": "libtensorflow",
+            "version": "2.14.1",
+            "pip_index": "",
+            "python_packages": [
+                "tensorflow==2.18.1"
+            ],
+            "lib_source": "https://github.com/CrayLabs/ml_lib_builder/releases/download/v0.2/libtensorflow-2.14.1-linux-x64-cuda-11.8.0.tgz",
+            "rai_patches":[
                 {
                     "description": "Fix the type in a Tensorflow function signature",
                     "source_file": "src/backends/tensorflow.c",
@@ -42,15 +53,6 @@
                     "replacement": "TF_Output port"
                 }
             ]
-        },
-        {
-            "name": "libtensorflow",
-            "version": "2.14.1",
-            "pip_index": "",
-            "python_packages": [
-                "tensorflow==2.14.1"
-            ],
-            "lib_source": "https://github.com/CrayLabs/ml_lib_builder/releases/download/v0.2/libtensorflow-2.14.1-linux-x64-cuda-11.8.0.tgz"
         },
         {
             "name": "onnxruntime",

--- a/smartsim/_core/_install/configs/mlpackages/LinuxX64CUDA12.json
+++ b/smartsim/_core/_install/configs/mlpackages/LinuxX64CUDA12.json
@@ -28,6 +28,23 @@
                     "source_file": "src/backends/libtorch_c/CMakeLists.txt",
                     "regex": "set_property\\(TARGET\\storch_c\\sPROPERTY\\sCXX_STANDARD\\s(98|11|14)\\)",
                     "replacement": "set_property(TARGET torch_c PROPERTY CXX_STANDARD 17)"
+                }
+            ]
+        },
+        {
+            "name": "libtensorflow",
+            "version": "2.18.1",
+            "pip_index": "",
+            "python_packages": [
+                "tensorflow==2.18.1"
+            ],
+            "lib_source": "https://storage.googleapis.com/tensorflow/versions/2.18.1/libtensorflow-gpu-linux-x86_64.tar.gz",
+            "rai_patches": [
+                {
+                    "description": "Patch RedisAI to point to correct tsl directory",
+                    "source_file": "CMakeLists.txt",
+                    "regex": "INCLUDE_DIRECTORIES\\(\\$\\{depsAbs\\}/libtensorflow/include\\)",
+                    "replacement": "INCLUDE_DIRECTORIES(${depsAbs}/libtensorflow/include ${depsAbs}/libtensorflow/include/external/local_tsl)"
                 },
                 {
                     "description": "Fix the type in a Tensorflow function signature",
@@ -40,23 +57,6 @@
                     "source_file": "src/backends/tensorflow.c",
                     "regex": "TF_Input port",
                     "replacement": "TF_Output port"
-                }
-            ]
-        },
-        {
-            "name": "libtensorflow",
-            "version": "2.16.2",
-            "pip_index": "",
-            "python_packages": [
-                "tensorflow==2.16.2"
-            ],
-            "lib_source": "https://storage.googleapis.com/tensorflow/versions/2.16.2/libtensorflow-gpu-linux-x86_64.tar.gz",
-            "rai_patches": [
-                {
-                    "description": "Patch RedisAI to point to correct tsl directory",
-                    "source_file": "CMakeLists.txt",
-                    "regex": "INCLUDE_DIRECTORIES\\(\\$\\{depsAbs\\}/libtensorflow/include\\)",
-                    "replacement": "INCLUDE_DIRECTORIES(${depsAbs}/libtensorflow/include ${depsAbs}/libtensorflow/include/external/local_tsl)"
                 }
             ]
         },

--- a/smartsim/_core/_install/configs/mlpackages/LinuxX64ROCM6.json
+++ b/smartsim/_core/_install/configs/mlpackages/LinuxX64ROCM6.json
@@ -40,18 +40,6 @@
                     "source_file": "../package/libtorch/share/cmake/Caffe2/Caffe2Targets.cmake",
                     "regex": "/opt/rocm",
                     "replacement": "$ENV{ROCM_PATH}"
-                },
-                {
-                    "description": "Fix the type in a Tensorflow function signature",
-                    "source_file": "src/backends/tensorflow.c",
-                    "regex": "TF_Input inputs",
-                    "replacement": "TF_Output inputs"
-                },
-                {
-                    "description": "Fix the type in a Tensorflow function signature",
-                    "source_file": "src/backends/tensorflow.c",
-                    "regex": "TF_Input port",
-                    "replacement": "TF_Output port"
                 }
             ]
         }


### PR DESCRIPTION
Updates the TensorFlow versions SmartSim pulls for its ML backends to allow for use of Numpy 2.0. This targets parmarily tensorflow 2.18.1, which is what we already shipped and tested on ARM MacOS.

Additionally reorganizes some TensorFlow specific RedisAI patches.

Fixes #802 