### PR TITLE
Dragon Deprecation Warning

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -24,8 +24,9 @@ Description
 - Terminate LSF and LSB support
 - Implement workaround for Tensorflow that allows RedisAI to build with GCC-14
 - Add instructions for installing SmartSim on PML's Scylla
-- Drop unsued development dependencies
+- Drop unused development dependencies
 - Fix typos in documentation
+- Raise a deprecation warning when building SmartSim with Dragon support
 
 Detailed Notes
 
@@ -108,6 +109,11 @@ Detailed Notes
 - Removes an Numpy upper bound in the SmartSim dependency list now that
   SmartRedis and supported ML backends support Numpy 2.0.
   ([SmartSim-PR803](https://github.com/CrayLabs/SmartSim/pull/803))
+- SmartSim's `smart build` CLI will attempt to build an out of date version of
+  Dragon when provided with the `--dragon` flag. This is not something the
+  SmartSim team plans to address and as such a deprecation warning is now
+  raised when attempting to build SmartSim with Dragon.
+  ([SmarSim-PR807](https://github.com/CrayLabs/SmartSim/pull/807))
 
 
 ### 0.8.0

--- a/smartsim/_core/_cli/build.py
+++ b/smartsim/_core/_cli/build.py
@@ -356,7 +356,7 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         "--dragon",
         action="store_true",
         default=False,
-        help="Install the dragon runtime",
+        help="[DEPRECATED] Install the dragon runtime",
     )
     parser.add_argument(
         "--skip-python-packages",

--- a/smartsim/_core/_cli/scripts/dragon_install.py
+++ b/smartsim/_core/_cli/scripts/dragon_install.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import sys
+import textwrap
 import typing as t
 from collections.abc import Collection
 
@@ -182,7 +183,7 @@ def install_package(asset_dir: pathlib.Path) -> int:
         logger.info(f"Installing package: {wheel_path.absolute()}")
 
         try:
-            pip("install", "--force-reinstall", str(wheel_path), "numpy<2")
+            pip("install", "--force-reinstall", str(wheel_path))
             wheel_path = next(wheels, None)
         except Exception:
             logger.error(f"Unable to install from {asset_dir}")
@@ -207,6 +208,14 @@ def install_dragon(extraction_dir: str | os.PathLike[str]) -> int:
     and install to the current python environment
     :param extraction_dir: path for download and extraction of assets
     :returns: Integer return code, 0 for success, non-zero on failures"""
+    logger.warning(
+        "Dragon Deprecation Notice:\n%s",
+        textwrap.indent(
+            _DRAGON_DEPRECATION_MESSAGE,
+            "  | ",
+            predicate=lambda line: True,
+        ),
+    )
     if sys.platform == "darwin":
         logger.debug(f"Dragon not supported on platform: {sys.platform}")
         return 1
@@ -226,6 +235,30 @@ def install_dragon(extraction_dir: str | os.PathLike[str]) -> int:
         cleanup(filename)
 
     return 2
+
+
+_DRAGON_DEPRECATION_MESSAGE: t.Final = textwrap.dedent("""\
+    SmartSim has discontinued first class support for launching applications
+    with Dragon. The version of Dragon that will be collected and installed is
+    development build of Dragon and not the most up to date version available
+    on PyPI.
+
+    SmartSim does still ship with the Dragon launcher, but features are limited
+    and requires that users submit driver scripts to the Dragon runtime via the
+    Dragon CLI. The Dragon launcher in SmartSim should be forward compatible
+    with users looking to manually install a newer version of Dragon for more
+    up to date features.
+
+    Many of the design choices made by SmartSim to support launching complex
+    workflows using Dragon have been adopted, continued, and improved upon in
+    the RHAPSODY project. To learn more about that work visit
+    `https://radical-cybertools.github.io/rhapsody/`.
+
+    To learn more about the ongoing development for Dragon visit documentation
+    at `https://dragonhpc.github.io/dragon/doc/_build/html/index.html` or
+    puruse their GitHub page at `https://github.com/DragonHPC/dragon`. To
+    manually install an up to dateversion of the library, check out the
+    `dragonhpc` PyPI page at `https://pypi.org/project/dragonhpc/`.""")
 
 
 if __name__ == "__main__":

--- a/tests/test_dragon_run_request.py
+++ b/tests/test_dragon_run_request.py
@@ -658,7 +658,7 @@ def test_view(monkeypatch: pytest.MonkeyPatch) -> None:
         | ljace0-5 | NeverStarted |                 |                |      0      |""")
 
     # get rid of white space to make the comparison easier
-    actual_msg = dragon_backend.status_message.replace(" ", "")
-    expected_message = expected_message.replace(" ", "")
+    actual_msg = dragon_backend.status_message.replace("-", " ").replace(" ", "")
+    expected_message = expected_message.replace("-", " ").replace(" ", "")
 
     assert actual_msg == expected_message


### PR DESCRIPTION
Add deprecation warning when users attempt to install Dragon with the `smart build` CLI. Minor test correction for WLM tests.

Fixes #797